### PR TITLE
chore: rm single quotes within double quotes in solidity

### DIFF
--- a/contracts/contracts/BidderRegistry.sol
+++ b/contracts/contracts/BidderRegistry.sol
@@ -232,7 +232,7 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
         feeRecipientAmount = 0;
         require(amount > 0, "fee recipient amount Amount is zero");
         (bool successFee, ) = feeRecipient.call{value: amount}("");
-        require(successFee, "couldn't transfer to fee Recipient");
+        require(successFee, "could not transfer to fee Recipient");
     }
 
     function withdrawProviderAmount(
@@ -243,7 +243,7 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
 
         require(amount > 0, "provider Amount is zero");
         (bool success, ) = provider.call{value: amount}("");
-        require(success, "couldn't transfer to provider");
+        require(success, "could not transfer to provider");
     }
 
     function withdrawPrepaidAmount(address payable bidder) external nonReentrant {
@@ -253,7 +253,7 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
         require(prepaidAmount > 0, "bidder prepaid Amount is zero");
 
         (bool success, ) = bidder.call{value: prepaidAmount}("");
-        require(success, "couldn't transfer prepay to bidder");
+        require(success, "could not transfer prepay to bidder");
     }
 
     function withdrawProtocolFee(
@@ -264,6 +264,6 @@ contract BidderRegistry is IBidderRegistry, Ownable, ReentrancyGuard {
         require(_protocolFeeAmount > 0, "insufficient protocol fee amount");
 
         (bool success, ) = bidder.call{value: _protocolFeeAmount}("");
-        require(success, "couldn't transfer prepay to bidder");
+        require(success, "could not transfer prepay to bidder");
     }
 }

--- a/contracts/contracts/ProviderRegistry.sol
+++ b/contracts/contracts/ProviderRegistry.sol
@@ -191,7 +191,7 @@ contract ProviderRegistry is IProviderRegistry, Ownable, ReentrancyGuard {
     function withdrawFeeRecipientAmount() external nonReentrant {
         feeRecipientAmount = 0;
         (bool successFee, ) = feeRecipient.call{value: feeRecipientAmount}("");
-        require(successFee, "Couldn't transfer to fee Recipient");
+        require(successFee, "Could not transfer to fee Recipient");
     }
 
     function withdrawBidderAmount(address bidder) external nonReentrant {
@@ -200,7 +200,7 @@ contract ProviderRegistry is IProviderRegistry, Ownable, ReentrancyGuard {
         bidderAmount[bidder] = 0;
 
         (bool success, ) = bidder.call{value: bidderAmount[bidder]}("");
-        require(success, "Couldn't transfer to bidder");
+        require(success, "Could not transfer to bidder");
     }
 
     function withdrawStakedAmount(
@@ -225,6 +225,6 @@ contract ProviderRegistry is IProviderRegistry, Ownable, ReentrancyGuard {
         );
 
         (bool success, ) = provider.call{value: stake}("");
-        require(success, "Couldn't transfer stake to provider");
+        require(success, "Could not transfer stake to provider");
     }
 }

--- a/contracts/test/BidderRegistryTest.sol
+++ b/contracts/test/BidderRegistryTest.sol
@@ -78,14 +78,14 @@ contract BidderRegistryTest is Test {
         vm.prank(bidder);
         vm.expectRevert(bytes(""));
         (bool success, ) = address(bidderRegistry).call{value: 1 wei}("");
-        require(success, "couldn't transfer to bidder");
+        require(success, "could not transfer to bidder");
     }
 
     function testFail_fallback() public {
         vm.prank(bidder);
         vm.expectRevert(bytes(""));
         (bool success, ) = address(bidderRegistry).call{value: 1 wei}("");
-        require(success, "couldn't transfer to bidder");
+        require(success, "could not transfer to bidder");
     }
 
     function test_SetNewFeeRecipient() public {

--- a/contracts/test/ProviderRegistryTest.sol
+++ b/contracts/test/ProviderRegistryTest.sol
@@ -91,7 +91,7 @@ contract ProviderRegistryTest is Test {
         vm.prank(provider);
         vm.expectRevert(bytes(""));
         (bool success, ) = address(providerRegistry).call{value: 1 wei}("");
-        require(success, "Couldn't transfer to provider");
+        require(success, "Could not transfer to provider");
     }
 
     function testFail_fallback() public {
@@ -99,7 +99,7 @@ contract ProviderRegistryTest is Test {
         vm.prank(provider);
         vm.expectRevert(bytes(""));
         (bool success, ) = address(providerRegistry).call{value: 1 wei}("");
-        require(success, "Couldn't transfer to provider");
+        require(success, "Could not transfer to provider");
     }
 
     function test_SetNewFeeRecipient() public {
@@ -252,12 +252,12 @@ contract ProviderRegistryTest is Test {
         assertEq(
             providerRegistry.providerStakes(newProvider),
             0,
-            "Provider's staked amount should be zero after withdrawal"
+            "Providers staked amount should be zero after withdrawal"
         );
         assertEq(
             newProvider.balance,
             2e18 wei,
-            "Provider's balance should increase by staked amount"
+            "Providers balance should increase by staked amount"
         );
     }
 
@@ -302,12 +302,12 @@ contract ProviderRegistryTest is Test {
         assertEq(
             providerRegistry.providerStakes(newProvider),
             0,
-            "Provider's staked amount should be zero after withdrawal"
+            "Providers staked amount should be zero after withdrawal"
         );
         assertEq(
             newProvider.balance,
             2e18 wei,
-            "Provider's balance should increase by staked amount"
+            "Providers balance should increase by staked amount"
         );
     }
 


### PR DESCRIPTION
`'`s within double quotes do not render correctly with github PRs, see https://github.com/primevprotocol/monorepo/pull/5 for example. Therefore these instances were removed from solidity