### PR TITLE
fix: set static ips for bidder/provider

### DIFF
--- a/.github/workflows/mev-commit-infra.yml
+++ b/.github/workflows/mev-commit-infra.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Check Service Endpoints
       run: |
-        ips=("172.29.18.2" "172.29.0.3" "172.29.0.4")
+        ips=("172.29.18.2" "172.29.18.3" "172.29.18.4")
 
         for ip in "${ips[@]}"; do
           echo "Checking service at $ip"

--- a/p2p/integration-compose.yml
+++ b/p2p/integration-compose.yml
@@ -52,7 +52,8 @@ services:
     volumes:
       - ./integrationtest/keys/provider1:/key
     networks:
-      - primev_net
+      primev_net:
+        ipv4_address: 172.29.18.3
     ports:
       - "8081:13523"
     env_file:
@@ -249,7 +250,8 @@ services:
     volumes:
       - ./integrationtest/keys/bidder1:/key
     networks:
-      - primev_net
+      primev_net:
+        ipv4_address: 172.29.18.4
     ports:
       - "8087:13523"
     env_file:


### PR DESCRIPTION
The mev-commit-infra.yml workflow attempts to query the bootnode, provider and bidder p2p nodes. To make this workflow deterministic we should statically assign expected IPs