### PR TITLE
fix: use triggering workflow branch for infra workflow

### DIFF
--- a/.github/workflows/mev-commit-infra.yml
+++ b/.github/workflows/mev-commit-infra.yml
@@ -16,6 +16,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
+        ref: ${{ github.event.workflow_run.head_branch }}
+
       
     - name: Install jq
       run: |


### PR DESCRIPTION
`mev-commit-infra.yml` workflow currently runs with main even if triggered from a PR branch. This workflow should instead use the branch of the triggering workflow. 

Relevant docs:
- https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run