### PR TITLE
refactor: improve GitHub workflows

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -3,9 +3,14 @@ name: artifacts
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   upload_contracts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -44,10 +49,12 @@ jobs:
             --tagging 'TagSet=[{Key=AutoDelete,Value=true}]'
 
   upload_binaries:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
     strategy:
       matrix:
         module: [ infrastructure/tools/keystore-generator,  p2p/integrationtest/real-bidder, p2p/integrationtest/provider, bridge/standard/bridge-v1, external/geth, oracle, p2p]
+
     steps:
       - name: Set Snapshot Flag
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,18 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   commitlint:
     name: Check Commit Message
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
 
     steps:
       - name: Checkout Code
@@ -49,7 +57,8 @@ jobs:
 
   go-modules:
     name: Test and Build Go Modules
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
 
     steps:
       - name: Checkout Code
@@ -120,7 +129,8 @@ jobs:
 
   foundry:
     name: Foundry Checks and Reports
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: contracts
@@ -152,7 +162,8 @@ jobs:
 
   contracts:
     name: Test and Build Contracts Scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: contracts

--- a/.github/workflows/infrstructure.yml
+++ b/.github/workflows/infrstructure.yml
@@ -7,6 +7,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
@@ -17,6 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -11,10 +11,12 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
     strategy:
       matrix:
         module: [ bridge/standard/bridge-v1, external/geth, oracle, p2p ]
+
     steps:
       - if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: echo "FLAGS=--snapshot" >> $GITHUB_ENV


### PR DESCRIPTION
- set timeouts for workflows
- limits scope of workflow token
- pins runners to a specific version
- limits the concurrency of workflows