### PR TITLE
fix: contracts build in deploy-contracts job

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/deploy-contracts.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/deploy-contracts.nomad.j2
@@ -63,11 +63,15 @@ job "{{ job.name }}" {
       driver = "exec"
 
       artifact {
-        source = "https://github.com/foundry-rs/foundry/releases/download/nightly-0a5b22f07ba4f2ddf525089c8ee9cdcb05e44bd9/foundry_nightly_linux_amd64.tar.gz"
+        source = "https://nodejs.org/dist/v18.16.1/node-v18.16.1-linux-x64.tar.xz"
+        options {
+          archive = false
+        }
       }
 
       artifact {
-        source = "https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh"
+        source = "https://foundry.paradigm.xyz"
+        destination = "local/foundry.sh"
       }
 
       artifact {
@@ -76,6 +80,7 @@ job "{{ job.name }}" {
 
       template {
         data = <<-EOH
+          XDG_CONFIG_HOME="local/.config"
           {%- raw %}
           {{- range nomadService "mev-commit-geth-bootnode1" }}
             {{- if contains "http" .Tags }}
@@ -85,7 +90,6 @@ job "{{ job.name }}" {
           PRIVATE_KEY="{{ with secret "secret/data/mev-commit" }}{{ .Data.data.deploy_contracts_private_key }}{{ end }}"
           {% endraw %}
           CHAIN_ID="{{ job['chain-id'] }}"
-          FORGE_BIN_PATH="local/forge"
           DEPLOY_TYPE="core"
           SCRIPT_PATH_PREFIX="local/contracts/scripts/"
           CONTRACT_REPO_ROOT_PATH="local/contracts"
@@ -106,16 +110,18 @@ job "{{ job.name }}" {
           {{- end }}
           {% endraw %}
 
-          export NVM_DIR="/local/.nvm"
-          mkdir -p ${NVM_DIR}
-          chmod +x local/install.sh
-          local/install.sh
-          source local/.nvm/nvm.sh
-          nvm install 18
+          tar \
+            --extract \
+            --file local/node-v18.16.1-linux-x64.tar.xz \
+            --directory /usr/local \
+            --strip-components=1
 
-          ${FORGE_BIN_PATH} clean
+          chmod +x local/foundry.sh && local/foundry.sh
+          chmod +x ${XDG_CONFIG_HOME}/.foundry/bin/foundryup && ${XDG_CONFIG_HOME}/.foundry/bin/foundryup
+          export PATH="${XDG_CONFIG_HOME}/.foundry/bin:$PATH"
+
+          forge clean
           chmod +x ${CONTRACT_REPO_ROOT_PATH}/entrypoint.sh && ${CONTRACT_REPO_ROOT_PATH}/entrypoint.sh
-          rm -rf ${CONTRACT_REPO_ROOT_PATH}
         EOH
         destination = "local/run.sh"
         perms = "0755"

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-bridge.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-bridge.nomad.j2
@@ -37,7 +37,8 @@ job "{{ job.name }}" {
       {% endfor %}
 
       artifact {
-        source = "https://github.com/foundry-rs/foundry/releases/download/nightly-293fad73670b7b59ca901c7f2105bf7a29165a90/foundry_nightly_linux_amd64.tar.gz"
+        source = "https://foundry.paradigm.xyz"
+        destination = "local/foundry.sh"
       }
 
       artifact {
@@ -62,6 +63,7 @@ job "{{ job.name }}" {
 
       template {
         data = <<-EOH
+          XDG_CONFIG_HOME="local/.config"
           STANDARD_BRIDGE_RELAYER_LOG_LEVEL="{{ job.env.get('log-level', 'debug') }}"
           STANDARD_BRIDGE_RELAYER_LOG_FMT="{{ job.env.get('log-format', 'json') }}"
           STANDARD_BRIDGE_RELAYER_LOG_TAGS="{{
@@ -80,8 +82,6 @@ job "{{ job.name }}" {
           STANDARD_BRIDGE_RELAYER_L1_RPC_URL="{{ job.env['l1_rpc_url'] }}"
           STANDARD_BRIDGE_RELAYER_PRIV_KEY_FILE="secrets/relayer_key"
           L1_CHAIN_ID="{{ job.env['l1_chain_id'] }}"
-          FORGE_BIN_PATH="local/forge"
-          CAST_BIN_PATH="local/cast"
           CONTRACTS_PATH="local/contracts"
           ARTIFACT_OUT_PATH="local"
         EOH
@@ -100,6 +100,10 @@ job "{{ job.name }}" {
             {{ end }}
           {{- end }}
           {% endraw %}
+
+          chmod +x local/foundry.sh && local/foundry.sh
+          chmod +x ${XDG_CONFIG_HOME}/.foundry/bin/foundryup && ${XDG_CONFIG_HOME}/.foundry/bin/foundryup
+          export PATH="${XDG_CONFIG_HOME}/.foundry/bin:$PATH"
 
           if [ -f "local/L1GatewayArtifact.json" ] && [ -f "local/SettlementGatewayArtifact.json" ]; then
             echo "Artifacts exist. Skipping contract deployment..."

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-funder.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-funder.nomad.j2
@@ -6,16 +6,35 @@ job "{{ job.name }}" {
   group "{{ job.name }}-group" {
     count = {{ job.count }}
 
+    network {
+      dns {
+        servers = {{ (ansible_facts['dns']['nameservers'] + ['1.1.1.1']) | tojson }}
+      }
+    }
+
     task "funder" {
       driver = "exec"
 
       artifact {
-        source = "https://github.com/foundry-rs/foundry/releases/download/nightly-0a5b22f07ba4f2ddf525089c8ee9cdcb05e44bd9/foundry_nightly_linux_amd64.tar.gz"
+        source = "https://foundry.paradigm.xyz"
+        destination = "local/foundry.sh"
+      }
+
+      template {
+        data = <<-EOH
+          XDG_CONFIG_HOME="local/.config"
+        EOH
+        destination = "secrets/.env"
+        env = true
       }
 
       template {
         data = <<-EOH
           #!/usr/bin/env bash
+
+          chmod +x local/foundry.sh && local/foundry.sh
+          chmod +x ${XDG_CONFIG_HOME}/.foundry/bin/foundryup && ${XDG_CONFIG_HOME}/.foundry/bin/foundryup
+          export PATH="${XDG_CONFIG_HOME}/.foundry/bin:$PATH"
 
           {% raw %}
           {{- range nomadService "datadog-agent-logs-collector" }}
@@ -50,7 +69,7 @@ job "{{ job.name }}" {
 
             {{- range nomadService "mev-commit-geth-bootnode1" }}
               {{- if contains "http" .Tags }}
-            local/cast send \
+            cast send \
                  --priority-gas-price 2000000000 \
                  --gas-price 5000000000 \
                  --rpc-url http://{{ .Address }}:{{ .Port }} \


### PR DESCRIPTION
fixes smart contracts failed compilation:
- uses foundryup to install the foundary tool box
- uses nodejs directly from https://nodejs.org/dist