### PR TITLE
feat: add openzep upgrades as dep

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "contracts/lib/forge-std"]
 	path = contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "contracts/lib/openzeppelin-upgrades"]
+	path = contracts/lib/openzeppelin-upgrades
+	url = https://github.com/openzeppelin/openzeppelin-upgrades


### PR DESCRIPTION
adds [@openzeppelin/upgrades-core@1.33.1](https://github.com/OpenZeppelin/openzeppelin-upgrades/releases/tag/%40openzeppelin%2Fupgrades-core%401.33.1) as dependency due to following error seen on main 
```
 
Word Wrap

   
Installing foundryup...
foundryup: could not detect shell, manually add local/.config/.foundry/bin to your PATH.


.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx

 ╔═╗ ╔═╗ ╦ ╦ ╔╗╔ ╔╦╗ ╦═╗ ╦ ╦         Portable and modular toolkit
 ╠╣  ║ ║ ║ ║ ║║║  ║║ ╠╦╝ ╚╦╝    for Ethereum Application Development
 ╚   ╚═╝ ╚═╝ ╝╚╝ ═╩╝ ╩╚═  ╩                 written in Rust.

.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx

Repo       : https://github.com/foundry-rs/
Book       : https://book.getfoundry.sh/
Chat       : https://t.me/foundry_rs/
Support    : https://t.me/foundry_support/
Contribute : https://github.com/orgs/foundry-rs/projects/2/

.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx

foundryup: installing foundry (version nightly, tag nightly)
foundryup: downloading latest forge, cast, anvil, and chisel
foundryup: downloading manpages
foundryup: installed - forge 0.2.0 (b1f4684 2024-05-24T00:17:58.661151843Z)
foundryup: installed - cast 0.2.0 (b1f4684 2024-05-24T00:17:58.576351914Z)
foundryup: installed - anvil 0.2.0 (b1f4684 2024-05-24T00:17:58.548576729Z)
foundryup: installed - chisel 0.2.0 (b1f4684 2024-05-24T00:17:58.488219796Z)
foundryup: done!
Deploying core contracts
Compiling 70 files with Solc 0.8.23
Solc 0.8.23 finished in 26.37s
Compiler run successful!
Traces:
  [2776125] → new DeployScript@0x5b73C5498c1E3b4dbA84de0F1833c4a029d90519
    └─ ← [Return] 13755 bytes of code

  [1168676] DeployScript::run()
    ├─ [0] VM::startBroadcast()
    │   └─ ← [Return] 
    ├─ [0] VM::envOr("FOUNDRY_OUT", "out") [staticcall]
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::projectRoot() [staticcall]
    │   └─ ← [Return] "/local/contracts"
    ├─ [0] VM::readFile("/local/contracts/out/BlockTracker.sol/BlockTracker.json") [staticcall]
    │   └─ ← [Return] <file>
    ├─ [0] VM::keyExistsJson("<JSON file>", ".ast") [staticcall]
    │   └─ ← [Return] true
    ├─ [0] VM::parseJsonString("<stringified JSON>", ".ast.absolutePath") [staticcall]
    │   └─ ← [Return] "contracts/BlockTracker.sol"
    ├─ [0] VM::parseJsonString("<stringified JSON>", ".ast.license") [staticcall]
    │   └─ ← [Return] "BSL 1.1"
    ├─ [0] VM::parseJsonString("<stringified JSON>", ".metadata.sources.['contracts/BlockTracker.sol'].keccak256") [staticcall]
    │   └─ ← [Return] "0xf8c43e4c9ad30fa48dbc6f19609d8fec2863e4620ed68128906d306368b6372e"
    ├─ [0] VM::envOr("OPENZEPPELIN_BASH_PATH", "bash") [staticcall]
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::tryFfi(["bash", "-c", "npx @openzeppelin/upgrades-core@^1.32.3 validate out/build-info --contract contracts/BlockTracker.sol:BlockTracker"])
    │   └─ ← [Return] (1, 0x, 0x6e706d205741524e20657865632054686520666f6c6c6f77696e67207061636b61676520776173206e6f7420666f756e6420616e642077696c6c20626520696e7374616c6c65643a20406f70656e7a657070656c696e2f75706772616465732d636f726540312e33332e310a756e646566696e65643a310a0a0a0a53796e7461784572726f723a20556e657870656374656420746f6b656e200020696e204a534f4e20617420706f736974696f6e20300a202020206174204a534f4e2e706172736520283c616e6f6e796d6f75733e290a20202020617420726561644a534f4e20282f6e6f6e6578697374656e742f2e6e706d2f5f6e70782f666233343934663862616230386134642f6e6f64655f6d6f64756c65732f406f70656e7a657070656c696e2f75706772616465732d636f72652f646973742f636c692f76616c69646174652f6275696c642d696e666f2d66696c652e6a733a3133313a3137290a202020206174206173796e6320726561644275696c64496e666f20282f6e6f6e6578697374656e742f2e6e706d2f5f6e70782f666233343934663862616230386134642f6e6f64655f6d6f64756c65732f406f70656e7a657070656c696e2f75706772616465732d636f72652f646973742f636c692f76616c69646174652f6275696c642d696e666f2d66696c652e6a733a39373a3331290a202020206174206173796e63206765744275696c64496e666f46696c657320282f6e6f6e6578697374656e742f2e6e706d2f5f6e70782f666233343934663862616230386134642f6e6f64655f6d6f64756c65732f406f70656e7a657070656c696e2f75706772616465732d636f72652f646973742f636c692f76616c69646174652f6275696c642d696e666f2d66696c652e6a733a34353a3132290a202020206174206173796e632076616c69646174655570677261646553616665747920282f6e6f6e6578697374656e742f2e6e706d2f5f6e70782f666233343934663862616230386134642f6e6f64655f6d6f64756c65732f406f70656e7a657070656c696e2f75706772616465732d636f72652f646973742f636c692f76616c69646174652f76616c69646174652d757067726164652d7361666574792e6a733a32323a3238290a202020206174206173796e63206d61696e20282f6e6f6e6578697374656e742f2e6e706d2f5f6e70782f666233343934663862616230386134642f6e6f64655f6d6f64756c65732f406f70656e7a657070656c696e2f75706772616465732d636f72652f646973742f636c692f76616c69646174652e6a733a33303a3234290a202020206174206173796e632072756e20282f6e6f6e6578697374656e742f2e6e706d2f5f6e70782f666233343934663862616230386134642f6e6f64655f6d6f64756c65732f406f70656e7a657070656c696e2f75706772616465732d636f72652f646973742f636c692f636c692e6a733a363a35290a0a4e6f64652e6a73207631382e31362e310a6e706d206e6f74696365200a6e706d206e6f74696365204e6577206d616a6f722076657273696f6e206f66206e706d20617661696c61626c652120392e352e31202d3e2031302e382e300a6e706d206e6f74696365204368616e67656c6f673a203c68747470733a2f2f6769746875622e636f6d2f6e706d2f636c692f72656c65617365732f7461672f7631302e382e303e0a6e706d206e6f746963652052756e20606e706d20696e7374616c6c202d67206e706d4031302e382e306020746f20757064617465210a6e706d206e6f74696365200a)
    └─ ← [Revert] revert: Failed to run upgrade safety validation: npm WARN exec The following package was not found and will be installed: @openzeppelin/upgrades-core@1.33.1
undefined:1



SyntaxError: Unexpected token  in JSON at position 0
    at JSON.parse (<anonymous>)
    at readJSON (/nonexistent/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/validate/build-info-file.js:131:17)
    at async readBuildInfo (/nonexistent/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/validate/build-info-file.js:97:31)
    at async getBuildInfoFiles (/nonexistent/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/validate/build-info-file.js:45:12)
    at async validateUpgradeSafety (/nonexistent/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/validate/validate-upgrade-safety.js:22:28)
    at async main (/nonexistent/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/validate.js:30:24)
    at async run (/nonexistent/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/cli.js:6:5)

Node.js v18.16.1
npm notice 
npm notice New major version of npm available! 9.5.1 -> 10.8.0
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.8.0>
npm notice Run `npm install -g npm@10.8.0` to update!
npm notice 
```