### PR TITLE
fix: invoke nomad system gc only once

### DIFF
--- a/infrastructure/nomad/playbooks/deploy.yml
+++ b/infrastructure/nomad/playbooks/deploy.yml
@@ -195,7 +195,7 @@
 
     - name: Deploy Jobs
       ansible.builtin.shell: |
-        nomad system gc
+        [ -z "${GC_DONE}" ] && nomad system gc && GC_DONE="1" || true
         nomad run {{ ansible_env.HOME }}/{{ profile }}/{{ job.name }}.nomad
         [ "{{ job.name }}" = "deploy-contracts" ] && sleep 240 || true
       args:


### PR DESCRIPTION
Removes the invocation of the `nomad system gc` command before each job deployment and runs it only once before deploying any job.