### PR TITLE
fix: contract addresses

### DIFF
--- a/contracts-abi/config/testnet.go
+++ b/contracts-abi/config/testnet.go
@@ -12,9 +12,9 @@ var TestnetContracts = Contracts{
 	// If these addresses change for a testnet deployment,
 	// please also update snippets/testnet-addresses.mdx
 	// in https://github.com/primev/mev-commit-docs
-	BidderRegistry:         "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
-	ProviderRegistry:       "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
-	PreconfCommitmentStore: "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
-	Oracle:                 "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
-	BlockTracker:           "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+	BidderRegistry:         "0x8021D1a949E124E39F9FFc812F39054e1521dAed",
+	ProviderRegistry:       "0x9C108C6F4A6350B42B4Cf0384249A0BB2F57e12D",
+	PreconfCommitmentStore: "0xb4FFB66e8a913F6Bcc7FbF4d27BC2b1545A0811b",
+	Oracle:                 "0xfC9a86CcC74F63AFE1c1d4A1aC25B2e248b234F6",
+	BlockTracker:           "0x2816c159E9F0807a5121e39dA4969de3b6D8d25e",
 }


### PR DESCRIPTION
Contract addresses were changed again, and the ones in testnet.go are no longer working