### PR TITLE
fix: moved commitments count

### DIFF
--- a/contracts/contracts/PreConfCommitmentStore.sol
+++ b/contracts/contracts/PreConfCommitmentStore.sol
@@ -471,6 +471,8 @@ contract PreConfCommitmentStore is OwnableUpgradeable {
                 blockNumber
             );
 
+            commitmentsCount[commiterAddress] += 1;
+
             emit CommitmentStored(
                 commitmentIndex,
                 bidderAddress,
@@ -528,8 +530,6 @@ contract PreConfCommitmentStore is OwnableUpgradeable {
 
         // Store commitment
         encryptedCommitments[commitmentIndex] = newCommitment;
-
-        commitmentsCount[commiterAddress] += 1;
 
         emit EncryptedCommitmentStored(
             commitmentIndex,


### PR DESCRIPTION
Fixed a case where the commitment was stored but not opened. Without this fix, provider funds could be locked indefinitely.