### PR TITLE
refactor: deploy contracts using send raw transaction

### DIFF
--- a/.github/workflows/infrstructure.yml
+++ b/.github/workflows/infrstructure.yml
@@ -117,6 +117,9 @@ jobs:
           check-latest: true
           cache-dependency-path: go.work.sum
 
+      - name: Setup Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install Required Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/contracts/contracts/ContractRegistry.sol
+++ b/contracts/contracts/ContractRegistry.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BSL 1.1
+pragma solidity ^0.8.20;
+
+contract ContractRegistry {
+    struct ContractInfo {
+        string name;
+        address addr;
+    }
+
+    ContractInfo[] public contracts;
+    mapping(string => uint256) private nameToIndex;
+    mapping(string => bool) private nameExists;
+
+    event ContractAdded(string name, address addr);
+    event ContractUpdated(string name, address addr);
+
+    function addContract(string memory _name, address _addr) public {
+        require(!nameExists[_name], "Contract name already exists");
+        contracts.push(ContractInfo({name: _name, addr: _addr}));
+        nameToIndex[_name] = contracts.length - 1;
+        nameExists[_name] = true;
+        emit ContractAdded(_name, _addr);
+    }
+
+    function updateContract(string memory _name, address _addr) public {
+        require(nameExists[_name], "Contract name does not exist");
+        uint256 index = nameToIndex[_name];
+        contracts[index].addr = _addr;
+        emit ContractUpdated(_name, _addr);
+    }
+
+    function getContractAddress(string memory _name) public view returns (address) {
+        require(nameExists[_name], "Contract name does not exist");
+        uint256 index = nameToIndex[_name];
+        return contracts[index].addr;
+    }
+
+    function getAllContracts() public view returns (ContractInfo[] memory) {
+        return contracts;
+    }
+}

--- a/contracts/deploy.py
+++ b/contracts/deploy.py
@@ -1,0 +1,166 @@
+import json
+import argparse
+import time
+from web3 import Web3
+from eth_account import Account
+
+def check_geth_running(w3):
+    while True:
+        try:
+            latest_block = w3.eth.get_block('latest')
+            if latest_block:
+                print(f"Geth is running. Latest block number: {latest_block['number']}")
+                return True
+        except Exception as e:
+            print(f"Error connecting to Geth: {e}. Retrying in 5 seconds...")
+            time.sleep(5)
+
+def deploy_create2(w3, account):
+    # Check if contract already deployed
+    address = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+    checksum_address = Web3.to_checksum_address(address)
+    code = w3.eth.get_code(checksum_address)
+    if code != b'':
+        print(f"Contract already deployed at {checksum_address}")
+        return
+    else:
+        print(f"No contract deployed at {checksum_address}. Deploying...")
+
+    # Presigned transaction
+    transaction = "0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222"
+
+    # Deploy contract
+    tx_hash = w3.eth.send_raw_transaction(transaction)
+    print(f"CREATE2 deployment transaction hash: {tx_hash.hex()}")
+
+    # Wait for the transaction receipt
+    tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+    print(f"CREATE2 contract deployed at address: {checksum_address}")
+
+    # Check for leftover balance
+    address_balance = "0x3fab184622dc19b6109349b94811493bf2a45362"
+    checksum_balance_address = Web3.to_checksum_address(address_balance)
+    balance = w3.eth.get_balance(checksum_balance_address)
+    if balance != 0:
+        print(f"WARNING: Deployment signer ({checksum_balance_address}) has leftover balance of {balance} wei")
+
+def deploy_contract_create2(w3, account, contract_file, out_dir, gas_limit, chain_id):
+    contract_name = contract_file.split('.')[0]
+    json_file = f"{out_dir}/{contract_file}/{contract_name}.json"
+
+    # Load the contract ABI and bytecode
+    with open(json_file) as f:
+        contract_json = json.load(f)
+        abi = contract_json["abi"]
+        bytecode = contract_json["bytecode"]["object"]
+
+    # Ensure the bytecode is a valid hexadecimal string
+    if not bytecode.startswith("0x"):
+        bytecode = "0x" + bytecode
+
+    # Create2 address generation
+    salt = Web3.keccak(text=contract_name)  # Use a consistent salt
+    create2_address = Web3.to_checksum_address(Web3.solidity_keccak(
+        ['bytes1', 'address', 'bytes32', 'bytes32'],
+        ['0xff', account.address, salt, Web3.keccak(hexstr=bytecode)]
+    )[12:])
+
+    # Check if the contract is already deployed
+    if w3.eth.get_code(create2_address) != b'':
+        print(f"Contract {contract_name} already deployed at {create2_address}")
+        return
+
+    # Prepare CREATE2 deployment via proxy contract
+    proxy_contract_address = Web3.to_checksum_address("0x4e59b44847b379578588920ca78fbf26c0b4956c")
+    proxy_contract = w3.eth.contract(address=proxy_contract_address, abi=[{
+        "constant": False,
+        "inputs": [
+            {"name": "_salt", "type": "bytes32"},
+            {"name": "_code", "type": "bytes"}
+        ],
+        "name": "deploy",
+        "outputs": [{"name": "addr", "type": "address"}],
+        "payable": False,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }])
+
+    # Build the proxy deployment transaction
+    construct_txn = proxy_contract.functions.deploy(salt, bytecode).build_transaction({
+        'from': account.address,
+        'nonce': w3.eth.get_transaction_count(account.address),
+        'gas': gas_limit,
+        'gasPrice': w3.eth.gas_price,
+        'chainId': chain_id
+    })
+
+    # Sign the transaction with the private key
+    signed_txn = w3.eth.account.sign_transaction(construct_txn, private_key=account.key)
+
+    # Send the transaction and wait for the receipt
+    tx_hash = w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+    print(f"Transaction hash for {contract_name}: {tx_hash.hex()}")
+
+    tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+    print(f"Contract {contract_name} deployed at address: {create2_address}")
+
+def load_account_from_keystore(keystore_file, password):
+    with open(keystore_file) as keyfile:
+        encrypted_key = keyfile.read()
+        private_key = Account.decrypt(encrypted_key, password)
+        return Account.from_key(private_key)
+
+# Command-line argument parsing
+parser = argparse.ArgumentParser(description="Deploy Ethereum contracts.")
+parser.add_argument("--keystore", help="The keystore file for the Ethereum account.")
+parser.add_argument("--password", help="The password for the keystore file.")
+parser.add_argument("--private-key", help="The private key for the Ethereum account.")
+parser.add_argument("--rpc-url", default="http://127.0.0.1:8545", help="The RPC URL of the Ethereum node.")
+parser.add_argument("--contracts", nargs='+', default=["BidderRegistry.sol", "PreConfCommitmentStore.sol", "BlockTracker.sol", "Oracle.sol", "ProviderRegistry.sol"], help="List of contract files to deploy.")
+parser.add_argument("--gas-limit", type=int, default=3000000, help="The gas limit for the transactions.")
+parser.add_argument("--chain-id", type=int, default=31337, help="The chain ID of the Ethereum network.")
+parser.add_argument("--out-dir", default="out", help="The directory containing the compiled contract outputs.")
+parser.add_argument("--skip-deploy-create2", action='store_true', help="Skip deploying the CREATE2 proxy contract.")
+
+args = parser.parse_args()
+
+# Configuration
+KEYSTORE = args.keystore
+PASSWORD = args.password
+PRIVATE_KEY = args.private_key
+RPC_URL = args.rpc_url
+CONTRACTS = args.contracts
+GAS_LIMIT = args.gas_limit
+CHAIN_ID = args.chain_id
+OUT_DIR = args.out_dir
+SKIP_DEPLOY_CREATE2 = args.skip_deploy_create2
+
+# Validate input arguments
+if (KEYSTORE and PRIVATE_KEY) or (not KEYSTORE and not PRIVATE_KEY):
+    print("You must provide either a keystore file and password, or a private key, but not both.")
+    exit(1)
+
+# Connect to the Ethereum node
+w3 = Web3(Web3.HTTPProvider(RPC_URL))
+if not w3.is_connected():
+    print("Failed to connect to the Ethereum node.")
+    exit(1)
+
+# Check if Geth is running
+check_geth_running(w3)
+
+# Get the account from the keystore file and password or from the private key
+if KEYSTORE:
+    account = load_account_from_keystore(KEYSTORE, PASSWORD)
+else:
+    account = w3.eth.account.from_key(PRIVATE_KEY)
+
+# Deploy CREATE2 proxy if not skipped
+if not SKIP_DEPLOY_CREATE2:
+    deploy_create2(w3, account)
+
+# Loop through each contract and deploy it using CREATE2
+for contract in CONTRACTS:
+    deploy_contract_create2(w3, account, contract, OUT_DIR, GAS_LIMIT, CHAIN_ID)
+
+print("All contracts deployed!")

--- a/contracts/deploy.py
+++ b/contracts/deploy.py
@@ -15,8 +15,23 @@ def check_geth_running(w3):
             print(f"Error connecting to Geth: {e}. Retrying in 5 seconds...")
             time.sleep(5)
 
-def deploy_create2(w3, account):
-    # Check if contract already deployed
+def print_revert_reason(w3, tx_receipt):
+    try:
+        tx = w3.eth.get_transaction(tx_receipt['transactionHash'])
+        tx_input = tx['input']
+        to_address = tx_receipt['contractAddress'] if tx_receipt['contractAddress'] else tx_receipt['to']
+        try:
+            w3.eth.call({
+                'to': to_address,
+                'from': tx['from'],
+                'data': tx_input
+            }, tx_receipt['blockNumber'])
+        except Exception as e:
+            print(f"Revert reason: {e}")
+    except Exception as e:
+        print(f"Failed to fetch revert reason: {e}")
+
+def deploy_create2(w3, account, chain_id):
     address = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
     checksum_address = Web3.to_checksum_address(address)
     code = w3.eth.get_code(checksum_address)
@@ -26,83 +41,146 @@ def deploy_create2(w3, account):
     else:
         print(f"No contract deployed at {checksum_address}. Deploying...")
 
-    # Presigned transaction
-    transaction = "0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222"
+    transaction = "0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222"
 
-    # Deploy contract
-    tx_hash = w3.eth.send_raw_transaction(transaction)
-    print(f"CREATE2 deployment transaction hash: {tx_hash.hex()}")
+    try:
+        tx = {
+            'to': checksum_address,
+            'from': account.address,
+            'data': transaction,
+            'gasPrice': w3.eth.gas_price,
+            'chainId': chain_id
+        }
+        
+        try:
+            estimated_gas = w3.eth.estimate_gas(tx)
+            tx['gas'] = estimated_gas
+        except Exception as e:
+            print(f"Simulation failed for CREATE2 deployment: {e}")
+            return
 
-    # Wait for the transaction receipt
-    tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
-    print(f"CREATE2 contract deployed at address: {checksum_address}")
+        tx_hash = w3.eth.send_raw_transaction(transaction)
+        print(f"CREATE2 deployment transaction hash: {tx_hash.hex()}")
+        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        if tx_receipt['status'] == 0:
+            print(f"CREATE2 contract deployment failed.")
+            print_revert_reason(w3, tx_receipt)
+        else:
+            print(f"CREATE2 contract deployed at address: {checksum_address}")
+    except Exception as e:
+        print(f"Failed to deploy CREATE2 contract: {e}")
 
-    # Check for leftover balance
     address_balance = "0x3fab184622dc19b6109349b94811493bf2a45362"
     checksum_balance_address = Web3.to_checksum_address(address_balance)
     balance = w3.eth.get_balance(checksum_balance_address)
     if balance != 0:
         print(f"WARNING: Deployment signer ({checksum_balance_address}) has leftover balance of {balance} wei")
 
-def deploy_contract_create2(w3, account, contract_file, out_dir, gas_limit, chain_id):
+def deploy_contract(w3, account, contract_file, out_dir, gas_limit, chain_id, owner_addresses, registry_contract=None, registry_abi=None):
     contract_name = contract_file.split('.')[0]
     json_file = f"{out_dir}/{contract_file}/{contract_name}.json"
 
-    # Load the contract ABI and bytecode
     with open(json_file) as f:
         contract_json = json.load(f)
         abi = contract_json["abi"]
         bytecode = contract_json["bytecode"]["object"]
 
-    # Ensure the bytecode is a valid hexadecimal string
     if not bytecode.startswith("0x"):
         bytecode = "0x" + bytecode
 
-    # Create2 address generation
-    salt = Web3.keccak(text=contract_name)  # Use a consistent salt
-    create2_address = Web3.to_checksum_address(Web3.solidity_keccak(
-        ['bytes1', 'address', 'bytes32', 'bytes32'],
-        ['0xff', account.address, salt, Web3.keccak(hexstr=bytecode)]
-    )[12:])
-
-    # Check if the contract is already deployed
-    if w3.eth.get_code(create2_address) != b'':
-        print(f"Contract {contract_name} already deployed at {create2_address}")
-        return
-
-    # Prepare CREATE2 deployment via proxy contract
-    proxy_contract_address = Web3.to_checksum_address("0x4e59b44847b379578588920ca78fbf26c0b4956c")
-    proxy_contract = w3.eth.contract(address=proxy_contract_address, abi=[{
-        "constant": False,
-        "inputs": [
-            {"name": "_salt", "type": "bytes32"},
-            {"name": "_code", "type": "bytes"}
-        ],
-        "name": "deploy",
-        "outputs": [{"name": "addr", "type": "address"}],
-        "payable": False,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }])
-
-    # Build the proxy deployment transaction
-    construct_txn = proxy_contract.functions.deploy(salt, bytecode).build_transaction({
+    contract = w3.eth.contract(abi=abi, bytecode=bytecode)
+    construct_txn = contract.constructor().build_transaction({
         'from': account.address,
         'nonce': w3.eth.get_transaction_count(account.address),
-        'gas': gas_limit,
         'gasPrice': w3.eth.gas_price,
         'chainId': chain_id
     })
 
-    # Sign the transaction with the private key
+    try:
+        estimated_gas = w3.eth.estimate_gas(construct_txn)
+        construct_txn['gas'] = estimated_gas
+    except Exception as e:
+        print(f"Gas estimation failed for contract {contract_name}: {e}")
+        return
+
     signed_txn = w3.eth.account.sign_transaction(construct_txn, private_key=account.key)
 
-    # Send the transaction and wait for the receipt
-    tx_hash = w3.eth.send_raw_transaction(signed_txn.rawTransaction)
-    print(f"Transaction hash for {contract_name}: {tx_hash.hex()}")
+    try:
+        tx_hash = w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+        print(f"Transaction hash for {contract_name}: {tx_hash.hex()}")
+        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        if tx_receipt['status'] == 0:
+            print(f"Contract deployment failed for {contract_name}.")
+            print_revert_reason(w3, tx_receipt)
+        else:
+            contract_address = tx_receipt.contractAddress
+            print(f"Contract {contract_name} successfully deployed at address: {contract_address}")
+            if contract_name in owner_addresses:
+                transfer_ownership(w3, account, abi, contract_address, owner_addresses[contract_name], chain_id)
+            if registry_contract:
+                register_contract(w3, account, registry_contract, contract_name, contract_address, registry_abi, chain_id)
+    except Exception as e:
+        print(f"Failed to deploy contract {contract_name}: {e}")
 
-    tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
-    print(f"Contract {contract_name} deployed at address: {create2_address}")
+def transfer_ownership(w3, account, abi, contract_address, new_owner, chain_id):
+    contract = w3.eth.contract(address=contract_address, abi=abi)
+    transfer_txn = contract.functions.transferOwnership(new_owner).build_transaction({
+        'from': account.address,
+        'nonce': w3.eth.get_transaction_count(account.address),
+        'gasPrice': w3.eth.gas_price,
+        'chainId': chain_id
+    })
+
+    try:
+        estimated_gas = w3.eth.estimate_gas(transfer_txn)
+        transfer_txn['gas'] = estimated_gas
+    except Exception as e:
+        print(f"Gas estimation failed for transfer ownership: {e}")
+        return
+
+    signed_txn = w3.eth.account.sign_transaction(transfer_txn, private_key=account.key)
+
+    try:
+        tx_hash = w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+        print(f"Ownership transfer transaction hash: {tx_hash.hex()}")
+        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        if tx_receipt['status'] == 0:
+            print(f"Ownership transfer failed for contract at address: {contract_address}")
+            print_revert_reason(w3, tx_receipt)
+        else:
+            print(f"Ownership successfully transferred to {new_owner} for contract at address: {contract_address}")
+    except Exception as e:
+        print(f"Failed to transfer ownership for contract at address: {contract_address}: {e}")
+
+def register_contract(w3, account, registry_contract, contract_name, contract_address, registry_abi, chain_id):
+    contract = w3.eth.contract(address=registry_contract, abi=registry_abi)
+    register_txn = contract.functions.addContract(contract_name, contract_address).build_transaction({
+        'from': account.address,
+        'nonce': w3.eth.get_transaction_count(account.address),
+        'gasPrice': w3.eth.gas_price,
+        'chainId': chain_id
+    })
+
+    try:
+        estimated_gas = w3.eth.estimate_gas(register_txn)
+        register_txn['gas'] = estimated_gas
+    except Exception as e:
+        print(f"Gas estimation failed for register contract: {e}")
+        return
+
+    signed_txn = w3.eth.account.sign_transaction(register_txn, private_key=account.key)
+
+    try:
+        tx_hash = w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+        print(f"Register contract transaction hash for {contract_name}: {tx_hash.hex()}")
+        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        if tx_receipt['status'] == 0:
+            print(f"Registering contract failed for {contract_name}")
+            print_revert_reason(w3, tx_receipt)
+        else:
+            print(f"Contract {contract_name} successfully registered in registry")
+    except Exception as e:
+        print(f"Failed to register contract {contract_name}: {e}")
 
 def load_account_from_keystore(keystore_file, password):
     with open(keystore_file) as keyfile:
@@ -110,7 +188,60 @@ def load_account_from_keystore(keystore_file, password):
         private_key = Account.decrypt(encrypted_key, password)
         return Account.from_key(private_key)
 
-# Command-line argument parsing
+def parse_owner_addresses(owner_addresses_str):
+    owner_addresses = {}
+    if owner_addresses_str:
+        pairs = owner_addresses_str.split(',')
+        for pair in pairs:
+            contract, address = pair.split(':')
+            owner_addresses[contract] = address
+    return owner_addresses
+
+def deploy_registry_contract(w3, account, out_dir, gas_limit, chain_id):
+    registry_name = "ContractRegistry"
+    json_file = f"{out_dir}/{registry_name}.sol/{registry_name}.json"
+
+    with open(json_file) as f:
+        contract_json = json.load(f)
+        abi = contract_json["abi"]
+        bytecode = contract_json["bytecode"]["object"]
+
+    if not bytecode.startswith("0x"):
+        bytecode = "0x" + bytecode
+
+    contract = w3.eth.contract(abi=abi, bytecode=bytecode)
+    construct_txn = contract.constructor().build_transaction({
+        'from': account.address,
+        'nonce': w3.eth.get_transaction_count(account.address),
+        'gasPrice': w3.eth.gas_price,
+        'chainId': chain_id
+    })
+
+    try:
+        estimated_gas = w3.eth.estimate_gas(construct_txn)
+        construct_txn['gas'] = estimated_gas
+    except Exception as e:
+        print(f"Gas estimation failed for registry contract: {e}")
+        return None, None
+
+    signed_txn = w3.eth.account.sign_transaction(construct_txn, private_key=account.key)
+
+    try:
+        tx_hash = w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+        print(f"Transaction hash for {registry_name}: {tx_hash.hex()}")
+        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        if tx_receipt['status'] == 0:
+            print(f"Registry contract deployment failed.")
+            print_revert_reason(w3, tx_receipt)
+            return None, None
+        else:
+            contract_address = tx_receipt.contractAddress
+            print(f"Registry contract successfully deployed at address: {contract_address}")
+            return contract_address, abi
+    except Exception as e:
+        print(f"Failed to deploy registry contract: {e}")
+        return None, None
+
 parser = argparse.ArgumentParser(description="Deploy Ethereum contracts.")
 parser.add_argument("--keystore", help="The keystore file for the Ethereum account.")
 parser.add_argument("--password", help="The password for the keystore file.")
@@ -118,49 +249,63 @@ parser.add_argument("--private-key", help="The private key for the Ethereum acco
 parser.add_argument("--rpc-url", default="http://127.0.0.1:8545", help="The RPC URL of the Ethereum node.")
 parser.add_argument("--contracts", nargs='+', default=["BidderRegistry.sol", "PreConfCommitmentStore.sol", "BlockTracker.sol", "Oracle.sol", "ProviderRegistry.sol"], help="List of contract files to deploy.")
 parser.add_argument("--gas-limit", type=int, default=3000000, help="The gas limit for the transactions.")
-parser.add_argument("--chain-id", type=int, default=31337, help="The chain ID of the Ethereum network.")
+parser.add_argument("--chain-id", type=int, help="The chain ID of the Ethereum network.")
 parser.add_argument("--out-dir", default="out", help="The directory containing the compiled contract outputs.")
 parser.add_argument("--skip-deploy-create2", action='store_true', help="Skip deploying the CREATE2 proxy contract.")
+parser.add_argument("--owner-addresses", help="Comma-separated list of contract:owner_address pairs for ownership transfer.")
+parser.add_argument("--registry-contract", help="Address of the registry contract to register deployed contracts.")
 
 args = parser.parse_args()
 
-# Configuration
 KEYSTORE = args.keystore
 PASSWORD = args.password
 PRIVATE_KEY = args.private_key
 RPC_URL = args.rpc_url
 CONTRACTS = args.contracts
 GAS_LIMIT = args.gas_limit
-CHAIN_ID = args.chain_id
 OUT_DIR = args.out_dir
 SKIP_DEPLOY_CREATE2 = args.skip_deploy_create2
+OWNER_ADDRESSES_STR = args.owner_addresses
+REGISTRY_CONTRACT = args.registry_contract
 
-# Validate input arguments
+OWNER_ADDRESSES = parse_owner_addresses(OWNER_ADDRESSES_STR)
+
 if (KEYSTORE and PRIVATE_KEY) or (not KEYSTORE and not PRIVATE_KEY):
     print("You must provide either a keystore file and password, or a private key, but not both.")
     exit(1)
 
-# Connect to the Ethereum node
 w3 = Web3(Web3.HTTPProvider(RPC_URL))
 if not w3.is_connected():
     print("Failed to connect to the Ethereum node.")
     exit(1)
 
-# Check if Geth is running
 check_geth_running(w3)
 
-# Get the account from the keystore file and password or from the private key
 if KEYSTORE:
     account = load_account_from_keystore(KEYSTORE, PASSWORD)
 else:
     account = w3.eth.account.from_key(PRIVATE_KEY)
 
-# Deploy CREATE2 proxy if not skipped
-if not SKIP_DEPLOY_CREATE2:
-    deploy_create2(w3, account)
+# Get chain ID from Geth if not specified
+CHAIN_ID = args.chain_id if args.chain_id else w3.eth.chain_id
 
-# Loop through each contract and deploy it using CREATE2
+if not SKIP_DEPLOY_CREATE2:
+    deploy_create2(w3, account, CHAIN_ID)
+
+if not REGISTRY_CONTRACT:
+    REGISTRY_CONTRACT, registry_abi = deploy_registry_contract(w3, account, OUT_DIR, GAS_LIMIT, CHAIN_ID)
+    if not REGISTRY_CONTRACT:
+        print("Failed to deploy or locate the registry contract.")
+        exit(1)
+else:
+    registry_abi = None
+    # If registry_contract is provided, load its ABI
+    registry_json_file = f"{OUT_DIR}/ContractRegistry.sol/ContractRegistry.json"
+    with open(registry_json_file) as f:
+        registry_contract_json = json.load(f)
+        registry_abi = registry_contract_json["abi"]
+
 for contract in CONTRACTS:
-    deploy_contract_create2(w3, account, contract, OUT_DIR, GAS_LIMIT, CHAIN_ID)
+    deploy_contract(w3, account, contract, OUT_DIR, GAS_LIMIT, CHAIN_ID, OWNER_ADDRESSES, REGISTRY_CONTRACT, registry_abi)
 
 print("All contracts deployed!")

--- a/contracts/deploy.py
+++ b/contracts/deploy.py
@@ -2,9 +2,11 @@ import json
 import argparse
 import time
 from web3 import Web3
+from web3.middleware import geth_poa_middleware
 from eth_account import Account
 
 def check_geth_running(w3):
+    w3.middleware_onion.inject(geth_poa_middleware, layer=0)
     while True:
         try:
             latest_block = w3.eth.get_block('latest')

--- a/contracts/get_code.py
+++ b/contracts/get_code.py
@@ -1,0 +1,50 @@
+from web3 import Web3
+import argparse
+
+def check_geth_running(w3):
+    while True:
+        try:
+            latest_block = w3.eth.get_block('latest')
+            if latest_block:
+                print(f"Geth is running. Latest block number: {latest_block['number']}")
+                return True
+        except Exception as e:
+            print(f"Error connecting to Geth: {e}. Retrying in 5 seconds...")
+            time.sleep(5)
+
+def fetch_contract_code(w3, address):
+    try:
+        checksum_address = Web3.to_checksum_address(address)
+        if checksum_address != address:
+            print(f"Address {address} is not in checksum format")
+            return
+        code = w3.eth.get_code(checksum_address)
+        if code != b'':
+            print(f"Contract code at address {checksum_address}: {code.hex()}")
+        else:
+            print(f"No contract deployed at address {checksum_address}")
+    except ValueError as e:
+        print(f"Invalid address {address}: {e}")
+
+# Command-line argument parsing
+parser = argparse.ArgumentParser(description="Fetch contract code from Ethereum node.")
+parser.add_argument("--rpc-url", default="http://127.0.0.1:8545", help="The RPC URL of the Ethereum node.")
+parser.add_argument("--addresses", nargs='+', required=True, help="List of contract addresses to fetch code from.")
+
+args = parser.parse_args()
+
+RPC_URL = args.rpc_url
+ADDRESSES = args.addresses
+
+# Connect to the Ethereum node
+w3 = Web3(Web3.HTTPProvider(RPC_URL))
+if not w3.is_connected():
+    print("Failed to connect to the Ethereum node.")
+    exit(1)
+
+# Check if Geth is running
+check_geth_running(w3)
+
+# Fetch and print the contract code for each address
+for address in ADDRESSES:
+    fetch_contract_code(w3, address)

--- a/contracts/list_registered_contracts.py
+++ b/contracts/list_registered_contracts.py
@@ -1,0 +1,71 @@
+import json
+import argparse
+from web3 import Web3
+from eth_account import Account
+
+def check_geth_running(w3):
+    while True:
+        try:
+            latest_block = w3.eth.get_block('latest')
+            if latest_block:
+                print(f"Geth is running. Latest block number: {latest_block['number']}")
+                return True
+        except Exception as e:
+            print(f"Error connecting to Geth: {e}. Retrying in 5 seconds...")
+            time.sleep(5)
+
+def load_account_from_keystore(keystore_file, password):
+    with open(keystore_file) as keyfile:
+        encrypted_key = keyfile.read()
+        private_key = Account.decrypt(encrypted_key, password)
+        return Account.from_key(private_key)
+
+def list_registered_contracts(w3, registry_contract, registry_abi):
+    contract = w3.eth.contract(address=registry_contract, abi=registry_abi)
+    all_contracts = contract.functions.getAllContracts().call()
+    print(f"Total registered contracts: {len(all_contracts)}")
+    for contract_info in all_contracts:
+        contract_name = contract_info[0]
+        contract_address = contract_info[1]
+        print(f"Contract Name: {contract_name}, Contract Address: {contract_address}")
+
+parser = argparse.ArgumentParser(description="List registered Ethereum contracts.")
+parser.add_argument("--keystore", help="The keystore file for the Ethereum account.")
+parser.add_argument("--password", help="The password for the keystore file.")
+parser.add_argument("--private-key", help="The private key for the Ethereum account.")
+parser.add_argument("--rpc-url", default="http://127.0.0.1:8545", help="The RPC URL of the Ethereum node.")
+parser.add_argument("--registry-contract", required=True, help="Address of the registry contract.")
+parser.add_argument("--registry-abi", default="out/ContractRegistry.sol/ContractRegistry.json", help="Path to the ABI JSON file of the registry contract.")
+
+args = parser.parse_args()
+
+KEYSTORE = args.keystore
+PASSWORD = args.password
+PRIVATE_KEY = args.private_key
+RPC_URL = args.rpc_url
+REGISTRY_CONTRACT = args.registry_contract
+REGISTRY_ABI_PATH = args.registry_abi
+
+if (KEYSTORE and PRIVATE_KEY) or (not KEYSTORE and not PRIVATE_KEY):
+    print("You must provide either a keystore file and password, or a private key, but not both.")
+    exit(1)
+
+w3 = Web3(Web3.HTTPProvider(RPC_URL))
+if not w3.is_connected():
+    print("Failed to connect to the Ethereum node.")
+    exit(1)
+
+check_geth_running(w3)
+
+if KEYSTORE:
+    account = load_account_from_keystore(KEYSTORE, PASSWORD)
+else:
+    account = w3.eth.account.from_key(PRIVATE_KEY)
+
+# Load the registry contract ABI
+with open(REGISTRY_ABI_PATH) as f:
+    registry_contract_json = json.load(f)
+    registry_abi = registry_contract_json["abi"]
+
+# List registered contracts
+list_registered_contracts(w3, REGISTRY_CONTRACT, registry_abi)

--- a/infrastructure/nomad/cluster.sh
+++ b/infrastructure/nomad/cluster.sh
@@ -84,6 +84,7 @@ check_deps() {
         go
         yq
         aws
+        forge
         ansible
         goreleaser
     )

--- a/infrastructure/nomad/playbooks/deploy.yml
+++ b/infrastructure/nomad/playbooks/deploy.yml
@@ -118,8 +118,8 @@
         DESTINATION_DIR="{{ goreleaser_dist_dir }}/{{ item.name }}" && mkdir -p ${DESTINATION_DIR}
         if [ "{{ item.name }}" == "contracts" ]; then
           cd ./{{ item.path }}
-          forge build
-          tar -czvf "${DESTINATION_DIR}/contracts_{{ version }}.tar.gz" ./out ./deployer_keystore
+          forge build --via-ir
+          tar -czvf "${DESTINATION_DIR}/contracts_{{ version }}.tar.gz" ./out ./deployer_keystore ./deploy.py
         elif [ "{{ item.name }}" == "faucet-keystore" ]; then
           tar -czvf "${DESTINATION_DIR}/faucet_keystore_{{ version }}.tar.gz" -C ./{{ item.path }} .
         else

--- a/infrastructure/nomad/playbooks/deploy.yml
+++ b/infrastructure/nomad/playbooks/deploy.yml
@@ -117,7 +117,9 @@
       ansible.builtin.shell: |
         DESTINATION_DIR="{{ goreleaser_dist_dir }}/{{ item.name }}" && mkdir -p ${DESTINATION_DIR}
         if [ "{{ item.name }}" == "contracts" ]; then
-          tar -czvf "${DESTINATION_DIR}/contracts_{{ version }}.tar.gz" ./{{ item.path }}
+          cd ./{{ item.path }}
+          forge build
+          tar -czvf "${DESTINATION_DIR}/contracts_{{ version }}.tar.gz" ./out ./deployer_keystore
         elif [ "{{ item.name }}" == "faucet-keystore" ]; then
           tar -czvf "${DESTINATION_DIR}/faucet_keystore_{{ version }}.tar.gz" -C ./{{ item.path }} .
         else

--- a/infrastructure/nomad/playbooks/init.yml
+++ b/infrastructure/nomad/playbooks/init.yml
@@ -65,11 +65,6 @@
           - msr-tools
         state: present
 
-    - name: Install Foundry Tools
-      shell: |
-        curl -L https://foundry.paradigm.xyz | bash
-        ~/.foundry/bin/foundryup
-
     - name: Install Python Web3 Package
       pip:
         name: web3

--- a/infrastructure/nomad/playbooks/init.yml
+++ b/infrastructure/nomad/playbooks/init.yml
@@ -65,6 +65,15 @@
           - msr-tools
         state: present
 
+    - name: Install Foundry Tools
+      shell: |
+        curl -L https://foundry.paradigm.xyz | bash
+        ~/.foundry/bin/foundryup
+
+    - name: Install Python Web3 Package
+      pip:
+        name: web3
+
     - name: Include Variables
       include_vars:
         file: vars.yml

--- a/infrastructure/nomad/playbooks/templates/jobs/deploy-contracts.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/deploy-contracts.nomad.j2
@@ -18,64 +18,12 @@ job "{{ job.name }}" {
       }
     }
 
-    task "deploy-create2" {
-      driver = "exec"
-
-      lifecycle {
-        hook = "prestart"
-      }
-
-      artifact {
-        source = "https://primev-infrastructure-artifacts.s3.us-west-2.amazonaws.com/mev-commit-geth_{{ version }}_Linux_x86_64.tar.gz"
-      }
-
-      template {
-        data = <<-EOH
-          #!/usr/bin/env bash
-
-          {% raw %}
-          {{- range nomadService "datadog-agent-logs-collector" }}
-            {{ if contains "tcp" .Tags }}
-          exec > >(nc {{ .Address }} {{ .Port }}) 2>&1
-            {{ end }}
-          {{- end }}
-
-          {{- range nomadService "mev-commit-geth-bootnode1" }}
-            {{ if contains "http" .Tags }}
-          chmod +x local/deploy_create2.sh
-          local/deploy_create2.sh "http://{{ .Address }}:{{ .Port }}"
-            {{ end }}
-          {{- end }}
-          {% endraw %}
-
-        EOH
-        destination = "local/run.sh"
-        perms = "0755"
-      }
-
-      config {
-        command = "bash"
-        args = ["-c", "local/run.sh"]
-      }
-    }
-
     task "deploy-contracts" {
       driver = "exec"
 
       artifact {
-        source = "https://nodejs.org/dist/v18.16.1/node-v18.16.1-linux-x64.tar.xz"
-        options {
-          archive = false
-        }
-      }
-
-      artifact {
-        source = "https://foundry.paradigm.xyz"
-        destination = "local/foundry.sh"
-      }
-
-      artifact {
         source = "https://primev-infrastructure-artifacts.s3.us-west-2.amazonaws.com/contracts_{{ version }}.tar.gz"
+        destination = "local/"
       }
 
       template {
@@ -91,7 +39,6 @@ job "{{ job.name }}" {
           {% endraw %}
           CHAIN_ID="{{ job['chain-id'] }}"
           DEPLOY_TYPE="core"
-          SCRIPT_PATH_PREFIX="local/contracts/scripts/"
           CONTRACT_REPO_ROOT_PATH="local/contracts"
         EOH
         destination = "secrets/.env"
@@ -110,18 +57,24 @@ job "{{ job.name }}" {
           {{- end }}
           {% endraw %}
 
-          tar \
-            --extract \
-            --file local/node-v18.16.1-linux-x64.tar.xz \
-            --directory /usr/local \
-            --strip-components=1
+          # Get the keystore file
+          KEYSTORE_DIR=$CONTRACT_REPO_ROOT_PATH/deployer_keystore
+          KEYSTORE_FILE=$(ls $KEYSTORE_DIR/* 2>/dev/null)
 
-          chmod +x local/foundry.sh && local/foundry.sh
-          chmod +x ${XDG_CONFIG_HOME}/.foundry/bin/foundryup && ${XDG_CONFIG_HOME}/.foundry/bin/foundryup
-          export PATH="${XDG_CONFIG_HOME}/.foundry/bin:$PATH"
+          if [ -z "$KEYSTORE_FILE" ]; then
+            echo "No keystore file found in $KEYSTORE_DIR. Terminating job."
+            exit 1
+          fi
 
-          forge clean
-          chmod +x ${CONTRACT_REPO_ROOT_PATH}/entrypoint.sh && ${CONTRACT_REPO_ROOT_PATH}/entrypoint.sh
+          # Run the deployment script
+          python3 $CONTRACT_REPO_ROOT_PATH/deploy.py \
+            --keystore $KEYSTORE_FILE \
+            --password "$KEYSTORE_PASSWORD" \
+            --rpc-url "$RPC_URL" \
+            --contracts BidderRegistry.sol PreConfCommitmentStore.sol BlockTracker.sol Oracle.sol ProviderRegistry.sol \
+            --gas-limit 3000000 \
+            --chain-id "$CHAIN_ID" \
+            --out-dir $CONTRACT_REPO_ROOT_PATH/out
         EOH
         destination = "local/run.sh"
         perms = "0755"

--- a/infrastructure/nomad/playbooks/templates/jobs/deploy-contracts.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/deploy-contracts.nomad.j2
@@ -23,7 +23,7 @@ job "{{ job.name }}" {
 
       artifact {
         source = "https://primev-infrastructure-artifacts.s3.us-west-2.amazonaws.com/contracts_{{ version }}.tar.gz"
-        destination = "local/"
+        destination = "local/contracts"
       }
 
       template {


### PR DESCRIPTION
There seems to be a lot of issues with deploy_contract.job especially related to foundry version etc. While foundry is a great tool I thought deploying contracts using `eth_sendRawTransaction` should be the easiest and cleanest way to do it. 

The python script simply grabs the required contracts and deploys them to ethereum using `send_raw_transaction`

How to run:

1. `pip install web3`
2. make sure you are under `mev-commit/contracts`
3. `forge build` (sometimes `forge build` complains. If so, run it with `forge build --via-ir` )
4. `python3 deploy.py`


