### PR TITLE
fix: update settlement connection type logic

### DIFF
--- a/p2p/cmd/main.go
+++ b/p2p/cmd/main.go
@@ -28,6 +28,9 @@ const (
 	defaultKeyFile   = "key"
 	defaultSecret    = "secret"
 	defaultKeystore  = "keystore"
+
+	defaultSettlementRPC   = "http://localhost:8545"
+	defaultSettlementWSRPC = "ws://localhost:8546"
 )
 
 var (
@@ -203,14 +206,14 @@ var (
 		Name:    "settlement-rpc-endpoint",
 		Usage:   "rpc endpoint of the settlement layer",
 		EnvVars: []string{"MEV_COMMIT_SETTLEMENT_RPC_ENDPOINT"},
-		Value:   "http://localhost:8545",
+		Value:   defaultSettlementRPC,
 	})
 
 	optionSettlementWSRPCEndpoint = altsrc.NewStringFlag(&cli.StringFlag{
 		Name:    "settlement-ws-rpc-endpoint",
 		Usage:   "ws rpc endpoint of the settlement layer",
 		EnvVars: []string{"MEV_COMMIT_SETTLEMENT_WS_RPC_ENDPOINT"},
-		Value:   "ws://localhost:8546",
+		Value:   defaultSettlementWSRPC,
 	})
 
 	optionNATAddr = altsrc.NewStringFlag(&cli.StringFlag{
@@ -333,6 +336,14 @@ func launchNodeWithConfig(c *cli.Context) error {
 		return fmt.Errorf("both -%s and -%s must be provided to enable TLS", optionServerTLSCert.Name, optionServerTLSPrivateKey.Name)
 	}
 
+	settlementConnType := "http"
+	if c.String(optionSettlementRPCEndpoint.Name) != defaultSettlementRPC {
+		settlementConnType = "http"
+	}
+	if c.String(optionSettlementWSRPCEndpoint.Name) != defaultSettlementWSRPC {
+		settlementConnType = "ws"
+	}
+
 	nd, err := node.NewNode(&node.Options{
 		KeySigner:                keysigner,
 		Secret:                   c.String(optionSecret.Name),
@@ -349,6 +360,7 @@ func launchNodeWithConfig(c *cli.Context) error {
 		BlockTrackerContract:     c.String(optionBlockTrackerAddr.Name),
 		RPCEndpoint:              c.String(optionSettlementRPCEndpoint.Name),
 		WSRPCEndpoint:            c.String(optionSettlementWSRPCEndpoint.Name),
+		SettlementConnType:       settlementConnType,
 		NatAddr:                  natAddr,
 		TLSCertificateFile:       crtFile,
 		TLSPrivateKeyFile:        keyFile,

--- a/p2p/pkg/node/node.go
+++ b/p2p/pkg/node/node.go
@@ -75,6 +75,7 @@ type Options struct {
 	BidderRegistryContract   string
 	RPCEndpoint              string
 	WSRPCEndpoint            string
+	SettlementConnType       string
 	NatAddr                  string
 	TLSCertificateFile       string
 	TLSPrivateKeyFile        string
@@ -97,7 +98,8 @@ func NewNode(opts *Options) (*Node, error) {
 		contractRPC *ethclient.Client
 		err         error
 	)
-	if opts.WSRPCEndpoint != "" {
+
+	if opts.SettlementConnType == "ws" {
 		contractRPC, err = ethclient.Dial(opts.WSRPCEndpoint)
 		if err != nil {
 			opts.Logger.Error("failed to connect to ws rpc", "error", err)
@@ -142,7 +144,7 @@ func NewNode(opts *Options) (*Node, error) {
 	var startables []Startable
 	var evtPublisher PublisherStartable
 
-	if opts.WSRPCEndpoint != "" {
+	if opts.SettlementConnType == "ws" {
 		// Use WS publisher if WSRPCEndpoint is set
 		evtPublisher = publisher.NewWSPublisher(
 			store,


### PR DESCRIPTION
as long as --settlement-ws-rpc-endpoint="" is not left empty, it will attempt to connect via the default ws://localhost:8546. Instead, it seems more logical for the system to connect to the chain through either rpcendpoint or wsrpcendpoint if one of these arguments is provided