### PR TITLE
fix: deleted address checker

### DIFF
--- a/contracts/contracts/BlockTracker.sol
+++ b/contracts/contracts/BlockTracker.sol
@@ -118,9 +118,6 @@ contract BlockTracker is OwnableUpgradeable {
         // Check if the block number is valid (not 0)
         require(blockNumber != 0, "Invalid block number");
 
-        // Check if the winner address is valid (not the zero address)
-        require(winner != address(0), "Invalid winner address");
-
         blockWinners[blockNumber] = winner;
     }
 


### PR DESCRIPTION
Deleted this checker because if the builder is not in the map, the oracle will not record the block.