### PR TITLE
fix: stressnet bidder emulator count

### DIFF
--- a/infrastructure/nomad/playbooks/variables/profiles.yml
+++ b/infrastructure/nomad/playbooks/variables/profiles.yml
@@ -439,7 +439,7 @@ jobs:
     template: mev-commit-emulator.nomad.j2
     artifacts:
       - *bidder_emulator_artifact
-    count: 1
+    count: 5
     target_type: bidder
     target_name: mev-commit-bidder-node
     ports:


### PR DESCRIPTION
Fixes the number of bidder emulator nodes deployed in the `stressnet` profile.