### PR TITLE
perf: allocate more resources for oracle db testnet

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-oracle.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-oracle.nomad.j2
@@ -41,6 +41,17 @@ job "{{ job.name }}" {
         sidecar = true
       }
 
+      {% if profile == 'testnet' %}
+      resources {
+        cores = 4
+        memory = 8192
+      }
+      {% elif profile == 'stressnet' %}
+      resources {
+        memory = 4096
+      }
+      {% endif %}
+
       {% if profile == 'stressnet' %}
       resources {
         memory = 4096
@@ -122,7 +133,7 @@ job "{{ job.name }}" {
       {% if profile == 'testnet' %}
       resources {
         cores = 4
-        memory = 16384
+        memory = 8192
       }
       {% elif profile == 'stressnet' %}
       resources {


### PR DESCRIPTION
Allocates more resources to the mev-commit oracle database when using the `testnet` profile.