### PR TITLE
fix: oracle db running check

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-oracle.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-oracle.nomad.j2
@@ -100,12 +100,13 @@ job "{{ job.name }}" {
           postgres -D "${POSTGRES_DATA}" &
           pid=$!
 
-          until pg_isready --quiet --username="${USER}" --dbname=postgres; do
+          if ! timeout 5m bash -c 'until pg_ctl status --pgdata="${POSTGRES_DATA}" --silent --no-wait; do sleep 1; done'; then
             echo "Waiting for PostgreSQL to start..."
             sleep 1
-          done
+          fi
 
-          createuser --username="${USER}" --createdb "${POSTGRES_USERNAME}"
+          createuser --superuser postgres > /dev/null 2>&1
+          createuser --username=postgres --createdb "${POSTGRES_USERNAME}"
           createdb --username="${POSTGRES_USERNAME}" "${POSTGRES_DB}"
           psql --quiet \
                --username="${POSTGRES_USERNAME}" \


### PR DESCRIPTION
Replaces `pg_isready` with the more reliable `pg_ctl status`, which does not need a user to conduct the check.