### PR TITLE
fix: oracle db duplicate resources block

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-oracle.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-oracle.nomad.j2
@@ -52,12 +52,6 @@ job "{{ job.name }}" {
       }
       {% endif %}
 
-      {% if profile == 'stressnet' %}
-      resources {
-        memory = 4096
-      }
-      {% endif %}
-
       template {
         data = <<-EOH
           POSTGRES_VERSION="15"


### PR DESCRIPTION
Fixes a duplicate oracle db resource block occurring in the `stressnet` profile.