### PR TITLE
feat: adds execution enforcement to preconfirmations

### DIFF
--- a/infrastructure/nomad/playbooks/variables/profiles.yml
+++ b/infrastructure/nomad/playbooks/variables/profiles.yml
@@ -1,5 +1,5 @@
 datacenter: "dc1"
-l1_rpc_url: "https://eth-holesky.g.alchemy.com/v2/WqNEQeeexFLQwECjxCPpdep0uvCgn8Yj"
+l1_rpc_url: "https://eth-holesky.g.alchemy.com/v2/H8JN1wImnEPrxkFRVOT7cJ_gzu9x3VmB"
 
 artifacts:
   bidder_emulator: &bidder_emulator_artifact

--- a/oracle/pkg/l1Listener/l1Listener.go
+++ b/oracle/pkg/l1Listener/l1Listener.go
@@ -27,6 +27,7 @@ type WinnerRegister interface {
 type EthClient interface {
 	BlockNumber(ctx context.Context) (uint64, error)
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
+	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
 }
 
 type L1Listener struct {

--- a/oracle/pkg/l1Listener/l1Listener_test.go
+++ b/oracle/pkg/l1Listener/l1Listener_test.go
@@ -205,6 +205,10 @@ func (t *testEthClient) HeaderByNumber(_ context.Context, number *big.Int) (*typ
 	return hdr, nil
 }
 
+func (t *testEthClient) BlockByNumber(_ context.Context, number *big.Int) (*types.Block, error) {
+	return nil, nil
+}
+
 func publishLog(
 	eventManager events.EventManager,
 	blockNum *big.Int,

--- a/oracle/pkg/node/node.go
+++ b/oracle/pkg/node/node.go
@@ -419,7 +419,7 @@ func (i *infiniteRetryL1Client) BlockNumber(ctx context.Context) (uint64, error)
 		if err == nil {
 			break
 		}
-		if httpErr, ok := err.(interface{ StatusCode() int }); ok && httpErr.StatusCode() == 429 {
+		if strings.Contains(err.Error(), "429") {
 			i.logger.Error("received 429 Too Many Requests, retrying...", "error", err)
 		} else {
 			i.logger.Error("failed to get block number", "error", err)
@@ -438,7 +438,7 @@ func (i *infiniteRetryL1Client) HeaderByNumber(ctx context.Context, number *big.
 		if err == nil {
 			break
 		}
-		if httpErr, ok := err.(interface{ StatusCode() int }); ok && httpErr.StatusCode() == 429 {
+		if strings.Contains(err.Error(), "429") {
 			i.logger.Error("received 429 Too Many Requests, retrying...", "error", err)
 		} else {
 			i.logger.Error("failed to get header by number", "error", err)
@@ -457,7 +457,7 @@ func (i *infiniteRetryL1Client) BlockByNumber(ctx context.Context, number *big.I
 		if err == nil {
 			break
 		}
-		if httpErr, ok := err.(interface{ StatusCode() int }); ok && httpErr.StatusCode() == 429 {
+		if strings.Contains(err.Error(), "429") {
 			i.logger.Error("received 429 Too Many Requests, retrying...", "error", err)
 		} else {
 			i.logger.Error("failed to get block by number", "error", err)
@@ -467,7 +467,6 @@ func (i *infiniteRetryL1Client) BlockByNumber(ctx context.Context, number *big.I
 	}
 	return blk, nil
 }
-
 func setBuilderMapping(
 	ctx context.Context,
 	bt *blocktracker.BlocktrackerTransactorSession,

--- a/oracle/pkg/node/node.go
+++ b/oracle/pkg/node/node.go
@@ -106,7 +106,7 @@ func NewNode(opts *Options) (*Node, error) {
 	monitor := txmonitor.New(
 		owner,
 		settlementClient,
-		txmonitor.NewEVMHelper(settlementClient.Client()),
+		txmonitor.NewEVMHelperWithLogger(settlementClient.Client(), nd.logger),
 		st,
 		nd.logger.With("component", "tx_monitor"),
 		1024,
@@ -238,7 +238,7 @@ func NewNode(opts *Options) (*Node, error) {
 		st,
 		evtMgr,
 		oracleTransactorSession,
-		txmonitor.NewEVMHelper(l1Client.Client()),
+		txmonitor.NewEVMHelperWithLogger(l1Client.Client(), nd.logger),
 	)
 	if err != nil {
 		nd.logger.Error("failed to instantiate updater", "error", err)

--- a/oracle/pkg/node/node.go
+++ b/oracle/pkg/node/node.go
@@ -236,6 +236,7 @@ func NewNode(opts *Options) (*Node, error) {
 		st,
 		evtMgr,
 		oracleTransactorSession,
+		txmonitor.NewEVMHelper(l1Client.Client()),
 	)
 	if err != nil {
 		nd.logger.Error("failed to instantiate updater", "error", err)

--- a/oracle/pkg/node/node.go
+++ b/oracle/pkg/node/node.go
@@ -419,7 +419,12 @@ func (i *infiniteRetryL1Client) BlockNumber(ctx context.Context) (uint64, error)
 		if err == nil {
 			break
 		}
-		i.logger.Error("failed to get block number, retrying...", "error", err)
+		if httpErr, ok := err.(interface{ StatusCode() int }); ok && httpErr.StatusCode() == 429 {
+			i.logger.Error("received 429 Too Many Requests, retrying...", "error", err)
+		} else {
+			i.logger.Error("failed to get block number", "error", err)
+			return 0, err
+		}
 		time.Sleep(1 * time.Second)
 	}
 	return blkNum, nil
@@ -433,7 +438,12 @@ func (i *infiniteRetryL1Client) HeaderByNumber(ctx context.Context, number *big.
 		if err == nil {
 			break
 		}
-		i.logger.Error("failed to get header by number, retrying...", "error", err)
+		if httpErr, ok := err.(interface{ StatusCode() int }); ok && httpErr.StatusCode() == 429 {
+			i.logger.Error("received 429 Too Many Requests, retrying...", "error", err)
+		} else {
+			i.logger.Error("failed to get header by number", "error", err)
+			return nil, err
+		}
 		time.Sleep(1 * time.Second)
 	}
 	return hdr, nil
@@ -447,7 +457,12 @@ func (i *infiniteRetryL1Client) BlockByNumber(ctx context.Context, number *big.I
 		if err == nil {
 			break
 		}
-		i.logger.Error("failed to get block by number, retrying...", "error", err)
+		if httpErr, ok := err.(interface{ StatusCode() int }); ok && httpErr.StatusCode() == 429 {
+			i.logger.Error("received 429 Too Many Requests, retrying...", "error", err)
+		} else {
+			i.logger.Error("failed to get block by number", "error", err)
+			return nil, err
+		}
 		time.Sleep(1 * time.Second)
 	}
 	return blk, nil

--- a/oracle/pkg/node/node.go
+++ b/oracle/pkg/node/node.go
@@ -414,18 +414,16 @@ type infiniteRetryL1Client struct {
 func (i *infiniteRetryL1Client) BlockNumber(ctx context.Context) (uint64, error) {
 	var blkNum uint64
 	var err error
-	for {
+	for retries := 50; retries > 0; retries-- {
 		blkNum, err = i.EthClient.BlockNumber(ctx)
 		if err == nil {
 			break
 		}
-		if strings.Contains(err.Error(), "429") {
-			i.logger.Error("received 429 Too Many Requests, retrying...", "error", err)
-		} else {
-			i.logger.Error("failed to get block number", "error", err)
-			return 0, err
-		}
+		i.logger.Error("failed to get block number, retrying...", "error", err)
 		time.Sleep(1 * time.Second)
+	}
+	if err != nil {
+		return 0, err
 	}
 	return blkNum, nil
 }
@@ -433,18 +431,16 @@ func (i *infiniteRetryL1Client) BlockNumber(ctx context.Context) (uint64, error)
 func (i *infiniteRetryL1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	var hdr *types.Header
 	var err error
-	for {
+	for retries := 50; retries > 0; retries-- {
 		hdr, err = i.EthClient.HeaderByNumber(ctx, number)
 		if err == nil {
 			break
 		}
-		if strings.Contains(err.Error(), "429") {
-			i.logger.Error("received 429 Too Many Requests, retrying...", "error", err)
-		} else {
-			i.logger.Error("failed to get header by number", "error", err)
-			return nil, err
-		}
+		i.logger.Error("failed to get header by number, retrying...", "error", err)
 		time.Sleep(1 * time.Second)
+	}
+	if err != nil {
+		return nil, err
 	}
 	return hdr, nil
 }
@@ -452,18 +448,16 @@ func (i *infiniteRetryL1Client) HeaderByNumber(ctx context.Context, number *big.
 func (i *infiniteRetryL1Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
 	var blk *types.Block
 	var err error
-	for {
+	for retries := 50; retries > 0; retries-- {
 		blk, err = i.EthClient.BlockByNumber(ctx, number)
 		if err == nil {
 			break
 		}
-		if strings.Contains(err.Error(), "429") {
-			i.logger.Error("received 429 Too Many Requests, retrying...", "error", err)
-		} else {
-			i.logger.Error("failed to get block by number", "error", err)
-			return nil, err
-		}
+		i.logger.Error("failed to get block by number, retrying...", "error", err)
 		time.Sleep(1 * time.Second)
+	}
+	if err != nil {
+		return nil, err
 	}
 	return blk, nil
 }

--- a/oracle/pkg/node/node.go
+++ b/oracle/pkg/node/node.go
@@ -420,7 +420,7 @@ func (i *infiniteRetryL1Client) BlockNumber(ctx context.Context) (uint64, error)
 			break
 		}
 		i.logger.Error("failed to get block number, retrying...", "error", err)
-		time.Sleep(1 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 	if err != nil {
 		return 0, err
@@ -437,7 +437,7 @@ func (i *infiniteRetryL1Client) HeaderByNumber(ctx context.Context, number *big.
 			break
 		}
 		i.logger.Error("failed to get header by number, retrying...", "error", err)
-		time.Sleep(1 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 	if err != nil {
 		return nil, err
@@ -454,7 +454,7 @@ func (i *infiniteRetryL1Client) BlockByNumber(ctx context.Context, number *big.I
 			break
 		}
 		i.logger.Error("failed to get block by number, retrying...", "error", err)
-		time.Sleep(1 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 	if err != nil {
 		return nil, err

--- a/oracle/pkg/updater/metrics.go
+++ b/oracle/pkg/updater/metrics.go
@@ -8,20 +8,21 @@ const (
 )
 
 type metrics struct {
-	CommitmentsReceivedCount  prometheus.Counter
-	CommitmentsProcessedCount prometheus.Counter
-	CommitmentsTooOldCount    prometheus.Counter
-	DuplicateCommitmentsCount prometheus.Counter
-	RewardsCount              prometheus.Counter
-	SlashesCount              prometheus.Counter
-	EncryptedCommitmentsCount prometheus.Counter
-	NoWinnerCount             prometheus.Counter
-	BlockTxnCacheHits         prometheus.Counter
-	BlockTxnCacheMisses       prometheus.Counter
-	BlockTimeCacheHits        prometheus.Counter
-	BlockTimeCacheMisses      prometheus.Counter
-	LastSentNonce             prometheus.Gauge
-	TxnReceiptRequestDuration prometheus.Histogram
+	CommitmentsReceivedCount       prometheus.Counter
+	CommitmentsProcessedCount      prometheus.Counter
+	CommitmentsTooOldCount         prometheus.Counter
+	DuplicateCommitmentsCount      prometheus.Counter
+	RewardsCount                   prometheus.Counter
+	SlashesCount                   prometheus.Counter
+	EncryptedCommitmentsCount      prometheus.Counter
+	NoWinnerCount                  prometheus.Counter
+	BlockTxnCacheHits              prometheus.Counter
+	BlockTxnCacheMisses            prometheus.Counter
+	BlockTimeCacheHits             prometheus.Counter
+	BlockTimeCacheMisses           prometheus.Counter
+	LastSentNonce                  prometheus.Gauge
+	TxnReceiptRequestDuration      prometheus.Histogram
+	TxnReceiptRequestBlockDuration prometheus.Histogram
 }
 
 func newMetrics() *metrics {
@@ -138,6 +139,14 @@ func newMetrics() *metrics {
 			Help:      "Duration of transaction receipt requests",
 		},
 	)
+	m.TxnReceiptRequestBlockDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: defaultNamespace,
+			Subsystem: subsystem,
+			Name:      "txn_receipt_request_block_duration",
+			Help:      "Duration of transaction receipt requests",
+		},
+	)
 	return m
 }
 
@@ -157,5 +166,6 @@ func (m *metrics) Collectors() []prometheus.Collector {
 		m.BlockTimeCacheMisses,
 		m.LastSentNonce,
 		m.TxnReceiptRequestDuration,
+		m.TxnReceiptRequestBlockDuration,
 	}
 }

--- a/oracle/pkg/updater/metrics.go
+++ b/oracle/pkg/updater/metrics.go
@@ -21,6 +21,7 @@ type metrics struct {
 	BlockTimeCacheHits        prometheus.Counter
 	BlockTimeCacheMisses      prometheus.Counter
 	LastSentNonce             prometheus.Gauge
+	TxnReceiptRequestDuration prometheus.Histogram
 }
 
 func newMetrics() *metrics {
@@ -127,6 +128,14 @@ func newMetrics() *metrics {
 			Subsystem: subsystem,
 			Name:      "last_sent_nonce",
 			Help:      "Last nonce sent to for settlement",
+		},
+	)
+	m.TxnReceiptRequestDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: defaultNamespace,
+			Subsystem: subsystem,
+			Name:      "txn_receipt_request_duration",
+			Help:      "Duration of transaction receipt requests",
 		},
 	)
 	return m

--- a/oracle/pkg/updater/metrics.go
+++ b/oracle/pkg/updater/metrics.go
@@ -156,5 +156,6 @@ func (m *metrics) Collectors() []prometheus.Collector {
 		m.BlockTimeCacheHits,
 		m.BlockTimeCacheMisses,
 		m.LastSentNonce,
+		m.TxnReceiptRequestDuration,
 	}
 }

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -497,7 +497,6 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 	}
 
 	for _, bucket := range buckets {
-		bucket := bucket // closure for each errorgroup
 		eg.Go(func() error {
 			results, err := u.receiptBatcher.BatchReceipts(ctx, bucket)
 			if err != nil {

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -27,7 +27,6 @@ type SettlementType string
 type TxMetadata struct {
 	PosInBlock int
 	Succeeded  bool
-	// Add other metadata fields here as needed
 }
 
 const (

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -335,7 +335,7 @@ func (u *Updater) handleOpenedCommitment(
 	// Ensure Bundle is atomic and present in the block
 	for i := 0; i < len(commitmentTxnHashes); i++ {
 		txnDetails, found := txns[commitmentTxnHashes[i]]
-		if !found || txnDetails.PosInBlock != (txns[commitmentTxnHashes[0]].PosInBlock)+i {
+		if !found || txnDetails.PosInBlock != (txns[commitmentTxnHashes[0]].PosInBlock)+i || !txnDetails.Succeeded {
 			u.logger.Info(
 				"bundle is not atomic",
 				"commitmentIdx", common.Bytes2Hex(update.CommitmentIndex[:]),

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -458,6 +458,7 @@ func (u *Updater) addSettlement(
 
 	return nil
 }
+
 func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]TxMetadata, error) {
 	txns, ok := u.l1BlockCache.Get(blockNum)
 	if ok {
@@ -467,7 +468,7 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 
 	u.metrics.BlockTxnCacheMisses.Inc()
 
-	blk, err := u.l1Client.BlockByNumber(ctx, big.NewInt(0).SetUint64(blockNum))
+	block, err := u.l1Client.BlockByNumber(ctx, big.NewInt(0).SetUint64(blockNum))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get block by number: %w", err)
 	}
@@ -475,22 +476,35 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 	txnsInBlock := make(map[string]TxMetadata)
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	for posInBlock, tx := range blk.Transactions() {
-		wg.Add(1)
-		go func(posInBlock int, tx *types.Transaction) {
-			defer wg.Done()
-			receipt, err := u.l1Client.TransactionReceipt(ctx, tx.Hash())
-			if err != nil {
-				u.logger.Error("failed to get transaction receipt", "txHash", tx.Hash().Hex(), "error", err)
-				return
-			}
-			txSucceeded := receipt.Status == 1
+	var receiptErr error
+
+	processTransactionMetadata := func(posInBlock int, tx *types.Transaction) {
+		defer wg.Done()
+		receipt, err := u.l1Client.TransactionReceipt(ctx, tx.Hash())
+		if err != nil {
+			u.logger.Error("failed to get transaction receipt", "txHash", tx.Hash().Hex(), "error", err)
 			mu.Lock()
-			txnsInBlock[strings.TrimPrefix(tx.Hash().Hex(), "0x")] = TxMetadata{PosInBlock: posInBlock, Succeeded: txSucceeded}
+			receiptErr = err
 			mu.Unlock()
-		}(posInBlock, tx)
+			return
+		}
+		txSucceeded := receipt.Status == 1
+		mu.Lock()
+		txnsInBlock[strings.TrimPrefix(tx.Hash().Hex(), "0x")] = TxMetadata{PosInBlock: posInBlock, Succeeded: txSucceeded}
+		mu.Unlock()
 	}
+
+	for posInBlock, tx := range block.Transactions() {
+		wg.Add(1)
+		go processTransactionMetadata(posInBlock, tx)
+	}
+
 	wg.Wait()
+
+	if receiptErr != nil {
+		return nil, receiptErr
+	}
+
 	_ = u.l1BlockCache.Add(blockNum, txnsInBlock)
 
 	return txnsInBlock, nil

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -216,7 +216,8 @@ func (u *Updater) Start(ctx context.Context) <-chan struct{} {
 	go func() {
 		defer close(doneChan)
 		if err := eg.Wait(); err != nil {
-			u.logger.Error("failed to start updater", "error", err)
+			u.logger.Error("updater failed, exiting", "error", err)
+			panic(err)
 		}
 	}()
 

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -484,10 +484,11 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 	for i, tx := range block.Transactions() {
 		txnsArray[i] = tx.Hash()
 	}
+	const bucketSize = 50 // Arbitrary number for bucket size
 
-	bucketSize := (len(txnsArray) + 3) / 4 // Calculate the size of each bucket, rounding up
-	buckets := make([][]common.Hash, 4)
-	for i := 0; i < 4; i++ {
+	numBuckets := (len(txnsArray) + bucketSize - 1) / bucketSize // Calculate the number of buckets needed, rounding up
+	buckets := make([][]common.Hash, numBuckets)
+	for i := 0; i < numBuckets; i++ {
 		start := i * bucketSize
 		end := start + bucketSize
 		if end > len(txnsArray) {

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -497,6 +497,8 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 		buckets[i] = txnsArray[start:end]
 	}
 
+	blockStart := time.Now()
+
 	for _, bucket := range buckets {
 		eg.Go(func() error {
 			start := time.Now()
@@ -520,6 +522,8 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
+
+	u.metrics.TxnReceiptRequestBlockDuration.Observe(time.Since(blockStart).Seconds())
 
 	txnsMap := make(map[string]TxMetadata)
 	for i, tx := range txnsArray {

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -498,10 +499,12 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 
 	for _, bucket := range buckets {
 		eg.Go(func() error {
+			start := time.Now()
 			results, err := u.receiptBatcher.BatchReceipts(ctx, bucket)
 			if err != nil {
 				return fmt.Errorf("failed to get batch receipts: %w", err)
 			}
+			u.metrics.TxnReceiptRequestDuration.Observe(time.Since(start).Seconds())
 			for _, result := range results {
 				if result.Err != nil {
 					return fmt.Errorf("failed to get receipt for txn: %s", result.Err)

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -91,7 +91,6 @@ type Oracle interface {
 
 type EVMClient interface {
 	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
-	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 }
 
 type Updater struct {
@@ -509,7 +508,7 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 					return fmt.Errorf("failed to get receipt for txn: %s", result.Err)
 				}
 
-				txnReceipts.Store(result.Receipt.TxHash.Hex(), *result.Receipt)
+				txnReceipts.Store(result.Receipt.TxHash.Hex(), result.Receipt)
 			}
 
 			return nil
@@ -526,7 +525,7 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 		if !ok {
 			return nil, fmt.Errorf("receipt not found for txn: %s", tx)
 		}
-		txnsMap[strings.TrimPrefix(tx.Hex(), "0x")] = TxMetadata{PosInBlock: i, Succeeded: receipt.(types.Receipt).Status == types.ReceiptStatusSuccessful}
+		txnsMap[strings.TrimPrefix(tx.Hex(), "0x")] = TxMetadata{PosInBlock: i, Succeeded: receipt.(*types.Receipt).Status == types.ReceiptStatusSuccessful}
 	}
 
 	_ = u.l1BlockCache.Add(blockNum, txnsMap)

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -484,7 +484,7 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 	for i, tx := range block.Transactions() {
 		txnsArray[i] = tx.Hash()
 	}
-	const bucketSize = 50 // Arbitrary number for bucket size
+	const bucketSize = 25 // Arbitrary number for bucket size
 
 	numBuckets := (len(txnsArray) + bucketSize - 1) / bucketSize // Calculate the number of buckets needed, rounding up
 	buckets := make([][]common.Hash, numBuckets)

--- a/oracle/pkg/updater/updater_test.go
+++ b/oracle/pkg/updater/updater_test.go
@@ -173,6 +173,14 @@ func TestUpdater(t *testing.T) {
 		blocks: map[int64]*types.Block{
 			5: types.NewBlock(&types.Header{}, txns, nil, nil, NewHasher()),
 		},
+		receipts: make(map[string]*types.Receipt),
+	}
+	for _, txn := range txns {
+		receipt := &types.Receipt{
+			Status: types.ReceiptStatusSuccessful,
+			TxHash: txn.Hash(),
+		}
+		l1Client.receipts[txn.Hash().Hex()] = receipt
 	}
 
 	pcABI, err := abi.JSON(strings.NewReader(preconf.PreconfcommitmentstoreABI))
@@ -380,6 +388,14 @@ func TestUpdaterBundlesFailure(t *testing.T) {
 		blocks: map[int64]*types.Block{
 			5: types.NewBlock(&types.Header{}, txns, nil, nil, NewHasher()),
 		},
+		receipts: make(map[string]*types.Receipt),
+	}
+	for _, txn := range txns {
+		receipt := &types.Receipt{
+			Status: types.ReceiptStatusSuccessful,
+			TxHash: txn.Hash(),
+		}
+		l1Client.receipts[txn.Hash().Hex()] = receipt
 	}
 
 	oracle := &testOracle{

--- a/oracle/pkg/updater/updater_test.go
+++ b/oracle/pkg/updater/updater_test.go
@@ -809,6 +809,10 @@ func (t *testEVMClient) BlockByNumber(ctx context.Context, blkNum *big.Int) (*ty
 	return blk, nil
 }
 
+func (t *testEVMClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	return &types.Receipt{Status: 1}, nil
+}
+
 type processedCommitment struct {
 	commitmentIdx [32]byte
 	blockNum      *big.Int

--- a/oracle/pkg/updater/updater_test.go
+++ b/oracle/pkg/updater/updater_test.go
@@ -99,7 +99,7 @@ func TestUpdater(t *testing.T) {
 
 	signer := types.NewLondonSigner(big.NewInt(5))
 	var txns []*types.Transaction
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		txns = append(txns, types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
 			Nonce:     uint64(i + 1),
 			Gas:       1000000,
@@ -147,7 +147,7 @@ func TestUpdater(t *testing.T) {
 	}
 
 	// constructing bundles
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		idxBytes := getIdxBytes(int64(i + 10))
 
 		bundle := strings.TrimPrefix(txns[i].Hash().Hex(), "0x")
@@ -360,7 +360,7 @@ func TestUpdaterRevertedTxns(t *testing.T) {
 
 	signer := types.NewLondonSigner(big.NewInt(5))
 	var txns []*types.Transaction
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		txns = append(txns, types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
 			Nonce:     uint64(i + 1),
 			Gas:       1000000,
@@ -408,7 +408,7 @@ func TestUpdaterRevertedTxns(t *testing.T) {
 	}
 
 	// constructing bundles
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		idxBytes := getIdxBytes(int64(i + 10))
 
 		bundle := strings.TrimPrefix(txns[i].Hash().Hex(), "0x")
@@ -625,7 +625,7 @@ func TestUpdaterBundlesFailure(t *testing.T) {
 
 	signer := types.NewLondonSigner(big.NewInt(5))
 	var txns []*types.Transaction
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		txns = append(txns, types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
 			Nonce:     uint64(i + 1),
 			Gas:       1000000,
@@ -811,7 +811,7 @@ func TestUpdaterIgnoreCommitments(t *testing.T) {
 
 	signer := types.NewLondonSigner(big.NewInt(5))
 	var txns []*types.Transaction
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		txns = append(txns, types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
 			Nonce:     uint64(i + 1),
 			Gas:       1000000,

--- a/oracle/pkg/updater/updater_test.go
+++ b/oracle/pkg/updater/updater_test.go
@@ -318,6 +318,266 @@ func TestUpdater(t *testing.T) {
 	}
 }
 
+func TestUpdaterRevertedTxns(t *testing.T) {
+	t.Parallel()
+
+	// timestamp of the First block commitment is X
+	startTimestamp := time.UnixMilli(1615195200000)
+	midTimestamp := startTimestamp.Add(time.Duration(2.5 * float64(time.Second)))
+	endTimestamp := startTimestamp.Add(5 * time.Second)
+
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	builderAddr := common.HexToAddress("0xabcd")
+	otherBuilderAddr := common.HexToAddress("0xabdc")
+
+	signer := types.NewLondonSigner(big.NewInt(5))
+	var txns []*types.Transaction
+	for i := 0; i < 10; i++ {
+		txns = append(txns, types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
+			Nonce:     uint64(i + 1),
+			Gas:       1000000,
+			Value:     big.NewInt(1),
+			GasTipCap: big.NewInt(500),
+			GasFeeCap: big.NewInt(500),
+		}))
+	}
+
+	encCommitments := make([]preconf.PreconfcommitmentstoreEncryptedCommitmentStored, 0)
+	commitments := make([]preconf.PreconfcommitmentstoreCommitmentStored, 0)
+
+	for i, txn := range txns {
+		idxBytes := getIdxBytes(int64(i))
+
+		encCommitment := preconf.PreconfcommitmentstoreEncryptedCommitmentStored{
+			CommitmentIndex:     idxBytes,
+			CommitmentDigest:    common.HexToHash(fmt.Sprintf("0x%02d", i)),
+			CommitmentSignature: []byte("signature"),
+			DispatchTimestamp:   uint64(midTimestamp.UnixMilli()),
+		}
+		commitment := preconf.PreconfcommitmentstoreCommitmentStored{
+			CommitmentIndex:     idxBytes,
+			TxnHash:             strings.TrimPrefix(txn.Hash().Hex(), "0x"),
+			Bid:                 big.NewInt(10),
+			BlockNumber:         5,
+			CommitmentHash:      common.HexToHash(fmt.Sprintf("0x%02d", i)),
+			CommitmentSignature: []byte("signature"),
+			DecayStartTimeStamp: uint64(startTimestamp.UnixMilli()),
+			DecayEndTimeStamp:   uint64(endTimestamp.UnixMilli()),
+			DispatchTimestamp:   uint64(midTimestamp.UnixMilli()),
+		}
+
+		if i%2 == 0 {
+			encCommitment.Commiter = builderAddr
+			commitment.Commiter = builderAddr
+			encCommitments = append(encCommitments, encCommitment)
+			commitments = append(commitments, commitment)
+		} else {
+			encCommitment.Commiter = otherBuilderAddr
+			commitment.Commiter = otherBuilderAddr
+			encCommitments = append(encCommitments, encCommitment)
+			commitments = append(commitments, commitment)
+		}
+	}
+
+	// constructing bundles
+	for i := 0; i < 10; i++ {
+		idxBytes := getIdxBytes(int64(i + 10))
+
+		bundle := strings.TrimPrefix(txns[i].Hash().Hex(), "0x")
+		for j := i + 1; j < 10; j++ {
+			bundle += "," + strings.TrimPrefix(txns[j].Hash().Hex(), "0x")
+		}
+
+		encCommitment := preconf.PreconfcommitmentstoreEncryptedCommitmentStored{
+			CommitmentIndex:     idxBytes,
+			Commiter:            builderAddr,
+			CommitmentDigest:    common.HexToHash(fmt.Sprintf("0x%02d", i)),
+			CommitmentSignature: []byte("signature"),
+			DispatchTimestamp:   uint64(midTimestamp.UnixMilli()),
+		}
+		commitment := preconf.PreconfcommitmentstoreCommitmentStored{
+			CommitmentIndex:     idxBytes,
+			Commiter:            builderAddr,
+			Bid:                 big.NewInt(10),
+			TxnHash:             bundle,
+			BlockNumber:         5,
+			CommitmentHash:      common.HexToHash(fmt.Sprintf("0x%02d", i)),
+			CommitmentSignature: []byte("signature"),
+			DecayStartTimeStamp: uint64(startTimestamp.UnixMilli()),
+			DecayEndTimeStamp:   uint64(endTimestamp.UnixMilli()),
+			DispatchTimestamp:   uint64(midTimestamp.UnixMilli()),
+		}
+		encCommitments = append(encCommitments, encCommitment)
+		commitments = append(commitments, commitment)
+	}
+
+	register := &testWinnerRegister{
+		winners: []testWinner{
+			{
+				blockNum: 5,
+				winner: updater.Winner{
+					Winner: builderAddr.Bytes(),
+					Window: 1,
+				},
+			},
+		},
+		settlements: make(chan testSettlement, 1),
+		encCommit:   make(chan testEncryptedCommitment, 1),
+	}
+
+	l1Client := &testEVMClient{
+		blocks: map[int64]*types.Block{
+			5: types.NewBlock(&types.Header{}, txns, nil, nil, NewHasher()),
+		},
+		receipts: make(map[string]*types.Receipt),
+	}
+	for _, txn := range txns {
+		receipt := &types.Receipt{
+			Status: types.ReceiptStatusFailed,
+			TxHash: txn.Hash(),
+		}
+		l1Client.receipts[txn.Hash().Hex()] = receipt
+	}
+
+	pcABI, err := abi.JSON(strings.NewReader(preconf.PreconfcommitmentstoreABI))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	btABI, err := abi.JSON(strings.NewReader(blocktracker.BlocktrackerABI))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evtMgr := events.NewListener(
+		util.NewTestLogger(io.Discard),
+		&btABI,
+		&pcABI,
+	)
+
+	oracle := &testOracle{
+		commitments: make(chan processedCommitment, 1),
+	}
+
+	updtr, err := updater.NewUpdater(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		l1Client,
+		register,
+		evtMgr,
+		oracle,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := updtr.Start(ctx)
+
+	w := blocktracker.BlocktrackerNewWindow{
+		Window: big.NewInt(1),
+	}
+	publishNewWindow(evtMgr, &btABI, w)
+
+	for _, ec := range encCommitments {
+		if err := publishEncCommitment(evtMgr, &pcABI, ec); err != nil {
+			t.Fatal(err)
+		}
+
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout")
+		case enc := <-register.encCommit:
+			if !bytes.Equal(enc.commitmentIdx, ec.CommitmentIndex[:]) {
+				t.Fatal("wrong commitment index")
+			}
+			if !bytes.Equal(enc.committer, ec.Commiter.Bytes()) {
+				t.Fatal("wrong committer")
+			}
+			if !bytes.Equal(enc.commitmentHash, ec.CommitmentDigest[:]) {
+				t.Fatal("wrong commitment hash")
+			}
+			if !bytes.Equal(enc.commitmentSignature, ec.CommitmentSignature) {
+				t.Fatal("wrong commitment signature")
+			}
+			if enc.dispatchTimestamp != ec.DispatchTimestamp {
+				t.Fatal("wrong dispatch timestamp")
+			}
+		}
+	}
+
+	for _, c := range commitments {
+		if err := publishCommitment(evtMgr, &pcABI, c); err != nil {
+			t.Fatal(err)
+		}
+
+		if c.Commiter.Cmp(otherBuilderAddr) == 0 {
+			continue
+		}
+
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout")
+		case commitment := <-oracle.commitments:
+			if !bytes.Equal(commitment.commitmentIdx[:], c.CommitmentIndex[:]) {
+				t.Fatal("wrong commitment index")
+			}
+			if commitment.blockNum.Cmp(big.NewInt(5)) != 0 {
+				t.Fatal("wrong block number")
+			}
+			if commitment.builder != c.Commiter {
+				t.Fatal("wrong builder")
+			}
+			if !commitment.isSlash {
+				t.Fatal("wrong isSlash")
+			}
+			if commitment.residualDecay.Cmp(big.NewInt(50)) != 0 {
+				t.Fatal("wrong residual decay")
+			}
+		}
+
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout")
+		case settlement := <-register.settlements:
+			if !bytes.Equal(settlement.commitmentIdx, c.CommitmentIndex[:]) {
+				t.Fatal("wrong commitment index")
+			}
+			if settlement.txHash != c.TxnHash {
+				t.Fatal("wrong txn hash")
+			}
+			if settlement.blockNum != 5 {
+				t.Fatal("wrong block number")
+			}
+			if !bytes.Equal(settlement.builder, c.Commiter.Bytes()) {
+				t.Fatal("wrong builder")
+			}
+			if settlement.amount.Uint64() != 10 {
+				t.Fatal("wrong amount")
+			}
+			if settlement.settlementType != updater.SettlementTypeSlash {
+				t.Fatal("wrong settlement type")
+			}
+			if settlement.decayPercentage != 50 {
+				t.Fatal("wrong decay percentage")
+			}
+			if settlement.window != 1 {
+				t.Fatal("wrong window")
+			}
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
 func TestUpdaterBundlesFailure(t *testing.T) {
 	t.Parallel()
 

--- a/oracle/pkg/updater/updater_test.go
+++ b/oracle/pkg/updater/updater_test.go
@@ -1127,14 +1127,6 @@ func (t *testEVMClient) BlockByNumber(ctx context.Context, blkNum *big.Int) (*ty
 	return blk, nil
 }
 
-func (t *testEVMClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
-	receipt, found := t.receipts[txHash.Hex()]
-	if !found {
-		return nil, fmt.Errorf("receipt for transaction hash %s not found", txHash.Hex())
-	}
-	return receipt, nil
-}
-
 type processedCommitment struct {
 	commitmentIdx [32]byte
 	blockNum      *big.Int

--- a/p2p/pkg/node/node.go
+++ b/p2p/pkg/node/node.go
@@ -185,7 +185,7 @@ func NewNode(opts *Options) (*Node, error) {
 	monitor := txmonitor.New(
 		opts.KeySigner.GetAddress(),
 		contractRPC,
-		txmonitor.NewEVMHelper(contractRPC.Client()),
+		txmonitor.NewEVMHelperWithLogger(contractRPC.Client(), opts.Logger.With("component", "txmonitor")),
 		store,
 		opts.Logger.With("component", "txmonitor"),
 		1024,
@@ -337,7 +337,7 @@ func NewNode(opts *Options) (*Node, error) {
 			evtMgr,
 			store,
 			commitmentDA,
-			txmonitor.NewEVMHelper(contractRPC.Client()),
+			txmonitor.NewEVMHelperWithLogger(contractRPC.Client(), opts.Logger.With("component", "evm_helper")),
 			optsGetter,
 			opts.Logger.With("component", "tracker"),
 		)

--- a/x/contracts/txmonitor/eth_helper.go
+++ b/x/contracts/txmonitor/eth_helper.go
@@ -3,6 +3,7 @@ package txmonitor
 import (
 	"context"
 	"log"
+	"log/slog"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -78,11 +79,11 @@ type BatchReceiptGetter interface {
 
 type evmHelper struct {
 	client *rpc.Client
+	logger *slog.Logger
 }
 
-// NewEVMHelper creates a new EVMHelper instance.
-func NewEVMHelper(client *rpc.Client) *evmHelper {
-	return &evmHelper{client}
+func NewEVMHelperWithLogger(client *rpc.Client, logger *slog.Logger) *evmHelper {
+	return &evmHelper{client, logger}
 }
 
 // TraceTransaction implements Debugger.TraceTransaction interface.

--- a/x/contracts/txmonitor/eth_helper.go
+++ b/x/contracts/txmonitor/eth_helper.go
@@ -2,6 +2,7 @@ package txmonitor
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -114,7 +115,7 @@ func (e *evmHelper) BatchReceipts(ctx context.Context, txHashes []common.Hash) (
 
 	var receipts []Result
 	var err error
-	for retries := 0; retries < 100; retries++ {
+	for {
 		// Execute the batch request
 		err = e.client.BatchCallContext(ctx, batch)
 		if err == nil {
@@ -123,14 +124,11 @@ func (e *evmHelper) BatchReceipts(ctx context.Context, txHashes []common.Hash) (
 
 		// Check if the error is a 429 (Too Many Requests)
 		if rpcErr, ok := err.(rpc.Error); ok && rpcErr.ErrorCode() == 429 {
+			log.Println("received 429 Too Many Requests, retrying...", "error", err)
 			time.Sleep(1 * time.Second)
 			continue
 		}
 
-		return nil, err
-	}
-
-	if err != nil {
 		return nil, err
 	}
 

--- a/x/contracts/txmonitor/eth_helper.go
+++ b/x/contracts/txmonitor/eth_helper.go
@@ -115,7 +115,7 @@ func (e *evmHelper) BatchReceipts(ctx context.Context, txHashes []common.Hash) (
 
 	var receipts []Result
 	var err error
-	for attempts := 0; attempts < 10; attempts++ {
+	for attempts := 0; attempts < 50; attempts++ {
 		// Execute the batch request
 		err = e.client.BatchCallContext(ctx, batch)
 		if err != nil {

--- a/x/contracts/txmonitor/eth_helper.go
+++ b/x/contracts/txmonitor/eth_helper.go
@@ -117,7 +117,7 @@ func (e *evmHelper) BatchReceipts(ctx context.Context, txHashes []common.Hash) (
 	var err error
 	for attempts := 0; attempts < 50; attempts++ {
 		// Execute the batch request
-		err = e.client.BatchCallContext(ctx, batch)
+		err = e.client.BatchCallContext(context.Background(), batch)
 		if err != nil {
 			log.Printf("Batch call attempt %d failed: %v", attempts+1, err)
 			time.Sleep(1 * time.Second)

--- a/x/contracts/txmonitor/eth_helper.go
+++ b/x/contracts/txmonitor/eth_helper.go
@@ -2,7 +2,6 @@ package txmonitor
 
 import (
 	"context"
-	"log"
 	"log/slog"
 	"time"
 
@@ -104,9 +103,11 @@ func (e *evmHelper) TraceTransaction(ctx context.Context, txHash common.Hash) (*
 
 // BatchReceipts retrieves multiple receipts for a list of transaction hashes.
 func (e *evmHelper) BatchReceipts(ctx context.Context, txHashes []common.Hash) ([]Result, error) {
+	e.logger.Info("Starting BatchReceipts", "txHashes", txHashes)
 	batch := make([]rpc.BatchElem, len(txHashes))
 
 	for i, hash := range txHashes {
+		e.logger.Debug("Preparing batch element", "index", i, "hash", hash.Hex())
 		batch[i] = rpc.BatchElem{
 			Method: "eth_getTransactionReceipt",
 			Args:   []interface{}{hash},
@@ -117,24 +118,31 @@ func (e *evmHelper) BatchReceipts(ctx context.Context, txHashes []common.Hash) (
 	var receipts []Result
 	var err error
 	for attempts := 0; attempts < 50; attempts++ {
+		e.logger.Debug("Attempting batch call", "attempt", attempts+1)
 		// Execute the batch request
 		err = e.client.BatchCallContext(context.Background(), batch)
 		if err != nil {
-			log.Printf("Batch call attempt %d failed: %v", attempts+1, err)
+			e.logger.Error("Batch call attempt failed", "attempt", attempts+1, "error", err)
 			time.Sleep(1 * time.Second)
+		} else {
+			e.logger.Info("Batch call attempt succeeded", "attempt", attempts+1)
+			break
 		}
 	}
 
 	if err != nil {
+		e.logger.Error("All batch call attempts failed", "error", err)
 		return nil, err
 	}
 	receipts = make([]Result, len(batch))
 	for i, elem := range batch {
+		e.logger.Debug("Processing batch element", "index", i, "result", elem.Result, "error", elem.Error)
 		receipts[i].Receipt = elem.Result.(*types.Receipt)
 		if elem.Error != nil {
 			receipts[i].Err = elem.Error
 		}
 	}
 
+	e.logger.Info("BatchReceipts completed successfully", "receipts", receipts)
 	return receipts, nil
 }

--- a/x/contracts/txmonitor/eth_helper.go
+++ b/x/contracts/txmonitor/eth_helper.go
@@ -114,7 +114,7 @@ func (e *evmHelper) BatchReceipts(ctx context.Context, txHashes []common.Hash) (
 
 	var receipts []Result
 	var err error
-	for retries := 0; retries < 3; retries++ {
+	for retries := 0; retries < 100; retries++ {
 		// Execute the batch request
 		err = e.client.BatchCallContext(ctx, batch)
 		if err == nil {


### PR DESCRIPTION
## Motivation
Preconfirmations can trivially be satisfied by most block builders by placing the transactions at the bottom of the block. This is known as an inclusion preconfirmation. However, most preconfirmations are meant for contested state, like doing cex-dex arbitrage to bring the price an on-chain DEX or AMM into parity with the external world. In such cases, it's important to ensure the provider doesn't simply **_include_** the preconfirmation, but also ensures its successful execution.

### Implementation Details
We alter the data stored in our LRU cache to also keep track of the status of the transaction (success v.s failure). We subsequently continue our preconfirmation validation as normal, with the additional check of successful execution before the disbursement of rewards.

### Roadmap and relevance
 This is not a required check, as builders generally provide revert protection. This one of two PRs in this theme, that will introduce a bid expression where parties to can dictate which transactions are required to succeed and which ones can revert. The subsequent PR will deal with adding support for bid expressions, along with the first bid expression being the ability to specify which transactions in a bundle are ok to revert.