### PR TITLE
fix: forge build now specifies correct script directory 

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,6 +1,7 @@
 [profile.default]
 src = 'contracts'
 solc-version = '0.8.20'
+script = 'scripts'
 out = 'out'
 libs = ['node_modules', 'lib']
 test = 'test'

--- a/contracts/scripts/DeployScripts.s.sol
+++ b/contracts/scripts/DeployScripts.s.sol
@@ -6,7 +6,6 @@ import "../contracts/ProviderRegistry.sol";
 import "../contracts/PreConfCommitmentStore.sol";
 import "../contracts/Oracle.sol";
 import "../contracts/Whitelist.sol";
-import "../contracts/validator-registry/ValidatorRegistryV1.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 import "../contracts/BlockTracker.sol";
 

--- a/contracts/scripts/DeployStandardBridge.s.sol
+++ b/contracts/scripts/DeployStandardBridge.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BSL 1.1
 pragma solidity ^0.8.20;
 import "forge-std/Script.sol";
-import {Create2Deployer} from "../scripts/DeployScripts.s.sol";
 import {SettlementGateway} from "../contracts/standard-bridge/SettlementGateway.sol";
 import {L1Gateway} from "../contracts/standard-bridge/L1Gateway.sol";
 import {Whitelist} from "../contracts/Whitelist.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
 contract DeploySettlementGateway is Script {
     function run() external {
@@ -13,23 +13,26 @@ contract DeploySettlementGateway is Script {
         vm.startBroadcast();
 
         address relayerAddr = vm.envAddress("RELAYER_ADDR");
+        require(relayerAddr != address(0), "RELAYER_ADDR is not set");
+        address whitelistAddr = vm.envAddress("WHITELIST_ADDR");
+        require(whitelistAddr != address(0), "WHITELIST_ADDR is not set");
 
         address sgProxy = Upgrades.deployUUPSProxy(
             "SettlementGateway.sol",
             abi.encodeCall(SettlementGateway.initialize,
-            (msg.sender, // Owner
+            (whitelistAddr,
+            msg.sender, // Owner
             relayerAddr,
             1, 1)) // Fees set to 1 wei for now
         );
         SettlementGateway gateway = SettlementGateway(sgProxy);
         console.log("Standard bridge gateway for settlement chain deployed to:",
             address(gateway));
-
         address whitelistProxy = Upgrades.deployUUPSProxy(
             "Whitelist.sol",
             abi.encodeCall(Whitelist.initialize, (msg.sender))
         );
-        Whitelist whitelist = Whitelist(whitelistProxy);
+        Whitelist whitelist = Whitelist(payable(whitelistProxy));
         console.log("Whitelist deployed to:", address(whitelist));
 
         whitelist.addToWhitelist(address(gateway));
@@ -62,7 +65,7 @@ contract DeployL1Gateway is Script {
             relayerAddr,
             1, 1)) // Fees set to 1 wei for now
         );
-        L1Gateway gateway = L1Gateway(l1gProxy);
+        L1Gateway gateway = L1Gateway(payable(l1gProxy));
         console.log("Standard bridge gateway for l1 deployed to:",
             address(gateway));
         


### PR DESCRIPTION
Previously bugs like https://github.com/primev/mev-commit/pull/173 would not be caught by ci, because forge thinks scripts reside in the `script` directory by default. Our script directory is actually `scripts` as addressed in this PR. Now `forge test`, `forge build` etc. will fail as expected when one of the solidity scripts doesn't build.  