### PR TITLE
fix: use forge clean with snapshot and coverage ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,10 @@ jobs:
         run: forge clean && forge test -vvv --via-ir
 
       - name: Run Snapshot
-        run: forge snapshot --via-ir
+        run: forge clean && forge snapshot --via-ir
 
       - name: Run Coverage
-        run: forge coverage --ir-minimum
+        run: forge clean && forge coverage --ir-minimum
 
   contracts:
     name: Test and Build Contracts Scripts


### PR DESCRIPTION
Prevents the following ci failure

```
Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 18.67ms (17.91ms CPU time)

Ran 1 test for test/standard-bridge/SettlementGatewayTest.sol:SettlementGatewayTest
[FAIL. Reason: setup failed: revert: Failed to run upgrade safety validation: /home/runner/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/validate/find-contract.js:22
        throw new error_1.ValidateCommandError(msg, () => `This may be caused by old copies of build info files. Clean and recompile your project, then run the command again with the updated files.`);
              ^

ValidateCommandError: Found multiple contracts with name contracts/Whitelist.sol:Whitelist.

This may be caused by old copies of build info files. Clean and recompile your project, then run the command again with the updated files.
    at findContract (/home/runner/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/validate/find-contract.js:22:15)
    at findSpecifiedContracts (/home/runner/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/validate/validate-upgrade-safety.js:32:56)
    at validateUpgradeSafety (/home/runner/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/validate/validate-upgrade-safety.js:[24](https://github.com/primev/mev-commit/actions/runs/9706124644/job/26790655214?pr=176#step:7:25):32)
    at async main (/home/runner/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/validate.js:30:24)
    at async run (/home/runner/.npm/_npx/fb3494f8bab08a4d/node_modules/@openzeppelin/upgrades-core/dist/cli/cli.js:6:5)

Node.js v18.20.3
] setUp() (gas: 0)
Suite result: FAILED. 0 passed; 1 failed; 0 skipped; finished in 6.62s (0.00ns CPU time)
```