### PR TITLE
refactor: double nomad decompression file count limit

### DIFF
--- a/infrastructure/nomad/playbooks/templates/services/nomad.hcl.j2
+++ b/infrastructure/nomad/playbooks/templates/services/nomad.hcl.j2
@@ -25,6 +25,9 @@ client {
     "/usr" = "/usr"
     "/opt" = "/opt"
   }
+  artifact {
+    decompression_file_count_limit = 8192
+  }
   {% if env == "devenv" %}
   host_volume "artifacts-volume" {
     path = "{{ ansible_user_home }}/{{ env }}/artifacts"


### PR DESCRIPTION
Fixes the following types of errors: `failed to download artifact: tar archive contains too many files: 4097 > 4096`