### PR TITLE
fix: contracts deployer nodeJS binary arch

### DIFF
--- a/infrastructure/nomad/playbooks/deploy.yml
+++ b/infrastructure/nomad/playbooks/deploy.yml
@@ -168,6 +168,7 @@
           Profile:         {{ environments[env].profile }}
           Version:         {{ environments[env].version }}
           Secrets:         {{ environments[env].secrets }}
+          Hostname:        {{ ansible_hostname }}
           Build Artifacts: {{ 'yes' if build_artifacts | default(false) else 'no' }}
           Build Templates: {{ 'yes' if build_templates | default(false) else 'no' }}
 
@@ -236,7 +237,7 @@
           {% if artifact.keystore is defined %}
             case "{{ environments[env].secrets }}" in
               "generate")
-                PASSPHRASE="{{ lookup('password', '/dev/null', length=1024, chars=["ascii_letters", "digits", ".,:_"]) }}"
+                PASSPHRASE="{{ lookup('password', '/dev/null', length=1024, chars=['ascii_letters', 'digits', '.,:_<>|/']) }}"
 
                 RESULT=$(
                   {{ keystore_generator.stdout }} generate \
@@ -644,3 +645,4 @@
           Artifacts:   {{ 'built' if build_artifacts | default(false) else 'skipped' }}
           Templates:   {{ 'built' if build_templates | default(false) else 'skipped' }}
           Timestamp:   {{ now(utc=true, fmt='%a %Y-%m-%d %H:%M:%S UTC') }}
+          Hostname:    {{ ansible_hostname }}

--- a/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
@@ -35,7 +35,7 @@ job "{{ job.name }}" {
       {% endfor %}
 
       artifact {
-        source = "https://nodejs.org/dist/v18.16.1/node-v18.16.1-linux-x64.tar.xz"
+        source = "https://nodejs.org/dist/v18.16.1/node-v18.16.1-linux-{{ 'x64' if target_system_architecture == 'x86_64' else 'arm64' }}.tar.xz"
         options {
           archive = false
         }
@@ -101,7 +101,7 @@ job "{{ job.name }}" {
 
           tar \
             --extract \
-            --file local/node-v18.16.1-linux-x64.tar.xz \
+            --file local/node-v18.16.1-linux-{{ 'x64' if target_system_architecture == 'x86_64' else 'arm64' }}.tar.xz \
             --directory /usr/local \
             --strip-components=1
 

--- a/infrastructure/nomad/playbooks/templates/jobs/datadog-agent.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/datadog-agent.nomad.j2
@@ -50,6 +50,7 @@ job "{{ job.name }}" {
 
       template {
         data = <<-EOH
+          hostname: {{ ansible_hostname }}
           site: datadoghq.com
           logs_enabled: true
           api_key: {{ datadog_key }}


### PR DESCRIPTION
fixes:
- explicitly set hostname
- contracts deployer nodeJS binary arch
- exclude problematic characters form generated passphrase