### PR TITLE
fix: remove special characters from passphrase generation

### DIFF
--- a/infrastructure/nomad/playbooks/deploy.yml
+++ b/infrastructure/nomad/playbooks/deploy.yml
@@ -237,7 +237,7 @@
           {% if artifact.keystore is defined %}
             case "{{ environments[env].secrets }}" in
               "generate")
-                PASSPHRASE="{{ lookup('password', '/dev/null', length=1024, chars=['ascii_letters', 'digits', '+-_,.:@']) }}"
+                PASSPHRASE="{{ lookup('password', '/dev/null', length=1024, chars=['ascii_letters', 'digits']) }}"
 
                 RESULT=$(
                   {{ keystore_generator.stdout }} generate \


### PR DESCRIPTION
Removing special characters from the passphrase character set eliminates problems similar to the following:
```
TASK [Push Generated Secrets to Vault] *****************************************
Friday 05 July 2024  00:02:38 +0000 (0:00:13.870)       0:00:39.462 *********** 
fatal: [69.67.150.157 -> localhost]: FAILED! => 
  msg: |-
    the field 'args' has an invalid value ({'url': '{{ vault_address }}/v1/{{ vault_kv_engine_path }}/data/{{ vault_secret_path }}', 'method': 'POST', 'body_format': 'json', 'headers': {'X-Vault-Token': '{{ vault_init.json.root_token }}', 'Content-Type': 'application/json'}, 'body': "{{ {'data': (lookup('file', dist_dir + '/secrets.json') | from_json)} | to_json }}", 'status_code': [200, 204], 'validate_certs': False}), and could not be converted to dict. The error was: Expecting value: line 1 column 1 (char 0)
  
    The error appears to be in '/home/runner/work/mev-commit/mev-commit/infrastructure/nomad/playbooks/deploy.yml': line 520, column 7, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
```    
