### PR TITLE
fix: real-bidder panic

### DIFF
--- a/p2p/integrationtest/real-bidder/main.go
+++ b/p2p/integrationtest/real-bidder/main.go
@@ -225,7 +225,7 @@ func main() {
 				}
 
 				bundleLen := rand.Intn(10)
-				bundleStart := rand.Intn(len(currentBlock.txns) - 1)
+				bundleStart := rand.Intn(len(currentBlock.txns))
 				bundleEnd := bundleStart + bundleLen
 				if bundleEnd > len(currentBlock.txns) {
 					bundleEnd = len(currentBlock.txns) - 1


### PR DESCRIPTION
Fixes the following panic:
```
panic: invalid argument to Intn

goroutine 34 [running]:
math/rand.(*Rand).Intn(0x120ed60?, 0xc000b88520?)
	/opt/hostedtoolcache/go/1.22.5/x64/src/math/rand/rand.go:180 +0x4c
math/rand.Intn(0x0)
	/opt/hostedtoolcache/go/1.22.5/x64/src/math/rand/rand.go:453 +0x25
main.main.func4(0xc000044ac0, 0xc0000db7a0)
	/home/runner/work/mev-commit/mev-commit/p2p/integrationtest/real-bidder/main.go:233 +0x1e9
created by main.main in goroutine 1
	/home/runner/work/mev-commit/mev-commit/p2p/integrationtest/real-bidder/main.go:217 +0xb08
panic: invalid argument to Intn

goroutine 33 [running]:
math/rand.(*Rand).Intn(0x120ed60?, 0xc0003228e0?)
	/opt/hostedtoolcache/go/1.22.5/x64/src/math/rand/rand.go:180 +0x4c
math/rand.Intn(0x0)
	/opt/hostedtoolcache/go/1.22.5/x64/src/math/rand/rand.go:453 +0x25
main.main.func4(0xc000044ac0, 0xc0000db740)
	/home/runner/work/mev-commit/mev-commit/p2p/integrationtest/real-bidder/main.go:233 +0x1e9
created by main.main in goroutine 1
	/home/runner/work/mev-commit/mev-commit/p2p/integrationtest/real-bidder/main.go:217 +0xb08
```