### PR TITLE
chore: standardize solidity version to 0.8.20 across repo

### DIFF
--- a/bridge/standard/bridge-v1/deploy_contracts.sh
+++ b/bridge/standard/bridge-v1/deploy_contracts.sh
@@ -119,7 +119,7 @@ RELAYER_ADDR="$RELAYER_ADDR" $FORGE_BIN_PATH script \
     --broadcast \
     --chain-id "$SETTLEMENT_CHAIN_ID" \
     -vvvv \
-    --use 0.8.23 | tee deploy_sg_output.txt
+    --use 0.8.20 | tee deploy_sg_output.txt
 
 awk -F"JSON_DEPLOY_ARTIFACT: " '/JSON_DEPLOY_ARTIFACT:/ {print $2}' deploy_sg_output.txt | sed '/^$/d' > SettlementGatewayArtifact.json
 mv SettlementGatewayArtifact.json "$ARTIFACT_OUT_PATH"
@@ -131,7 +131,7 @@ RELAYER_ADDR="$RELAYER_ADDR" $FORGE_BIN_PATH script \
     --broadcast \
     --chain-id "$L1_CHAIN_ID" \
     -vvvv \
-    --use 0.8.23 | tee deploy_l1g_output.txt
+    --use 0.8.20 | tee deploy_l1g_output.txt
 
 awk -F"JSON_DEPLOY_ARTIFACT: " '/JSON_DEPLOY_ARTIFACT:/ {print $2}' deploy_l1g_output.txt | sed '/^$/d' > L1GatewayArtifact.json
 mv L1GatewayArtifact.json "$ARTIFACT_OUT_PATH"

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 # Copy our source code into the container
 COPY . .
 
-# Compile contracts using solidity compiler version 0.8.23
-RUN forge build --use 0.8.23 --via-ir
+# Compile contracts using solidity compiler version 0.8.20
+RUN forge build --use 0.8.20 --via-ir
 
 # Set environment variables for RPC URL and private key
 # These should be passed during the Docker build process

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -6,7 +6,7 @@ deploy-val-reg:
 		--broadcast \
 		--chain-id 31337 \
 		-vvvv \
-		--use 0.8.23 \
+		--use 0.8.20 \
 		--via-ir \
 
 deploy-core:

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -163,26 +163,26 @@ export CHAIN_ID=17864
 - Run the deploy script for core contracts
 
 ```
-forge script scripts/DeployScripts.s.sol:DeployScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast --chain-id $CHAIN_ID -vvvv --use 0.8.23
+forge script scripts/DeployScripts.s.sol:DeployScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast --chain-id $CHAIN_ID -vvvv --use 0.8.20
 ```
 
 - Run deploy script for whitelist contract, HYP_ERC20_ADDR denotes the HypERC20.sol contract address to give native mint/burn privileges.
 
 ```
-HYP_ERC20_ADDR=0xBe3dEF3973584FdcC1326634aF188f0d9772D57D forge script scripts/DeployScripts.s.sol:DeployWhitelist --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast --chain-id $CHAIN_ID -vvvv --use 0.8.23
+HYP_ERC20_ADDR=0xBe3dEF3973584FdcC1326634aF188f0d9772D57D forge script scripts/DeployScripts.s.sol:DeployWhitelist --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast --chain-id $CHAIN_ID -vvvv --use 0.8.20
 ```
 
 #### Note on CREATE2
 
 Foundry scripts in this repo use the CREATE2 opcode to deploy for every contract. Meaning deployment on any chain will yield the same contract addresses, given a constant deployer account, contract bytecode, and salt.
 
-This means the solidity version used for contract compilation affects the addresses those contracts will be deployed to. Solidity 0.8.23 is the canonical version to use.
+This means the solidity version used for contract compilation affects the addresses those contracts will be deployed to. Solidity 0.8.20 is the canonical version to use.
 
 It's recommended to use `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` as the deployer account so that contract addresses will match external facing documentation. In production this address will have proper key management, for now here's the private key: `ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`.
 
 The CREATE2 proxy needs to be deployed prior to these contracts. See [this repo](https://github.com/primev/deterministic-deployment-proxy), or this [make command](https://github.com/primev/mev-commit-geth/blob/d29cfe94205e852cc57a8184585ccc895d32a517/geth-poa/Makefile#L48) to deploy. Anvil automatically deploys this proxy to the expected address.
 
-Using the above private key and compiling with solidity 0.8.23, expected contract addresses are:
+Using the above private key and compiling with solidity 0.8.20, expected contract addresses are:
 
 ```bash
 UserRegistry deployed to: 0xe38B5a8C41f307646F395030992Aa008978E2699

--- a/contracts/contracts/BidderRegistry.sol
+++ b/contracts/contracts/BidderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/BlockTracker.sol
+++ b/contracts/contracts/BlockTracker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/Oracle.sol
+++ b/contracts/contracts/Oracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/PreConfCommitmentStore.sol
+++ b/contracts/contracts/PreConfCommitmentStore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {ECDSA} from "@openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/contracts/contracts/ProviderRegistry.sol
+++ b/contracts/contracts/ProviderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/Whitelist.sol
+++ b/contracts/contracts/Whitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/interfaces/IBidderRegistry.sol
+++ b/contracts/contracts/interfaces/IBidderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 interface IBidderRegistry {
     struct PreConfCommitment {

--- a/contracts/contracts/interfaces/IBlockTracker.sol
+++ b/contracts/contracts/interfaces/IBlockTracker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 /// @title IBlockTracker interface for BlockTracker contract
 interface IBlockTracker {

--- a/contracts/contracts/interfaces/IMevCommitAVS.sol
+++ b/contracts/contracts/interfaces/IMevCommitAVS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {EventHeightLib} from "../utils/EventHeight.sol";

--- a/contracts/contracts/interfaces/IPreConfCommitmentStore.sol
+++ b/contracts/contracts/interfaces/IPreConfCommitmentStore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 /**
  * @title IPreConfCommitmentStore

--- a/contracts/contracts/interfaces/IProviderRegistry.sol
+++ b/contracts/contracts/interfaces/IProviderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 interface IProviderRegistry {
     function registerAndStake(bytes calldata blsPublicKey) external payable;

--- a/contracts/contracts/interfaces/IValidatorOptInRouter.sol
+++ b/contracts/contracts/interfaces/IValidatorOptInRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 interface IValidatorOptInRouter {
     /// @notice Initializes the contract with the validator registry and mev-commit AVS contracts.

--- a/contracts/contracts/interfaces/IValidatorRegistryV1.sol
+++ b/contracts/contracts/interfaces/IValidatorRegistryV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import { EventHeightLib } from "../utils/EventHeight.sol";
 

--- a/contracts/contracts/interfaces/IWhitelist.sol
+++ b/contracts/contracts/interfaces/IWhitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 interface IWhitelist {
     function mint(address _mintTo, uint256 _amount) external;

--- a/contracts/contracts/standard-bridge/Gateway.sol
+++ b/contracts/contracts/standard-bridge/Gateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/standard-bridge/L1Gateway.sol
+++ b/contracts/contracts/standard-bridge/L1Gateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {Gateway} from "./Gateway.sol";
 

--- a/contracts/contracts/standard-bridge/SettlementGateway.sol
+++ b/contracts/contracts/standard-bridge/SettlementGateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {Gateway} from "./Gateway.sol";
 import {IWhitelist} from "../interfaces/IWhitelist.sol";

--- a/contracts/contracts/utils/EnumerableMap.sol
+++ b/contracts/contracts/utils/EnumerableMap.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {EnumerableSet} from "./EnumerableSet.sol";
 

--- a/contracts/contracts/utils/EnumerableSet.sol
+++ b/contracts/contracts/utils/EnumerableSet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 /// @title Implements an enumerable set of bytes arrays.
 /// @notice Adapted from OpenZeppelin's EnumerableSet.sol implementation. 

--- a/contracts/contracts/utils/EventHeight.sol
+++ b/contracts/contracts/utils/EventHeight.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 library EventHeightLib {
     /// @title EventHeight

--- a/contracts/contracts/utils/WindowFromBlockNumber.sol
+++ b/contracts/contracts/utils/WindowFromBlockNumber.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 /**
  * @title WindowFromBlockNumber

--- a/contracts/contracts/validator-registry/ValidatorOptInRouter.sol
+++ b/contracts/contracts/validator-registry/ValidatorOptInRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {ValidatorOptInRouterStorage} from "./ValidatorOptInRouterStorage.sol";
 import {IValidatorOptInRouter} from "../interfaces/IValidatorOptInRouter.sol";

--- a/contracts/contracts/validator-registry/ValidatorOptInRouterStorage.sol
+++ b/contracts/contracts/validator-registry/ValidatorOptInRouterStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {IValidatorRegistryV1} from "../interfaces/IValidatorRegistryV1.sol";
 import {IMevCommitAVS} from "../interfaces/IMevCommitAVS.sol";

--- a/contracts/contracts/validator-registry/ValidatorRegistryV1.sol
+++ b/contracts/contracts/validator-registry/ValidatorRegistryV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {IValidatorRegistryV1} from "../interfaces/IValidatorRegistryV1.sol";
 import {ValidatorRegistryV1Storage} from "./ValidatorRegistryV1Storage.sol";

--- a/contracts/contracts/validator-registry/ValidatorRegistryV1Storage.sol
+++ b/contracts/contracts/validator-registry/ValidatorRegistryV1Storage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {IValidatorRegistryV1} from "../interfaces/IValidatorRegistryV1.sol";
 

--- a/contracts/contracts/validator-registry/avs/MevCommitAVS.sol
+++ b/contracts/contracts/validator-registry/avs/MevCommitAVS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {IMevCommitAVS} from "../../interfaces/IMevCommitAVS.sol";
 import {MevCommitAVSStorage} from "./MevCommitAVSStorage.sol";

--- a/contracts/contracts/validator-registry/avs/MevCommitAVSStorage.sol
+++ b/contracts/contracts/validator-registry/avs/MevCommitAVSStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 
 import {IMevCommitAVS} from "../../interfaces/IMevCommitAVS.sol";

--- a/contracts/entrypoint.sh
+++ b/contracts/entrypoint.sh
@@ -27,7 +27,7 @@ if [ "${DEPLOY_TYPE}" = "core" ]; then
         --password "${KEYSTORE_PASSWORD}" \
         --sender "${SENDER}" \
         --skip-simulation \
-        --use 0.8.23 \
+        --use 0.8.20 \
         --broadcast \
         --force \
         --json \
@@ -61,7 +61,7 @@ elif [ "${DEPLOY_TYPE}" = "transfer-ownership" ]; then
         --password "${KEYSTORE_PASSWORD}" \
         --sender "${SENDER}" \
         --skip-simulation \
-        --use 0.8.23 \
+        --use 0.8.20 \
         --broadcast \
         --force \
         --json \
@@ -82,7 +82,7 @@ elif [ "${DEPLOY_TYPE}" = "whitelist" ]; then
         --broadcast \
         --chain-id "${CHAIN_ID}" \
         -vvvv \
-        --use 0.8.23 \
+        --use 0.8.20 \
         --root "${CONTRACT_REPO_ROOT_PATH}" \
         --via-ir
 
@@ -101,7 +101,7 @@ elif [ "${DEPLOY_TYPE}" = "settlement-gateway" ]; then
         --broadcast \
         --chain-id "${CHAIN_ID}" \
         -vvvv \
-        --use 0.8.23 \
+        --use 0.8.20 \
         --root "${CONTRACT_REPO_ROOT_PATH}" \
         --via-ir
 
@@ -120,7 +120,7 @@ elif [ "${DEPLOY_TYPE}" = "l1-gateway" ]; then
         --broadcast \
         --chain-id "${CHAIN_ID}" \
         -vvvv \
-        --use 0.8.23 \
+        --use 0.8.20 \
         --root "${CONTRACT_REPO_ROOT_PATH}" \
         --via-ir
 
@@ -135,7 +135,7 @@ elif [ "${DEPLOY_TYPE}" = "validator-registry" ]; then
         --broadcast \
         --chain-id "${CHAIN_ID}" \
         -vvvv \
-        --use 0.8.23 \
+        --use 0.8.20 \
         --root "${CONTRACT_REPO_ROOT_PATH}" \
         --via-ir \
         --skip-simulation \

--- a/contracts/scripts/DeployScripts.s.sol
+++ b/contracts/scripts/DeployScripts.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 import "forge-std/Script.sol";
 import "../contracts/BidderRegistry.sol";
 import "../contracts/ProviderRegistry.sol";

--- a/contracts/scripts/DeployStandardBridge.s.sol
+++ b/contracts/scripts/DeployStandardBridge.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 import "forge-std/Script.sol";
 import {SettlementGateway} from "../contracts/standard-bridge/SettlementGateway.sol";
 import {L1Gateway} from "../contracts/standard-bridge/L1Gateway.sol";

--- a/contracts/scripts/validator-registry/DeployValidatorRegistryV1.s.sol
+++ b/contracts/scripts/validator-registry/DeployValidatorRegistryV1.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Script.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";

--- a/contracts/test/BidderRegistryTest.sol
+++ b/contracts/test/BidderRegistryTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import {BidderRegistry} from "../contracts/BidderRegistry.sol";

--- a/contracts/test/OracleTest.sol
+++ b/contracts/test/OracleTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import "../contracts/Oracle.sol";

--- a/contracts/test/PreConfirmationConfTest.sol
+++ b/contracts/test/PreConfirmationConfTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 

--- a/contracts/test/ProviderRegistryTest.sol
+++ b/contracts/test/ProviderRegistryTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import {ProviderRegistry} from "../contracts/ProviderRegistry.sol";

--- a/contracts/test/WhitelistTest.sol
+++ b/contracts/test/WhitelistTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import "../contracts/Whitelist.sol";

--- a/contracts/test/standard-bridge/L1GatewayTest.sol
+++ b/contracts/test/standard-bridge/L1GatewayTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import "../../contracts/standard-bridge/L1Gateway.sol";

--- a/contracts/test/standard-bridge/SettlementGatewayTest.sol
+++ b/contracts/test/standard-bridge/SettlementGatewayTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import "../../contracts/standard-bridge/SettlementGateway.sol";

--- a/contracts/test/utils/EnumerableMapTest.sol
+++ b/contracts/test/utils/EnumerableMapTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import "../../contracts/utils/EnumerableMap.sol";

--- a/contracts/test/utils/EnumerableSetTest.sol
+++ b/contracts/test/utils/EnumerableSetTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import "../../contracts/utils/EnumerableSet.sol";

--- a/contracts/test/validator-registry/ValidatorRegistryV1Test.sol
+++ b/contracts/test/validator-registry/ValidatorRegistryV1Test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import "../../contracts/validator-registry/ValidatorRegistryV1.sol";

--- a/contracts/test/validator-registry/avs/AVSDirectoryMock.sol
+++ b/contracts/test/validator-registry/avs/AVSDirectoryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";

--- a/contracts/test/validator-registry/avs/EigenPodMock.sol
+++ b/contracts/test/validator-registry/avs/EigenPodMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import "eigenlayer-contracts/src/contracts/interfaces/IEigenPod.sol";

--- a/contracts/test/validator-registry/avs/MevCommitAVSTest.sol
+++ b/contracts/test/validator-registry/avs/MevCommitAVSTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import "../../../contracts/validator-registry/avs/MevCommitAVS.sol";


### PR DESCRIPTION
See https://swcregistry.io/docs/SWC-103/. This branch [looks good in devnet setup](https://github.com/primev/mev-commit/actions/runs/9900092362) and should effectively be a refactor. Ie. we've been using 0.8.20 already but this PR makes it explicit everywhere