### PR TITLE
docs: clarify MevCommitAVS behavior w/ associated tests

### DIFF
--- a/contracts/contracts/validator-registry/avs/MevCommitAVS.sol
+++ b/contracts/contracts/validator-registry/avs/MevCommitAVS.sol
@@ -360,6 +360,9 @@ contract MevCommitAVS is IMevCommitAVS, MevCommitAVSStorage,
 
     /// @dev Internal function to register validators by their pod owner.
     /// @notice Invalid pubkeys should not correspond to VALIDATOR_STATUS.ACTIVE due to validations in EigenPod.sol
+    /// @dev A successful call to this function gauruntees isValidatorOptedIn() returns true for each pubkey immediately after
+    /// this function returns. However, sucessive state-changes (ex: delegated operator deregisters) may result in changes
+    /// to validator opt-in state.
     function _registerValidatorsByPodOwner(
         bytes[] calldata valPubKeys,
         address podOwner

--- a/contracts/contracts/validator-registry/avs/README.md
+++ b/contracts/contracts/validator-registry/avs/README.md
@@ -16,25 +16,42 @@ Operators mainly serve the purpose of (optionally) being able to register valida
 
 ## Validator Opt-in
 
-Recall that a native-restaking enabled validator opting-in to mev-commit requires two steps:
+Recall that a native-restaking enabled validator opting-in to mev-commit requires two high level steps:
 
-1. The validator must delegate their native stake to an Operator who's registered with the mev-commit AVS.
-2. The validator must separately *register* with the mev-commit AVS, confirming their attestation to follow the rules of the protocol.
+1. The validator must delegate (via eigenlayer core) their native stake to an Operator who's registered with the mev-commit AVS.
+2. The validator must separately be *registered* with the mev-commit AVS, confirming their attestation to follow the rules of the protocol.
 
-Multiple validator public keys can be registered at once, alongside their associated eigenpod owner `podOwner` address. Note each eigenpod owner account can represent one or many restaked validators:
+Multiple validator public keys can be registered at once, alongside their associated eigenpod owner `podOwner` address. Note each eigenpod owner account may represent one or many restaked validators:
 
 ```solidity
 function registerValidatorsByPodOwner(bytes[] calldata valPubKeys, address podOwner);
 ```
 
-This function stores relevant state and ensures that the provided pubkeys are indeed actively restaked with `podOwner`'s eigenPod. Note two entities are able to register validator pub keys in this way:
+This function verifies and updates state such that directly after the call, `isValidatorOptedIn(valPubKey)` will return true for each `valPubKey`.
+
+Note two entities are able to register validator pub keys in this way:
 
 1. The eigenpod owner account itself.
-2. An Operator account, so long as the relevant eigenpod is delegated to that Operator.
+2. The (delegated and registered) Operator account.
 
-Note if an Operator is registering pubkeys on behalf of validators, it's expected that the Operator manages those validators itself, or represents the validators to an extent that the Operator can realistically attest to the validator following the rules of mev-commit (staking-as-a-service providers for example). This trustful relationship between validators and their delegated Operator piggybacks off already agreed upon trust assumptions with eigenlayer delegation.
+If an Operator is registering pubkeys on behalf of validators, it's expected that the Operator manages those validators itself, or represents the validators to an extent that the Operator can realistically attest to the validator following the rules of mev-commit (staking-as-a-service providers for example). This trustful relationship between validators and their delegated Operator piggybacks off already agreed upon trust assumptions with eigenlayer delegation.
 
-Deregistration requires calling `requestValidatorsDeregistration`, waiting a configurable amount of blocks, then calling `deregisterValidators`. These functions are similarly callable by the eigenpod owner OR delegated operator.
+Validator deregistration requires calling `requestValidatorsDeregistration`, waiting a configurable amount of blocks, then calling `deregisterValidators`. These functions are similarly callable by the eigenpod owner OR delegated operator.
+
+### What defines a validator staying "opted-in"
+
+A validator staying opted-in following registration is explicitly defined by the following criteria:
+
+1. The validator's registration entry must still exists with the MevCommitAVS (ie. validator has not been deregistered).
+2. The validator must not be frozen.
+3. The validator must not have requested deregistration with the MevCommitAVS.
+4. The validator must be `VALIDATOR_STATUS.ACTIVE` with respect to its eigenpod.
+5. The validator's delegated operator must be registered with the MevCommitAVS.
+6. The validator's delegated operator must not have requested deregistration with the MevCommitAVS.
+
+Directly following a successful call to `registerValidatorsByPodOwner`, all of these criteria will be true as enforced by the function. However, anyone of these criteria becoming false will result in the validator no longer being "opted-in" from the mev-commit protocol's perspective.
+
+For example if an opted-in validator's delegated operator requests deregistration with the MevCommitAVS, the eigenpod owner representing this validator needs to [redelegate to a new operator](https://docs.eigenlayer.xyz/eigenlayer/restaking-guides/restaking-user-guide/restaker-delegation/redelegation-process) who's registered with the MevCommitAVS, to reclaim opted-in status.
 
 ## LST Restaker Registration
 
@@ -51,26 +68,6 @@ function registerLSTRestaker(bytes[] calldata chosenValidators) external onlyNon
 LST restakers will receive points/rewards commensurate with their chosen validator(s) being opted-in over time. Nothing enforces that validators chosen by LST restakers must be "opted-in" as described above. That is, responsibility is left up to the LST restaker as to choosing validators that are, and will stay, opted-in. When an LST restaker chooses multiple validators, attribution is split evenly between the validators.
 
 Validator opt-in state can be queried with `isValidatorOptedIn()`. This query offers concrete criteria that must be true for an LST restaker to accrue points/rewards over time from a chosen validator. 
-
-```solidity
-function isValidatorOptedIn(bytes calldata valPubKey) returns (bool) {
-    IMevCommitAVS.ValidatorRegistrationInfo memory valRegistration = validatorRegistrations[valPubKey];
-    bool isValRegistered = valRegistration.exists;
-    bool isFrozen = valRegistration.freezeHeight.exists;
-    bool isValDeregRequested = valRegistration.deregRequestHeight.exists;
-
-    IEigenPod pod = _eigenPodManager.getPod(valRegistration.podOwner);
-    bool isValActive = pod.validatorPubkeyToInfo(valPubKey).status == IEigenPod.VALIDATOR_STATUS.ACTIVE;
-
-    address delegatedOperator = _delegationManager.delegatedTo(valRegistration.podOwner);
-    IMevCommitAVS.OperatorRegistrationInfo memory operatorRegistration = operatorRegistrations[delegatedOperator];
-    bool isOperatorRegistered = operatorRegistration.exists;
-    bool isOperatorDeregRequested = operatorRegistration.deregRequestHeight.exists;
-
-    return isValRegistered && !isFrozen && !isValDeregRequested && isValActive
-        && isOperatorRegistered && !isOperatorDeregRequested;
-}
-```
 
 Since validators are chosen in sets, an LST restaker can only choose a new set of validators by deregistering, and registering again with the new set. This simplifies contract implementation and enforces an LST restaker is responsible for the actions of its chosen validator(s).
 

--- a/contracts/contracts/validator-registry/avs/README.md
+++ b/contracts/contracts/validator-registry/avs/README.md
@@ -32,11 +32,11 @@ This function verifies and updates state such that directly after the call, `isV
 Note two entities are able to register validator pub keys in this way:
 
 1. The eigenpod owner account itself.
-2. The (delegated and registered) Operator account.
+2. The (delegated and fully registered) Operator account.
 
 If an Operator is registering pubkeys on behalf of validators, it's expected that the Operator manages those validators itself, or represents the validators to an extent that the Operator can realistically attest to the validator following the rules of mev-commit (staking-as-a-service providers for example). This trustful relationship between validators and their delegated Operator piggybacks off already agreed upon trust assumptions with eigenlayer delegation.
 
-Validator deregistration requires calling `requestValidatorsDeregistration`, waiting a configurable amount of blocks, then calling `deregisterValidators`. These functions are similarly callable by the eigenpod owner OR delegated operator.
+Validator deregistration requires calling `requestValidatorsDeregistration`, waiting a configurable amount of blocks, then calling `deregisterValidators`. These functions are similarly callable by the eigenpod owner OR delegated operator. A delegated operator calling either `requestValidatorsDeregistration` or `deregisterValidators` does not require that operator to be registered with the MevCommitAVS (this is allowed due to aforementioned trust assumptions between validators and their delegated Operator).
 
 ### What defines a validator staying "opted-in"
 


### PR DESCRIPTION
Adds docs and test to clarify to auditors the correct behavior of:
- `registerValidatorsByPodOwners` being used in conjunction with `isValidatorOptedIn`
- `requestValidatorsDeregistration` and `deregisterValidators` being called by a delegated operator

This PR does not modify contract behavior 