### PR TITLE
Fixes bug with treasury getter of slashed funds and sets fee to 5% for slashing

### DIFF
--- a/contracts/contracts/ProviderRegistry.sol
+++ b/contracts/contracts/ProviderRegistry.sol
@@ -205,9 +205,11 @@ contract ProviderRegistry is
      * @dev Reward funds to the fee receipt.
      */
     function withdrawFeeRecipientAmount() external nonReentrant {
+        uint256 amount = feeRecipientAmount;
         feeRecipientAmount = 0;
-        (bool successFee, ) = feeRecipient.call{value: feeRecipientAmount}("");
-        require(successFee, "fee recipient transfer failed");
+        require(amount != 0, "fee amount is zero");
+        (bool successFee, ) = feeRecipient.call{value: amount}("");
+        require(successFee, "fee transfer failed");
     }
 
     /// @dev Requests unstake of the staked amount.

--- a/contracts/scripts/DeployScripts.s.sol
+++ b/contracts/scripts/DeployScripts.s.sol
@@ -26,6 +26,7 @@ contract DeployScript is Script {
             0x68bC10674b265f266b4b1F079Fa06eF4045c3ab9
         );
         uint16 feePercent = 2;
+        uint16 slashPercent = 5;
         uint64 commitmentDispatchWindow = 2000;
         uint256 blocksPerWindow = 10;
         uint256 withdrawalDelay = 24 * 3600 * 1000; // 24 hours in milliseconds
@@ -48,7 +49,7 @@ contract DeployScript is Script {
 
         address providerRegistryProxy = Upgrades.deployUUPSProxy(
             "ProviderRegistry.sol",
-            abi.encodeCall(ProviderRegistry.initialize, (minStake, feeRecipient, feePercent, msg.sender, withdrawalDelay))
+            abi.encodeCall(ProviderRegistry.initialize, (minStake, feeRecipient, slashPercent, msg.sender, withdrawalDelay))
         );
         ProviderRegistry providerRegistry = ProviderRegistry(payable(providerRegistryProxy));
         console.log("ProviderRegistry:", address(providerRegistry));

--- a/contracts/test/ProviderRegistryTest.sol
+++ b/contracts/test/ProviderRegistryTest.sol
@@ -257,12 +257,14 @@ contract ProviderRegistryTest is Test {
             5e16 wei,
             "FeeRecipientAmount should match"
         );
+        assertEq(provider.balance, 3 ether, "Provider should not have received fee yet");
         providerRegistry.withdrawFeeRecipientAmount();
         assertEq(
             providerRegistry.feeRecipientAmount(),
             0,
             "FeeRecipientAmount should be zero after withdrawal"
         );
+        assertEq(provider.balance, 3 ether + 5e16 wei, "Provider should have received fee");
     }
 
     function test_WithdrawStakedAmountWithoutFeeRecipient() public {

--- a/contracts/test/ProviderRegistryTest.sol
+++ b/contracts/test/ProviderRegistryTest.sol
@@ -257,14 +257,13 @@ contract ProviderRegistryTest is Test {
             5e16 wei,
             "FeeRecipientAmount should match"
         );
-        assertEq(provider.balance, 3 ether, "Provider should not have received fee yet");
         providerRegistry.withdrawFeeRecipientAmount();
         assertEq(
             providerRegistry.feeRecipientAmount(),
             0,
             "FeeRecipientAmount should be zero after withdrawal"
         );
-        assertEq(provider.balance, 3 ether + 5e16 wei, "Provider should have received fee");
+        assertEq(vm.addr(6).balance, 5e16 wei, "Fee Reciepient should have received fee");
     }
 
     function test_WithdrawStakedAmountWithoutFeeRecipient() public {


### PR DESCRIPTION
## Describe your changes
- Previously, we were setting the Fee allocated to the treasury due to slashing events to zero, before pulling the funds. We update this to ensure we keep a temporary variable that stores the value meant for the treasury during retrieval. We also set the slashing percentage reward for the protocol to 5%.

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested this code by deploying the infrastructure and ensuring that commitments are being settled
