### PR TITLE
Cleans up logs for non-verbose state

### DIFF
--- a/p2p/pkg/autodepositor/autodepositor.go
+++ b/p2p/pkg/autodepositor/autodepositor.go
@@ -172,7 +172,7 @@ func (adt *AutoDepositTracker) initSub(egCtx context.Context) (events.Subscripti
 	evt := events.NewEventHandler(
 		"NewWindow",
 		func(update *blocktracker.BlocktrackerNewWindow) {
-			adt.logger.Info(
+			adt.logger.Debug(
 				"new window event",
 				"window", update.Window,
 			)

--- a/p2p/pkg/preconfirmation/tracker/tracker.go
+++ b/p2p/pkg/preconfirmation/tracker/tracker.go
@@ -331,7 +331,7 @@ func (t *Tracker) handleNewL1Block(
 	ctx context.Context,
 	newL1Block *blocktracker.BlocktrackerNewL1Block,
 ) error {
-	t.logger.Info(
+	t.logger.Debug(
 		"new L1 Block event received",
 		"blockNumber", newL1Block.BlockNumber,
 		"winner", newL1Block.Winner,

--- a/p2p/pkg/preconfirmation/tracker/tracker.go
+++ b/p2p/pkg/preconfirmation/tracker/tracker.go
@@ -232,10 +232,10 @@ func (t *Tracker) Start(ctx context.Context) <-chan struct{} {
 				continue
 			}
 			if len(winners) == 0 {
-				t.logger.Info("no winners to open commitments")
+				t.logger.Debug("no winners to open commitments")
 				continue
 			}
-			t.logger.Info("stored block winners", "count", len(winners))
+			t.logger.Debug("stored block winners", "count", len(winners))
 			oldBlockNos := make([]int64, 0)
 			winners = slices.DeleteFunc(winners, func(item *store.BlockWinner) bool {
 				// the last block is the latest, so if any of the previous blocks are
@@ -260,14 +260,14 @@ func (t *Tracker) Start(ctx context.Context) <-chan struct{} {
 					// for bidder to open is only in cases of slashes as he will get refund. Only one
 					// of bidder or provider should open the commitment as 1 of the txns would
 					// fail. This delay is to ensure this.
-					t.logger.Info("bidder detected, processing 2 blocks behind the current one")
+					t.logger.Debug("bidder detected, processing 2 blocks behind the current one")
 					winners = winners[:len(winners)-2]
 				} else {
-					t.logger.Info("no winners to open commitments")
+					t.logger.Debug("no winners to open commitments")
 					continue
 				}
 			}
-			t.logger.Info("opening commitments", "count", len(winners))
+			t.logger.Debug("opening commitments", "winners", len(winners))
 			for _, winner := range winners {
 				if err := t.openCommitments(egCtx, winner); err != nil {
 					t.logger.Error("failed to open commitments", "error", err)

--- a/x/contracts/txmonitor/eth_helper.go
+++ b/x/contracts/txmonitor/eth_helper.go
@@ -103,7 +103,7 @@ func (e *evmHelper) TraceTransaction(ctx context.Context, txHash common.Hash) (*
 
 // BatchReceipts retrieves multiple receipts for a list of transaction hashes.
 func (e *evmHelper) BatchReceipts(ctx context.Context, txHashes []common.Hash) ([]Result, error) {
-	e.logger.Info("Starting BatchReceipts", "txHashes", txHashes)
+	e.logger.Debug("Starting BatchReceipts", "txHashes", txHashes)
 	batch := make([]rpc.BatchElem, len(txHashes))
 
 	for i, hash := range txHashes {
@@ -118,14 +118,14 @@ func (e *evmHelper) BatchReceipts(ctx context.Context, txHashes []common.Hash) (
 	var receipts []Result
 	var err error
 	for attempts := 0; attempts < 50; attempts++ {
-		e.logger.Info("Attempting batch call", "attempt", attempts+1)
+		e.logger.Debug("Attempting batch call", "attempt", attempts+1)
 		// Execute the batch request
 		err = e.client.BatchCallContext(context.Background(), batch)
 		if err != nil {
 			e.logger.Error("Batch call attempt failed", "attempt", attempts+1, "error", err)
 			time.Sleep(1 * time.Second)
 		} else {
-			e.logger.Info("Batch call attempt succeeded", "attempt", attempts+1)
+			e.logger.Debug("Batch call attempt succeeded", "attempt", attempts+1)
 			break
 		}
 	}
@@ -162,6 +162,6 @@ func (e *evmHelper) BatchReceipts(ctx context.Context, txHashes []common.Hash) (
 		}
 	}
 
-	e.logger.Info("BatchReceipts completed successfully", "receipts", receipts)
+	e.logger.Debug("BatchReceipts completed successfully", "receipts", receipts)
 	return receipts, nil
 }

--- a/x/contracts/txmonitor/txmonitor.go
+++ b/x/contracts/txmonitor/txmonitor.go
@@ -244,10 +244,9 @@ func (m *Monitor) Sent(ctx context.Context, tx *types.Transaction) {
 		if err := m.saver.Update(context.Background(), tx.Hash(), status); err != nil {
 			m.logger.Error("failed to update transaction", "err", err)
 		}
-		m.logger.Info("transaction status",
+		m.logger.Debug("transaction status",
 			"txHash", tx.Hash(),
 			"status", status,
-			"receipt", r.Receipt,
 		)
 	}()
 }


### PR DESCRIPTION
## Describe your changes

* Ensures we only log relevant details to bidders during normal operation of the node. (e.g INFO)
