### PR TITLE
fix: remove unnecessary # suffix check form PR title regex

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Lint PR Title
         run: |
-          REGEX="^(fix|feat|refactor|revert|test|perf|style|chore|docs): [a-z][^.]{0,60}( \\(\\#\\d+\\))?$"
+          REGEX="^(fix|feat|refactor|revert|test|perf|style|chore|docs): [a-z][^.]{0,60}$"
           if echo "${PR_TITLE}" | grep -Eq "${REGEX}"; then
             echo -e "PR title is valid: ${PR_TITLE}"
           else


### PR DESCRIPTION
## Describe your changes

Removes unnecessary `(#d+)` suffix check from PR title regex.