### PR TITLE
fix: check "hasPod" in _isValidatorOptedIn

### DIFF
--- a/contracts/test/validator-registry/avs/EigenPodManagerMock.sol
+++ b/contracts/test/validator-registry/avs/EigenPodManagerMock.sol
@@ -60,8 +60,8 @@ contract EigenPodManagerMock is IEigenPodManager, Test {
         return IStrategyManager(address(0));
     }
     
-    function hasPod(address /*podOwner*/) external pure returns (bool) {
-        return false;
+    function hasPod(address podOwner) external view returns (bool) {
+        return pods[podOwner] != EigenPodMock(address(0));
     }
 
     function pause(uint256 /*newPausedStatus*/) external{}

--- a/contracts/test/validator-registry/avs/MevCommitAVSTest.sol
+++ b/contracts/test/validator-registry/avs/MevCommitAVSTest.sol
@@ -1084,4 +1084,10 @@ contract MevCommitAVSTest is Test {
         vm.prank(operator);
         mevCommitAVS.deregisterValidators(valPubkeys);
     }
+
+    function testIsValidatorOptedInWithNoPod() public {
+        bytes[] memory valPubkeys = new bytes[](2);
+        valPubkeys[0] = bytes("valPubkey1"); // Intentially no setup 
+        assertFalse(mevCommitAVS.isValidatorOptedIn(valPubkeys[0]));
+    }
 }


### PR DESCRIPTION
## Describe your changes

`ValidatorOptInRouter.sol` runs the following logic to determine if a validator is opted in: 

```solidity
    function _isValidatorOptedIn(bytes calldata valBLSPubKey) internal view returns (bool) {
        if (validatorRegistryV1.isValidatorOptedIn(valBLSPubKey)) {
            return true;
        }
        return mevCommitAVS.isValidatorOptedIn(valBLSPubKey);
    }
```

This function should return true or false without revert. 

Before this PR, `mevCommitAVS.isValidatorOptedIn` would revert if the function was called with a public key for which `_eigenPodManager.getPod` returned an address that did not correspond to a deployed eigenpod. Ie. reverts would occur when `validatorPubkeyToInfo` was called on an undeployed contract. To fix this issue, we first check `_eigenPodManager.hasPod`, and only continue the function if an eigen pod is deployed. Further, we improve function performance by returning early if any condition deems the validator "not opted in". 

Note `testIsValidatorOptedInWithNoPod` fails (revert) without this fix

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested this code by deploying the infrastructure and ensuring that commitments are being settled
