### PR TITLE
feat: correlate logs with traces

### DIFF
--- a/p2p/go.mod
+++ b/p2p/go.mod
@@ -142,6 +142,7 @@ require (
 	github.com/quic-go/quic-go v0.44.0 // indirect
 	github.com/quic-go/webtransport-go v0.8.0 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
+	github.com/remychantenay/slog-otel v1.3.2 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect

--- a/p2p/go.sum
+++ b/p2p/go.sum
@@ -410,6 +410,8 @@ github.com/quic-go/webtransport-go v0.8.0 h1:HxSrwun11U+LlmwpgM1kEqIqH90IT4N8auv
 github.com/quic-go/webtransport-go v0.8.0/go.mod h1:N99tjprW432Ut5ONql/aUhSLT0YVSlwHohQsuac9WaM=
 github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
+github.com/remychantenay/slog-otel v1.3.2 h1:ZBx8qnwfLJ6e18Vba4e9Xp9B7khTmpIwFsU1sAmActw=
+github.com/remychantenay/slog-otel v1.3.2/go.mod h1:gKW4tQ8cGOKoA+bi7wtYba/tcJ6Tc9XyQ/EW8gHA/2E=
 github.com/rivo/uniseg v0.4.2 h1:YwD0ulJSJytLpiaWua0sBDusfsCZohxjxzVTYjwxfV8=
 github.com/rivo/uniseg v0.4.2/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/p2p/integrationtest/real-bidder/main.go
+++ b/p2p/integrationtest/real-bidder/main.go
@@ -353,6 +353,8 @@ func sendBid(
 
 	sentBids.Inc()
 
+	ctx, span := otel.Tracer("").Start(rcv.Context(), "receive")
+	logger.InfoContext(ctx, "receiving preconfs")
 	preConfCount := 0
 	for {
 		_, err := rcv.Recv()
@@ -370,6 +372,8 @@ func sendBid(
 		receivedPreconfs.Inc()
 		preConfCount++
 	}
+	logger.InfoContext(ctx, "received preconfs")
+	span.End()
 
 	sendBidDuration.WithLabelValues(
 		"success",

--- a/x/util/util.go
+++ b/x/util/util.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	slogotel "github.com/remychantenay/slog-otel"
 )
 
 func PadKeyTo32Bytes(key *big.Int) []byte {
@@ -55,7 +57,11 @@ func NewLogger(lvl, logFmt, tags string, sink io.Writer) (*slog.Logger, error) {
 		return nil, fmt.Errorf("invalid log format: %s", logFmt)
 	}
 
-	logger := slog.New(handler)
+	logger := slog.New(slogotel.OtelHandler{
+		Next:          handler,
+		NoBaggage:     true,
+		NoTraceEvents: true,
+	})
 
 	if tags == "" {
 		return logger, nil


### PR DESCRIPTION
## Describe your changes

Inserts `trace_id` and `span_id` into the logs to correlate them with the traces.

TODO: the `trace_id` and `span_id` needs to be converted to DataDog format, see: https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/opentelemetry/?tab=go

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
