### PR TITLE
refactor: force stop and purge jobs as default on destroy

### DIFF
--- a/infrastructure/nomad/playbooks/destroy.yml
+++ b/infrastructure/nomad/playbooks/destroy.yml
@@ -45,6 +45,7 @@
         fi
       args:
         executable: bash
+      when: backup is defined and backup
 
     - name: Purge Stopped Jobs
       ansible.builtin.shell: |
@@ -66,3 +67,17 @@
         nomad system gc
       args:
         executable: bash
+      when: backup is defined and backup
+
+    - name: Force Stop and Purge Jobs
+      ansible.builtin.shell: |
+        for job in $(nomad job status -json | jq -r '.[].Summary.JobID'); do
+          if [ "${job}" != "null" ]; then
+            nomad stop -purge "${job}"
+          fi
+        done
+        nomad var purge "nomad/jobs"
+        nomad system gc
+      args:
+        executable: bash
+      when: backup is not defined or not backup


### PR DESCRIPTION
## Describe your changes

Sets stop and purge jobs as the default on destroy unless the `---backup` flag is specified.

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
