### PR TITLE
refactor: run all services inside nomad task as pid 1

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
@@ -171,7 +171,7 @@ job "{{ job.name }}" {
           | jq -c 'with_entries(select(.key | startswith("_") | not))' \
           > local/www/contracts.json
 
-          python3 -m http.server {{ job.ports[0]['http']['static'] }} --directory /local/www
+          exec python3 -m http.server {{ job.ports[0]['http']['static'] }} --directory /local/www
           # endtodo
         EOH
         destination = "local/run.sh"
@@ -180,7 +180,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
   }

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-bridge.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-bridge.nomad.j2
@@ -149,7 +149,7 @@ job "{{ job.name }}" {
           echo "Settlement Contract Address: $STANDARD_BRIDGE_RELAYER_SETTLEMENT_CONTRACT_ADDR"
 
           chmod +x local/relayer-linux-amd64
-          ./local/relayer-linux-amd64 start
+          exec ./local/relayer-linux-amd64 start
         EOH
         destination = "local/run.sh"
         perms = "0755"
@@ -157,7 +157,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
   }

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-emulator.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-emulator.nomad.j2
@@ -111,7 +111,7 @@ job "{{ job.name }}" {
           {% endif %}
 
           chmod +x ${EMULATOR_BINARY}
-          ${EMULATOR_BINARY} \
+          exec ${EMULATOR_BINARY} \
             -server-addr "${EMULATOR_IP_RPC_PORT}" \
             {% if job.target_type == 'bidder' %}
             -rpc-addr "${EMULATOR_L1_RPC_URL}" \
@@ -126,7 +126,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
   }

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-faucet.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-faucet.nomad.j2
@@ -96,7 +96,7 @@ job "{{ job.name }}" {
             {{ end }}
 
           chmod +x local/eth-faucet
-          ./local/eth-faucet \
+          exec ./local/eth-faucet \
             --httpport "${HTTP_PORT}" \
             --faucet.amount 10 \
             --faucet.minutes 1 \
@@ -112,7 +112,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
   }

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-funder.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-funder.nomad.j2
@@ -101,7 +101,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
   }

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-geth.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-geth.nomad.j2
@@ -160,7 +160,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
 
@@ -392,7 +392,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
   }

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-oracle.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-oracle.nomad.j2
@@ -134,7 +134,7 @@ job "{{ job.name }}" {
             exit 1
           fi
 
-          postgres -D "${POSTGRES_DATA}"
+          exec postgres -D "${POSTGRES_DATA}"
           {% endraw %}
         EOH
         destination = "local/run.sh"
@@ -143,7 +143,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
 
@@ -320,7 +320,7 @@ job "{{ job.name }}" {
           fi
 
           chmod +x local/mev-commit-oracle
-          local/mev-commit-oracle start
+          exec local/mev-commit-oracle start
           {% endraw %}
         EOH
         destination = "local/run.sh"
@@ -329,7 +329,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
   }

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit.nomad.j2
@@ -175,7 +175,7 @@ job "{{ job.name }}" {
           {% endraw %}
 
           chmod +x local/mev-commit
-          local/mev-commit
+          exec local/mev-commit
         EOH
         destination = "local/run.sh"
         perms = "0755"
@@ -183,7 +183,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
   }

--- a/infrastructure/nomad/playbooks/templates/jobs/otel-collector.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/otel-collector.nomad.j2
@@ -128,7 +128,7 @@ job "{{ job.name }}" {
 
           mv local/otelcol-contrib local/otel-collector
           chmod +x local/otel-collector
-          local/otel-collector --config local/collector.yaml
+          exec local/otel-collector --config local/collector.yaml
         EOH
         destination = "local/run.sh"
         perms = "0755"
@@ -136,7 +136,7 @@ job "{{ job.name }}" {
 
       config {
         command = "bash"
-        args = ["-c", "local/run.sh"]
+        args = ["-c", "exec local/run.sh"]
       }
     }
   }


### PR DESCRIPTION
## Describe your changes

Use `exec` to start all services inside the nomad task as pid 1. This will also fix the propagation of OS signals to these running services.

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
