### PR TITLE
chore: bump solidity across repo

### DIFF
--- a/bridge/standard/bridge-v1/deploy_contracts.sh
+++ b/bridge/standard/bridge-v1/deploy_contracts.sh
@@ -119,7 +119,7 @@ RELAYER_ADDR="$RELAYER_ADDR" $FORGE_BIN_PATH script \
     --broadcast \
     --chain-id "$SETTLEMENT_CHAIN_ID" \
     -vvvv \
-    --use 0.8.25 | tee deploy_sg_output.txt
+    --use 0.8.26 | tee deploy_sg_output.txt
 
 awk -F"JSON_DEPLOY_ARTIFACT: " '/JSON_DEPLOY_ARTIFACT:/ {print $2}' deploy_sg_output.txt | sed '/^$/d' > SettlementGatewayArtifact.json
 mv SettlementGatewayArtifact.json "$ARTIFACT_OUT_PATH"
@@ -131,7 +131,7 @@ RELAYER_ADDR="$RELAYER_ADDR" $FORGE_BIN_PATH script \
     --broadcast \
     --chain-id "$L1_CHAIN_ID" \
     -vvvv \
-    --use 0.8.25 | tee deploy_l1g_output.txt
+    --use 0.8.26 | tee deploy_l1g_output.txt
 
 awk -F"JSON_DEPLOY_ARTIFACT: " '/JSON_DEPLOY_ARTIFACT:/ {print $2}' deploy_l1g_output.txt | sed '/^$/d' > L1GatewayArtifact.json
 mv L1GatewayArtifact.json "$ARTIFACT_OUT_PATH"

--- a/bridge/standard/bridge-v1/deploy_contracts.sh
+++ b/bridge/standard/bridge-v1/deploy_contracts.sh
@@ -119,7 +119,7 @@ RELAYER_ADDR="$RELAYER_ADDR" $FORGE_BIN_PATH script \
     --broadcast \
     --chain-id "$SETTLEMENT_CHAIN_ID" \
     -vvvv \
-    --use 0.8.20 | tee deploy_sg_output.txt
+    --use 0.8.25 | tee deploy_sg_output.txt
 
 awk -F"JSON_DEPLOY_ARTIFACT: " '/JSON_DEPLOY_ARTIFACT:/ {print $2}' deploy_sg_output.txt | sed '/^$/d' > SettlementGatewayArtifact.json
 mv SettlementGatewayArtifact.json "$ARTIFACT_OUT_PATH"
@@ -131,7 +131,7 @@ RELAYER_ADDR="$RELAYER_ADDR" $FORGE_BIN_PATH script \
     --broadcast \
     --chain-id "$L1_CHAIN_ID" \
     -vvvv \
-    --use 0.8.20 | tee deploy_l1g_output.txt
+    --use 0.8.25 | tee deploy_l1g_output.txt
 
 awk -F"JSON_DEPLOY_ARTIFACT: " '/JSON_DEPLOY_ARTIFACT:/ {print $2}' deploy_l1g_output.txt | sed '/^$/d' > L1GatewayArtifact.json
 mv L1GatewayArtifact.json "$ARTIFACT_OUT_PATH"

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -13,7 +13,7 @@ deploy-val-reg:
 		--broadcast \
 		--chain-id 31337 \
 		-vvvv \
-		--use 0.8.25 \
+		--use 0.8.26 \
 		--via-ir \
 
 deploy-opt-in-router-holesky:
@@ -25,7 +25,7 @@ deploy-opt-in-router-holesky:
         --sender "${SENDER}" \
 		--via-ir \
 		--chain-id 17000 \
-		--use 0.8.25 \
+		--use 0.8.26 \
 		--broadcast
 
 deploy-core:

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -13,7 +13,7 @@ deploy-val-reg:
 		--broadcast \
 		--chain-id 31337 \
 		-vvvv \
-		--use 0.8.20 \
+		--use 0.8.25 \
 		--via-ir \
 
 deploy-opt-in-router-holesky:
@@ -25,7 +25,7 @@ deploy-opt-in-router-holesky:
         --sender "${SENDER}" \
 		--via-ir \
 		--chain-id 17000 \
-		--use 0.8.20 \
+		--use 0.8.25 \
 		--broadcast
 
 deploy-core:

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -39,7 +39,7 @@ Invoking the upgrade involves creating a script in which a new implementation co
 See example below
 
 ```solidity
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -39,7 +39,7 @@ Invoking the upgrade involves creating a script in which a new implementation co
 See example below
 
 ```solidity
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";

--- a/contracts/contracts/core/BidderRegistry.sol
+++ b/contracts/contracts/core/BidderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/core/BidderRegistry.sol
+++ b/contracts/contracts/core/BidderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/core/BidderRegistryStorage.sol
+++ b/contracts/contracts/core/BidderRegistryStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {FeePayout} from "../utils/FeePayout.sol";
 import {IBlockTracker} from "../interfaces/IBlockTracker.sol";

--- a/contracts/contracts/core/BidderRegistryStorage.sol
+++ b/contracts/contracts/core/BidderRegistryStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {FeePayout} from "../utils/FeePayout.sol";
 import {IBlockTracker} from "../interfaces/IBlockTracker.sol";

--- a/contracts/contracts/core/BlockTracker.sol
+++ b/contracts/contracts/core/BlockTracker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {IBlockTracker} from "../interfaces/IBlockTracker.sol";
 import {BlockTrackerStorage} from "./BlockTrackerStorage.sol";

--- a/contracts/contracts/core/BlockTracker.sol
+++ b/contracts/contracts/core/BlockTracker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {IBlockTracker} from "../interfaces/IBlockTracker.sol";
 import {BlockTrackerStorage} from "./BlockTrackerStorage.sol";

--- a/contracts/contracts/core/BlockTrackerStorage.sol
+++ b/contracts/contracts/core/BlockTrackerStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 abstract contract BlockTrackerStorage {
     /// @dev Permissioned address of the oracle account.

--- a/contracts/contracts/core/BlockTrackerStorage.sol
+++ b/contracts/contracts/core/BlockTrackerStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 abstract contract BlockTrackerStorage {
     /// @dev Permissioned address of the oracle account.

--- a/contracts/contracts/core/Oracle.sol
+++ b/contracts/contracts/core/Oracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/core/Oracle.sol
+++ b/contracts/contracts/core/Oracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/core/OracleStorage.sol
+++ b/contracts/contracts/core/OracleStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {IPreconfManager} from "../interfaces/IPreconfManager.sol";
 import {IBlockTracker} from "../interfaces/IBlockTracker.sol";

--- a/contracts/contracts/core/OracleStorage.sol
+++ b/contracts/contracts/core/OracleStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {IPreconfManager} from "../interfaces/IPreconfManager.sol";
 import {IBlockTracker} from "../interfaces/IBlockTracker.sol";

--- a/contracts/contracts/core/PreconfManager.sol
+++ b/contracts/contracts/core/PreconfManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {ECDSA} from "@openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";

--- a/contracts/contracts/core/PreconfManager.sol
+++ b/contracts/contracts/core/PreconfManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {ECDSA} from "@openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";

--- a/contracts/contracts/core/PreconfManagerStorage.sol
+++ b/contracts/contracts/core/PreconfManagerStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {IProviderRegistry} from "../interfaces/IProviderRegistry.sol";
 import {IBidderRegistry} from "../interfaces/IBidderRegistry.sol";

--- a/contracts/contracts/core/PreconfManagerStorage.sol
+++ b/contracts/contracts/core/PreconfManagerStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {IProviderRegistry} from "../interfaces/IProviderRegistry.sol";
 import {IBidderRegistry} from "../interfaces/IBidderRegistry.sol";

--- a/contracts/contracts/core/ProviderRegistry.sol
+++ b/contracts/contracts/core/ProviderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/core/ProviderRegistry.sol
+++ b/contracts/contracts/core/ProviderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/core/ProviderRegistryStorage.sol
+++ b/contracts/contracts/core/ProviderRegistryStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {FeePayout} from "../utils/FeePayout.sol";
 

--- a/contracts/contracts/core/ProviderRegistryStorage.sol
+++ b/contracts/contracts/core/ProviderRegistryStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {FeePayout} from "../utils/FeePayout.sol";
 

--- a/contracts/contracts/interfaces/IBidderRegistry.sol
+++ b/contracts/contracts/interfaces/IBidderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 interface IBidderRegistry {
     struct OpenedCommitment {

--- a/contracts/contracts/interfaces/IBidderRegistry.sol
+++ b/contracts/contracts/interfaces/IBidderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 interface IBidderRegistry {
     struct OpenedCommitment {

--- a/contracts/contracts/interfaces/IBlockTracker.sol
+++ b/contracts/contracts/interfaces/IBlockTracker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 /// @title IBlockTracker interface for BlockTracker contract
 interface IBlockTracker {    

--- a/contracts/contracts/interfaces/IBlockTracker.sol
+++ b/contracts/contracts/interfaces/IBlockTracker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 /// @title IBlockTracker interface for BlockTracker contract
 interface IBlockTracker {    

--- a/contracts/contracts/interfaces/IMevCommitAVS.sol
+++ b/contracts/contracts/interfaces/IMevCommitAVS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {EventHeightLib} from "../utils/EventHeight.sol";

--- a/contracts/contracts/interfaces/IMevCommitAVS.sol
+++ b/contracts/contracts/interfaces/IMevCommitAVS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {EventHeightLib} from "../utils/EventHeight.sol";

--- a/contracts/contracts/interfaces/IOracle.sol
+++ b/contracts/contracts/interfaces/IOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 interface IOracle {
 

--- a/contracts/contracts/interfaces/IOracle.sol
+++ b/contracts/contracts/interfaces/IOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 interface IOracle {
 

--- a/contracts/contracts/interfaces/IPreconfManager.sol
+++ b/contracts/contracts/interfaces/IPreconfManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 /**
  * @title IPreconfManager

--- a/contracts/contracts/interfaces/IPreconfManager.sol
+++ b/contracts/contracts/interfaces/IPreconfManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 /**
  * @title IPreconfManager

--- a/contracts/contracts/interfaces/IProviderRegistry.sol
+++ b/contracts/contracts/interfaces/IProviderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 interface IProviderRegistry {
 

--- a/contracts/contracts/interfaces/IProviderRegistry.sol
+++ b/contracts/contracts/interfaces/IProviderRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 interface IProviderRegistry {
 

--- a/contracts/contracts/interfaces/IValidatorOptInRouter.sol
+++ b/contracts/contracts/interfaces/IValidatorOptInRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {IVanillaRegistry} from "./IVanillaRegistry.sol";
 import {IMevCommitAVS} from "./IMevCommitAVS.sol";

--- a/contracts/contracts/interfaces/IValidatorOptInRouter.sol
+++ b/contracts/contracts/interfaces/IValidatorOptInRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {IVanillaRegistry} from "./IVanillaRegistry.sol";
 import {IMevCommitAVS} from "./IMevCommitAVS.sol";

--- a/contracts/contracts/interfaces/IVanillaRegistry.sol
+++ b/contracts/contracts/interfaces/IVanillaRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import { EventHeightLib } from "../utils/EventHeight.sol";
 

--- a/contracts/contracts/interfaces/IVanillaRegistry.sol
+++ b/contracts/contracts/interfaces/IVanillaRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import { EventHeightLib } from "../utils/EventHeight.sol";
 

--- a/contracts/contracts/interfaces/IWhitelist.sol
+++ b/contracts/contracts/interfaces/IWhitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 interface IWhitelist {
     function mint(address _mintTo, uint256 _amount) external;

--- a/contracts/contracts/interfaces/IWhitelist.sol
+++ b/contracts/contracts/interfaces/IWhitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 interface IWhitelist {
     function mint(address _mintTo, uint256 _amount) external;

--- a/contracts/contracts/standard-bridge/Gateway.sol
+++ b/contracts/contracts/standard-bridge/Gateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/standard-bridge/Gateway.sol
+++ b/contracts/contracts/standard-bridge/Gateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/standard-bridge/L1Gateway.sol
+++ b/contracts/contracts/standard-bridge/L1Gateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Gateway} from "./Gateway.sol";
 

--- a/contracts/contracts/standard-bridge/L1Gateway.sol
+++ b/contracts/contracts/standard-bridge/L1Gateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Gateway} from "./Gateway.sol";
 

--- a/contracts/contracts/standard-bridge/SettlementGateway.sol
+++ b/contracts/contracts/standard-bridge/SettlementGateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Gateway} from "./Gateway.sol";
 import {IWhitelist} from "../interfaces/IWhitelist.sol";

--- a/contracts/contracts/standard-bridge/SettlementGateway.sol
+++ b/contracts/contracts/standard-bridge/SettlementGateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Gateway} from "./Gateway.sol";
 import {IWhitelist} from "../interfaces/IWhitelist.sol";

--- a/contracts/contracts/standard-bridge/Whitelist.sol
+++ b/contracts/contracts/standard-bridge/Whitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/standard-bridge/Whitelist.sol
+++ b/contracts/contracts/standard-bridge/Whitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/contracts/utils/Errors.sol
+++ b/contracts/contracts/utils/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 library Errors {
     /// @dev Custom error for invalid fallback calls.

--- a/contracts/contracts/utils/Errors.sol
+++ b/contracts/contracts/utils/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 library Errors {
     /// @dev Custom error for invalid fallback calls.

--- a/contracts/contracts/utils/EventHeight.sol
+++ b/contracts/contracts/utils/EventHeight.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 library EventHeightLib {
     /// @title EventHeight

--- a/contracts/contracts/utils/EventHeight.sol
+++ b/contracts/contracts/utils/EventHeight.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 library EventHeightLib {
     /// @title EventHeight

--- a/contracts/contracts/utils/FeePayout.sol
+++ b/contracts/contracts/utils/FeePayout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 library FeePayout {
 

--- a/contracts/contracts/utils/FeePayout.sol
+++ b/contracts/contracts/utils/FeePayout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 library FeePayout {
 

--- a/contracts/contracts/utils/WindowFromBlockNumber.sol
+++ b/contracts/contracts/utils/WindowFromBlockNumber.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 /**
  * @title WindowFromBlockNumber

--- a/contracts/contracts/utils/WindowFromBlockNumber.sol
+++ b/contracts/contracts/utils/WindowFromBlockNumber.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 /**
  * @title WindowFromBlockNumber

--- a/contracts/contracts/validator-registry/ValidatorOptInRouter.sol
+++ b/contracts/contracts/validator-registry/ValidatorOptInRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {ValidatorOptInRouterStorage} from "./ValidatorOptInRouterStorage.sol";
 import {IValidatorOptInRouter} from "../interfaces/IValidatorOptInRouter.sol";

--- a/contracts/contracts/validator-registry/ValidatorOptInRouter.sol
+++ b/contracts/contracts/validator-registry/ValidatorOptInRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {ValidatorOptInRouterStorage} from "./ValidatorOptInRouterStorage.sol";
 import {IValidatorOptInRouter} from "../interfaces/IValidatorOptInRouter.sol";

--- a/contracts/contracts/validator-registry/ValidatorOptInRouterStorage.sol
+++ b/contracts/contracts/validator-registry/ValidatorOptInRouterStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {IVanillaRegistry} from "../interfaces/IVanillaRegistry.sol";
 import {IMevCommitAVS} from "../interfaces/IMevCommitAVS.sol";

--- a/contracts/contracts/validator-registry/ValidatorOptInRouterStorage.sol
+++ b/contracts/contracts/validator-registry/ValidatorOptInRouterStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {IVanillaRegistry} from "../interfaces/IVanillaRegistry.sol";
 import {IMevCommitAVS} from "../interfaces/IMevCommitAVS.sol";

--- a/contracts/contracts/validator-registry/VanillaRegistry.sol
+++ b/contracts/contracts/validator-registry/VanillaRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {IVanillaRegistry} from "../interfaces/IVanillaRegistry.sol";
 import {VanillaRegistryStorage} from "./VanillaRegistryStorage.sol";

--- a/contracts/contracts/validator-registry/VanillaRegistry.sol
+++ b/contracts/contracts/validator-registry/VanillaRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {IVanillaRegistry} from "../interfaces/IVanillaRegistry.sol";
 import {VanillaRegistryStorage} from "./VanillaRegistryStorage.sol";

--- a/contracts/contracts/validator-registry/VanillaRegistryStorage.sol
+++ b/contracts/contracts/validator-registry/VanillaRegistryStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {IVanillaRegistry} from "../interfaces/IVanillaRegistry.sol";
 

--- a/contracts/contracts/validator-registry/VanillaRegistryStorage.sol
+++ b/contracts/contracts/validator-registry/VanillaRegistryStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {IVanillaRegistry} from "../interfaces/IVanillaRegistry.sol";
 

--- a/contracts/contracts/validator-registry/avs/MevCommitAVS.sol
+++ b/contracts/contracts/validator-registry/avs/MevCommitAVS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {IMevCommitAVS} from "../../interfaces/IMevCommitAVS.sol";
 import {MevCommitAVSStorage} from "./MevCommitAVSStorage.sol";

--- a/contracts/contracts/validator-registry/avs/MevCommitAVS.sol
+++ b/contracts/contracts/validator-registry/avs/MevCommitAVS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {IMevCommitAVS} from "../../interfaces/IMevCommitAVS.sol";
 import {MevCommitAVSStorage} from "./MevCommitAVSStorage.sol";

--- a/contracts/contracts/validator-registry/avs/MevCommitAVSStorage.sol
+++ b/contracts/contracts/validator-registry/avs/MevCommitAVSStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 
 import {IMevCommitAVS} from "../../interfaces/IMevCommitAVS.sol";

--- a/contracts/contracts/validator-registry/avs/MevCommitAVSStorage.sol
+++ b/contracts/contracts/validator-registry/avs/MevCommitAVSStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 
 import {IMevCommitAVS} from "../../interfaces/IMevCommitAVS.sol";

--- a/contracts/entrypoint.sh
+++ b/contracts/entrypoint.sh
@@ -32,7 +32,7 @@ if [ "${DEPLOY_TYPE}" = "core" ]; then
         --password "${KEYSTORE_PASSWORD}" \
         --sender "${SENDER}" \
         --skip-simulation \
-        --use 0.8.20 \
+        --use 0.8.25 \
         --broadcast \
         --force \
         --json \
@@ -53,7 +53,7 @@ elif [ "${DEPLOY_TYPE}" = "settlement-gateway" ]; then
         --broadcast \
         --chain-id "${CHAIN_ID}" \
         -vvvv \
-        --use 0.8.20 \
+        --use 0.8.25 \
         --root "${CONTRACT_REPO_ROOT_PATH}" \
         --via-ir
 
@@ -72,7 +72,7 @@ elif [ "${DEPLOY_TYPE}" = "l1-gateway" ]; then
         --broadcast \
         --chain-id "${CHAIN_ID}" \
         -vvvv \
-        --use 0.8.20 \
+        --use 0.8.25 \
         --root "${CONTRACT_REPO_ROOT_PATH}" \
         --via-ir
 
@@ -87,7 +87,7 @@ elif [ "${DEPLOY_TYPE}" = "vanilla-registry" ]; then
         --broadcast \
         --chain-id "${CHAIN_ID}" \
         -vvvv \
-        --use 0.8.20 \
+        --use 0.8.25 \
         --root "${CONTRACT_REPO_ROOT_PATH}" \
         --via-ir \
         --skip-simulation \

--- a/contracts/entrypoint.sh
+++ b/contracts/entrypoint.sh
@@ -32,7 +32,7 @@ if [ "${DEPLOY_TYPE}" = "core" ]; then
         --password "${KEYSTORE_PASSWORD}" \
         --sender "${SENDER}" \
         --skip-simulation \
-        --use 0.8.25 \
+        --use 0.8.26 \
         --broadcast \
         --force \
         --json \
@@ -53,7 +53,7 @@ elif [ "${DEPLOY_TYPE}" = "settlement-gateway" ]; then
         --broadcast \
         --chain-id "${CHAIN_ID}" \
         -vvvv \
-        --use 0.8.25 \
+        --use 0.8.26 \
         --root "${CONTRACT_REPO_ROOT_PATH}" \
         --via-ir
 
@@ -72,7 +72,7 @@ elif [ "${DEPLOY_TYPE}" = "l1-gateway" ]; then
         --broadcast \
         --chain-id "${CHAIN_ID}" \
         -vvvv \
-        --use 0.8.25 \
+        --use 0.8.26 \
         --root "${CONTRACT_REPO_ROOT_PATH}" \
         --via-ir
 
@@ -87,7 +87,7 @@ elif [ "${DEPLOY_TYPE}" = "vanilla-registry" ]; then
         --broadcast \
         --chain-id "${CHAIN_ID}" \
         -vvvv \
-        --use 0.8.25 \
+        --use 0.8.26 \
         --root "${CONTRACT_REPO_ROOT_PATH}" \
         --via-ir \
         --skip-simulation \

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 src = 'contracts'
-solc-version = '0.8.25'
+solc-version = '0.8.26'
 script = 'scripts'
 out = 'out'
 libs = ['node_modules', 'lib']

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 src = 'contracts'
-solc-version = '0.8.20'
+solc-version = '0.8.25'
 script = 'scripts'
 out = 'out'
 libs = ['node_modules', 'lib']

--- a/contracts/scripts/core/DeployCore.s.sol
+++ b/contracts/scripts/core/DeployCore.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Script} from "forge-std/Script.sol";
 import {BidderRegistry} from "../../contracts/core/BidderRegistry.sol";

--- a/contracts/scripts/core/DeployCore.s.sol
+++ b/contracts/scripts/core/DeployCore.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Script} from "forge-std/Script.sol";
 import {BidderRegistry} from "../../contracts/core/BidderRegistry.sol";

--- a/contracts/scripts/standard-bridge/DeployStandardBridge.s.sol
+++ b/contracts/scripts/standard-bridge/DeployStandardBridge.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Script} from "forge-std/Script.sol";
 import {SettlementGateway} from "../../contracts/standard-bridge/SettlementGateway.sol";

--- a/contracts/scripts/standard-bridge/DeployStandardBridge.s.sol
+++ b/contracts/scripts/standard-bridge/DeployStandardBridge.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Script} from "forge-std/Script.sol";
 import {SettlementGateway} from "../../contracts/standard-bridge/SettlementGateway.sol";

--- a/contracts/scripts/validator-registry/DeployValidatorOptInRouter.s.sol
+++ b/contracts/scripts/validator-registry/DeployValidatorOptInRouter.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";

--- a/contracts/scripts/validator-registry/DeployValidatorOptInRouter.s.sol
+++ b/contracts/scripts/validator-registry/DeployValidatorOptInRouter.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";

--- a/contracts/scripts/validator-registry/DeployVanillaRegistry.s.sol
+++ b/contracts/scripts/validator-registry/DeployVanillaRegistry.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Script} from "forge-std/Script.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";

--- a/contracts/scripts/validator-registry/DeployVanillaRegistry.s.sol
+++ b/contracts/scripts/validator-registry/DeployVanillaRegistry.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Script} from "forge-std/Script.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";

--- a/contracts/scripts/validator-registry/ValidatorExampleScript.s.sol
+++ b/contracts/scripts/validator-registry/ValidatorExampleScript.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";

--- a/contracts/scripts/validator-registry/ValidatorExampleScript.s.sol
+++ b/contracts/scripts/validator-registry/ValidatorExampleScript.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";

--- a/contracts/scripts/validator-registry/avs/DeployAVS.s.sol
+++ b/contracts/scripts/validator-registry/avs/DeployAVS.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";

--- a/contracts/scripts/validator-registry/avs/DeployAVS.s.sol
+++ b/contracts/scripts/validator-registry/avs/DeployAVS.s.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";

--- a/contracts/scripts/validator-registry/avs/DeployAVSWithMockEigen.s.sol
+++ b/contracts/scripts/validator-registry/avs/DeployAVSWithMockEigen.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 // solhint-disable no-console
 // solhint-disable one-contract-per-file

--- a/contracts/scripts/validator-registry/avs/DeployAVSWithMockEigen.s.sol
+++ b/contracts/scripts/validator-registry/avs/DeployAVSWithMockEigen.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.25;
 
 // solhint-disable no-console
 // solhint-disable one-contract-per-file

--- a/contracts/scripts/validator-registry/avs/ReleaseAddrConsts.sol
+++ b/contracts/scripts/validator-registry/avs/ReleaseAddrConsts.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 /// @notice Constants from https://github.com/Layr-Labs/eigenlayer-contracts?tab=readme-ov-file#deployments,
 /// @notice Last updated 07-26-2024

--- a/contracts/scripts/validator-registry/avs/ReleaseAddrConsts.sol
+++ b/contracts/scripts/validator-registry/avs/ReleaseAddrConsts.sol
@@ -3,7 +3,7 @@
 // solhint-disable no-console
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 /// @notice Constants from https://github.com/Layr-Labs/eigenlayer-contracts?tab=readme-ov-file#deployments,
 /// @notice Last updated 07-26-2024

--- a/contracts/test/core/BidderRegistryTest.sol
+++ b/contracts/test/core/BidderRegistryTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {BidderRegistry} from "../../contracts/core/BidderRegistry.sol";

--- a/contracts/test/core/BidderRegistryTest.sol
+++ b/contracts/test/core/BidderRegistryTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {BidderRegistry} from "../../contracts/core/BidderRegistry.sol";

--- a/contracts/test/core/OracleTest.sol
+++ b/contracts/test/core/OracleTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {Oracle} from "../../contracts/core/Oracle.sol";

--- a/contracts/test/core/OracleTest.sol
+++ b/contracts/test/core/OracleTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {Oracle} from "../../contracts/core/Oracle.sol";

--- a/contracts/test/core/PreconfManagerTest.sol
+++ b/contracts/test/core/PreconfManagerTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {PreconfManager} from "../../contracts/core/PreconfManager.sol";

--- a/contracts/test/core/PreconfManagerTest.sol
+++ b/contracts/test/core/PreconfManagerTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {PreconfManager} from "../../contracts/core/PreconfManager.sol";

--- a/contracts/test/core/ProviderRegistryTest.sol
+++ b/contracts/test/core/ProviderRegistryTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {ProviderRegistry} from "../../contracts/core/ProviderRegistry.sol";

--- a/contracts/test/core/ProviderRegistryTest.sol
+++ b/contracts/test/core/ProviderRegistryTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {ProviderRegistry} from "../../contracts/core/ProviderRegistry.sol";

--- a/contracts/test/standard-bridge/L1GatewayTest.sol
+++ b/contracts/test/standard-bridge/L1GatewayTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {L1Gateway} from "../../contracts/standard-bridge/L1Gateway.sol";

--- a/contracts/test/standard-bridge/L1GatewayTest.sol
+++ b/contracts/test/standard-bridge/L1GatewayTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {L1Gateway} from "../../contracts/standard-bridge/L1Gateway.sol";

--- a/contracts/test/standard-bridge/SettlementGatewayTest.sol
+++ b/contracts/test/standard-bridge/SettlementGatewayTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {SettlementGateway} from "../../contracts/standard-bridge/SettlementGateway.sol";

--- a/contracts/test/standard-bridge/SettlementGatewayTest.sol
+++ b/contracts/test/standard-bridge/SettlementGatewayTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {SettlementGateway} from "../../contracts/standard-bridge/SettlementGateway.sol";

--- a/contracts/test/standard-bridge/WhitelistTest.sol
+++ b/contracts/test/standard-bridge/WhitelistTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {Whitelist} from "../../contracts/standard-bridge/Whitelist.sol";

--- a/contracts/test/standard-bridge/WhitelistTest.sol
+++ b/contracts/test/standard-bridge/WhitelistTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {Whitelist} from "../../contracts/standard-bridge/Whitelist.sol";

--- a/contracts/test/validator-registry/ValidatorOptInRouterTest.sol
+++ b/contracts/test/validator-registry/ValidatorOptInRouterTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {VanillaRegistry} from "../../contracts/validator-registry/VanillaRegistry.sol";

--- a/contracts/test/validator-registry/ValidatorOptInRouterTest.sol
+++ b/contracts/test/validator-registry/ValidatorOptInRouterTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {VanillaRegistry} from "../../contracts/validator-registry/VanillaRegistry.sol";

--- a/contracts/test/validator-registry/VanillaRegistryTest.sol
+++ b/contracts/test/validator-registry/VanillaRegistryTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import {Test} from"forge-std/Test.sol";
 import {VanillaRegistry} from"../../contracts/validator-registry/VanillaRegistry.sol";

--- a/contracts/test/validator-registry/VanillaRegistryTest.sol
+++ b/contracts/test/validator-registry/VanillaRegistryTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import {Test} from"forge-std/Test.sol";
 import {VanillaRegistry} from"../../contracts/validator-registry/VanillaRegistry.sol";

--- a/contracts/test/validator-registry/avs/AVSDirectoryMock.sol
+++ b/contracts/test/validator-registry/avs/AVSDirectoryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import "forge-std/Test.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";

--- a/contracts/test/validator-registry/avs/AVSDirectoryMock.sol
+++ b/contracts/test/validator-registry/avs/AVSDirectoryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import "forge-std/Test.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";

--- a/contracts/test/validator-registry/avs/EigenPodMock.sol
+++ b/contracts/test/validator-registry/avs/EigenPodMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import "forge-std/Test.sol";
 import "eigenlayer-contracts/src/contracts/interfaces/IEigenPod.sol";

--- a/contracts/test/validator-registry/avs/EigenPodMock.sol
+++ b/contracts/test/validator-registry/avs/EigenPodMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import "forge-std/Test.sol";
 import "eigenlayer-contracts/src/contracts/interfaces/IEigenPod.sol";

--- a/contracts/test/validator-registry/avs/MevCommitAVSTest.sol
+++ b/contracts/test/validator-registry/avs/MevCommitAVSTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.26;
 
 import "forge-std/Test.sol";
 import "../../../contracts/validator-registry/avs/MevCommitAVS.sol";

--- a/contracts/test/validator-registry/avs/MevCommitAVSTest.sol
+++ b/contracts/test/validator-registry/avs/MevCommitAVSTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.20;
+pragma solidity 0.8.25;
 
 import "forge-std/Test.sol";
 import "../../../contracts/validator-registry/avs/MevCommitAVS.sol";


### PR DESCRIPTION
## Describe your changes

Bumps solidity to `0.8.26` across repo. This is required to integrate with https://github.com/symbioticfi/core. D3ploy auditors suggest 0.8.25 but the more recent version has features that may be useful to us. 

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
