### PR TITLE
refactor: double nomad decompression file count limit again

### DIFF
--- a/infrastructure/nomad/playbooks/templates/services/nomad.hcl.j2
+++ b/infrastructure/nomad/playbooks/templates/services/nomad.hcl.j2
@@ -26,7 +26,7 @@ client {
     "/opt" = "/opt"
   }
   artifact {
-    decompression_file_count_limit = 8192
+    decompression_file_count_limit = 16384
   }
   host_volume "tmp-volume" {
     path = "/tmp/{{ env }}"


### PR DESCRIPTION
## Describe your changes

Doubles the limit from https://github.com/primev/mev-commit/pull/184 again, as I'm seeing the following error in #383 

```
"DownloadError": "failed to download artifact \"[http://10.1.0.13:1111/contracts_1bd12c5-1725606484.tar.gz\](http://10.1.0.13:1111/contracts_1bd12c5-1725606484.tar.gz/)": getter subprocess failed: exit status 1: failed to download artifact: tar archive contains too many files: 8193 > 8192",
```

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
