### PR TITLE
fix: provider-emulator-nodes for stressnet profile

### DIFF
--- a/infrastructure/nomad/playbooks/variables/profiles.yml
+++ b/infrastructure/nomad/playbooks/variables/profiles.yml
@@ -295,6 +295,8 @@ jobs:
     ports:
       - metrics:
           to: 8080
+    env:
+      otel_collector_endpoint_url: "{{ otel_collector_endpoint_url }}"
 
   mev_commit_bidder_node1: &mev_commit_bidder_node1_job
     name: mev-commit-bidder-node1


### PR DESCRIPTION
## Describe your changes

Fixes missing env for `mev-commit-provider-emulator-nodes` used in the stressnet profile.

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
