### PR TITLE
chore: remove forge coverage command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,9 +139,6 @@ jobs:
       - name: Run Snapshot
         run: forge clean && forge snapshot --via-ir
 
-      - name: Run Coverage
-        run: forge clean && forge coverage --ir-minimum
-
   contracts:
     name: Test and Build Contracts Scripts
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Describe your changes

The forge coverage command has been very flaky lately. Recent comments from [this issue](https://github.com/foundry-rs/foundry/issues/3357) confirm others are having trouble lately as well. The command itself suggests our use of `--ir-minimum` is a workaround. 

Example error from https://github.com/primev/mev-commit/actions/runs/10807042835/job/29977007439?pr=395
```
forge clean && forge coverage --ir-minimum
Warning! "--ir-minimum" flag enables viaIR with minimum optimization, which can result in inaccurate source mappings.
Only use this flag as a workaround if you are experiencing "stack too deep" errors.
Note that "viaIR" is only available in Solidity 0.8.13 and above.
See more: https://github.com/foundry-rs/foundry/issues/3357
Compiling 1[4](https://github.com/primev/mev-commit/actions/runs/10807042835/job/29977007439?pr=395#step:7:5)1 files with Solc 0.8.26
Solc 0.8.26 finished in 25.11s
Error: 
Compiler run failed:
Error: Yul exception:Cannot swap Variable _28 with Variable _30: too deep in the stack by 1 slots in [ RET expr_81067_address _907_slot _28 expr_81091_value expr_81063_component expr _9 _22 _18 _2[5](https://github.com/primev/mev-commit/actions/runs/10807042835/job/29977007439?pr=395#step:7:6) _17 expr_81117_address _27 _26 _17 expr_81138_mpos expr_81134_mpos expr_2 _29 _30 ]
No memoryguard was present. Consider using memory-safe assembly only and annotating it via 'assembly ("memory-safe") { ... }'.
YulException: Cannot swap Variable _28 with Variable _30: too deep in the stack by 1 slots in [ RET expr_810[6](https://github.com/primev/mev-commit/actions/runs/10807042835/job/29977007439?pr=395#step:7:7)7_address _907_slot _28 expr_81091_value expr_81063_component expr _9 _22 _18 _25 _1[7](https://github.com/primev/mev-commit/actions/runs/10807042835/job/29977007439?pr=395#step:7:8) expr_81117_address _27 _26 _17 expr_[8](https://github.com/primev/mev-commit/actions/runs/10807042835/job/29977007439?pr=395#step:7:9)1138_mpos expr_81134_mpos expr_2 _29 _30 ]
No memoryguard was present. Consider using memory-safe assembly only and annotating it via 'assembly ("memory-safe") { ... }'.
```

I've consistently found the solution to this error is shortening .sol files. Ie. our main branch has `.sol` files that are just below the stack size threshold which causes this error to show up. In the case of https://github.com/primev/mev-commit/pull/395, we don't have the option to refactor in order to reduce "stack too deep" errors. New code must be added. 

The forge coverage command itself does not add value as CI, ie. it cannot pass or fail. Therefore it shouldn't be a problem to remove from CI. At least until the foundry team addresses these compilation issues.  