### PR TITLE
feat: dont reset unstake height upon slashing w/ vanilla registry

### DIFF
--- a/contracts/contracts/validator-registry/VanillaRegistry.sol
+++ b/contracts/contracts/validator-registry/VanillaRegistry.sol
@@ -340,10 +340,7 @@ contract VanillaRegistry is IVanillaRegistry, VanillaRegistryStorage,
             require(stakedValidators[pubKey].balance > slashAmount,
                 IVanillaRegistry.NotEnoughBalanceToSlash());
             stakedValidators[pubKey].balance -= slashAmount;
-            if (_isUnstaking(pubKey)) {
-                // If validator is already unstaking, reset their unstake block number
-                BlockHeightOccurrence.captureOccurrence(stakedValidators[pubKey].unstakeOccurrence);
-            } else {
+            if (!_isUnstaking(pubKey)) {
                 _unstakeSingle(pubKey);
             }
             (bool success, ) = slashReceiver.call{value: slashAmount}("");

--- a/contracts/test/validator-registry/VanillaRegistryTest.sol
+++ b/contracts/test/validator-registry/VanillaRegistryTest.sol
@@ -400,7 +400,8 @@ contract VanillaRegistryTest is Test {
         assertEq(address(SLASH_RECEIVER).balance, 0.1 ether);
         assertEq(validatorRegistry.getStakedValidator(user1BLSKey).balance, 0.9 ether);
         assertEq(validatorRegistry.getStakedValidator(user1BLSKey).withdrawalAddress, user1);
-        assertEq(validatorRegistry.getStakedValidator(user1BLSKey).unstakeOccurrence.blockHeight, 22);
+        // Unstake occurrence should not be updated for already unstaked validators
+        assertEq(validatorRegistry.getStakedValidator(user1BLSKey).unstakeOccurrence.blockHeight, 11);
         assertFalse(validatorRegistry.isValidatorOptedIn(user1BLSKey));
     }
 
@@ -445,7 +446,8 @@ contract VanillaRegistryTest is Test {
 
         assertEq(validatorRegistry.getStakedValidator(user1BLSKey).balance, 0.9 ether);
         assertEq(validatorRegistry.getStakedValidator(user1BLSKey).withdrawalAddress, user1);
-        assertEq(validatorRegistry.getStakedValidator(user1BLSKey).unstakeOccurrence.blockHeight, 78);
+        // Unstake occurrence should not be updated for already unstaked validators
+        assertEq(validatorRegistry.getStakedValidator(user1BLSKey).unstakeOccurrence.blockHeight, 14);
         assertFalse(validatorRegistry.isValidatorOptedIn(user1BLSKey));
 
         assertEq(validatorRegistry.getStakedValidator(user2BLSKey).balance, 0.9 ether);


### PR DESCRIPTION
## Describe your changes

Changes behavior of vanilla registry to match requested behavior for symbiotic solution. Unstaking validators who're slashed will no longer have their unstaking height reset. If a validator is slashed there's no need to punish them further by delaying the ability to fully deregister. 

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
