### PR TITLE
fix: avoid restarting nomad services on template change

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
@@ -175,6 +175,7 @@ job "{{ job.name }}" {
           # endtodo
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 

--- a/infrastructure/nomad/playbooks/templates/jobs/datadog-agent.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/datadog-agent.nomad.j2
@@ -72,6 +72,7 @@ job "{{ job.name }}" {
 
         EOH
         destination = "etc/datadog-agent/datadog.yaml"
+        change_mode = "noop"
       }
 
       {% if job.type == 'logs' %}

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-bridge.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-bridge.nomad.j2
@@ -148,6 +148,7 @@ job "{{ job.name }}" {
           exec ./local/relayer-linux-amd64 start
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-emulator.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-emulator.nomad.j2
@@ -117,6 +117,7 @@ job "{{ job.name }}" {
             -otel-collector-endpoint-url "${EMULATOR_OTEL_COLLECTOR_ENDPOINT_URL}" \
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-faucet.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-faucet.nomad.j2
@@ -107,6 +107,7 @@ job "{{ job.name }}" {
           {% endraw %}
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-funder.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-funder.nomad.j2
@@ -96,6 +96,7 @@ job "{{ job.name }}" {
           {% endraw %}
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-geth.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-geth.nomad.j2
@@ -162,6 +162,7 @@ job "{{ job.name }}" {
         fi
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 
@@ -225,7 +226,7 @@ job "{{ job.name }}" {
           {% endif %}
           NET_RESTRICT="{{ job.env['net_restrict'] }}"
           GETH_NODE_TYPE="{{ job.env['type'] }}"
-          GETH_VERBOSITY={{ job.env.get('log-verbosity', '3') }}
+          GETH_VERBOSITY={{ job.env.get('log-verbosity', '5') }}
           GETH_LOG_FORMAT="{{ job.env.get('log-format', 'json') }}"
           GETH_LOG_TAGS="{{ 'service.name:' + job.name + '-{{ env "NOMAD_ALLOC_INDEX" }}' + ',service.version:' + version }}"
           {% if job.env['type'] == 'bootnode' %}
@@ -299,6 +300,7 @@ job "{{ job.name }}" {
           exec local/entrypoint.sh
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 
@@ -401,6 +403,7 @@ job "{{ job.name }}" {
         fi
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit-oracle.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit-oracle.nomad.j2
@@ -138,6 +138,7 @@ job "{{ job.name }}" {
           {% endraw %}
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 
@@ -314,6 +315,7 @@ job "{{ job.name }}" {
           {% endraw %}
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 

--- a/infrastructure/nomad/playbooks/templates/jobs/mev-commit.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mev-commit.nomad.j2
@@ -168,6 +168,7 @@ job "{{ job.name }}" {
           exec local/mev-commit
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 

--- a/infrastructure/nomad/playbooks/templates/jobs/otel-collector.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/otel-collector.nomad.j2
@@ -131,6 +131,7 @@ job "{{ job.name }}" {
           exec local/otel-collector --config local/collector.yaml
         EOH
         destination = "local/run.sh"
+        change_mode = "noop"
         perms = "0755"
       }
 


### PR DESCRIPTION
## Describe your changes

This prevents other Nomad services from automatically restarting when the relevant template is changed.

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
