### PR TITLE
fix: dereg validators on freeze

### DIFF
--- a/contracts/contracts/validator-registry/avs/MevCommitAVS.sol
+++ b/contracts/contracts/validator-registry/avs/MevCommitAVS.sol
@@ -511,9 +511,14 @@ contract MevCommitAVS is IMevCommitAVS, MevCommitAVSStorage,
 
     /// @dev Internal function to freeze a validator.
     function _freeze(bytes calldata valPubKey) internal {
-        require(!validatorRegistrations[valPubKey].freezeOccurrence.exists, ValidatorAlreadyFrozen());
-        BlockHeightOccurrence.captureOccurrence(validatorRegistrations[valPubKey].freezeOccurrence);
-        emit ValidatorFrozen(valPubKey, validatorRegistrations[valPubKey].podOwner);
+        IMevCommitAVS.ValidatorRegistrationInfo storage valRegistration = validatorRegistrations[valPubKey];
+        require(!valRegistration.freezeOccurrence.exists, ValidatorAlreadyFrozen());
+        BlockHeightOccurrence.captureOccurrence(valRegistration.freezeOccurrence);
+        // Similar to slash behavior in other registries, we request validator deregistration if not already requested.
+        if (!valRegistration.deregRequestOccurrence.exists) {
+            BlockHeightOccurrence.captureOccurrence(valRegistration.deregRequestOccurrence);
+        }
+        emit ValidatorFrozen(valPubKey, valRegistration.podOwner);
     }
 
     /// @dev Internal function to unfreeze a validator.

--- a/contracts/contracts/validator-registry/avs/README.md
+++ b/contracts/contracts/validator-registry/avs/README.md
@@ -97,7 +97,7 @@ To exit the frozen state, a configurable unfreeze period must first pass. Then a
 function unfreeze(bytes[] calldata valPubKey) payable external;
 ```
 
-where a minimum of `unfreezeFee` must be included in the transaction. If the validator was in the `REQUESTED_DEREGISTRATION` state prior to being frozen, the validator will be returned to the `REGISTERED` state. That is, a validator must *not* be frozen for a full deregistration period, before it's able to deregister.
+where a minimum of `unfreezeFee` must be included in the transaction. Upon being unfrozen, the validator transitions to the `REQUESTED_DEREGISTRATION` state (ie. is no longer "opted-in"), and can eventually deregister from the AVS.
 
 The points/rewards for LST restakers will consider freeze related events. However, LST restakers are allowed to deregister from the AVS even if any of their chosen validator(s) are frozen.
 

--- a/contracts/test/validator-registry/avs/MevCommitAVSTest.sol
+++ b/contracts/test/validator-registry/avs/MevCommitAVSTest.sol
@@ -684,7 +684,8 @@ contract MevCommitAVSTest is Test {
         assertEq(mevCommitAVS.getValidatorRegInfo(valPubkeys[1]).freezeOccurrence.blockHeight, 461);
         assertTrue(mevCommitAVS.getValidatorRegInfo(valPubkeys[0]).deregRequestOccurrence.exists);
         assertEq(mevCommitAVS.getValidatorRegInfo(valPubkeys[0]).deregRequestOccurrence.blockHeight, 403);
-        assertFalse(mevCommitAVS.getValidatorRegInfo(valPubkeys[1]).deregRequestOccurrence.exists);
+        assertTrue(mevCommitAVS.getValidatorRegInfo(valPubkeys[1]).deregRequestOccurrence.exists);
+        assertEq(mevCommitAVS.getValidatorRegInfo(valPubkeys[1]).deregRequestOccurrence.blockHeight, 461);
 
         vm.expectRevert(abi.encodeWithSelector(IMevCommitAVS.ValidatorAlreadyFrozen.selector));
         vm.prank(freezeOracle);


### PR DESCRIPTION
## Describe your changes

`VanillaRegistry` and `MevCommitMiddleware` both request validator deregistration upon a validator being slashed. See [here](https://github.com/primev/mev-commit/blob/f5b98b4cd90f5ed7d66ee87489a6a6f313677c99/contracts/contracts/validator-registry/VanillaRegistry.sol#L357) and [here](https://github.com/primev/mev-commit/blob/f5b98b4cd90f5ed7d66ee87489a6a6f313677c99/contracts/contracts/validator-registry/middleware/MevCommitMiddleware.sol#L544). To be consistent, `MevCommitAVS` now requests deregistration upon a validator being frozen (MevCommitAVS's equivalent to slashing). 


## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
