### PR TITLE
feat: introduce mock l1 for devnet setup

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
@@ -39,6 +39,15 @@ job "{{ job.name }}" {
     task "geth" {
       driver = "exec"
 
+      {% for port_name in job.ports[0] %}
+      service {
+        name = "{{ job.name }}"
+        port = "{{ port_name }}"
+        tags = ["{{ port_name }}"]
+        provider = "nomad"
+      }
+      {% endfor %}
+
       artifact {
         source = "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.14.11-f3c696fa.tar.gz"
       }

--- a/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
@@ -1,0 +1,58 @@
+#jinja2: trim_blocks:True, lstrip_blocks:True
+job "{{ job.name }}" {
+  datacenters = ["{{ datacenter }}"]
+
+  group "{{ job.name }}-group" {
+    count = {{ job.count }}
+
+    {% if env == 'devenv' %}
+    restart {
+      attempts = 0
+      mode = "fail"
+    }
+
+    reschedule {
+      attempts = 0
+      unlimited = false
+    }
+    {% endif %}
+
+    network {
+      mode = "bridge"
+
+      dns {
+        servers = {{ (ansible_facts['dns']['nameservers'] + ['1.1.1.1']) | tojson }}
+      }
+
+      {% for port_name, port_details in job.ports[0].items() %}
+      port "{{ port_name }}" {
+        {% if port_details.get('static') %}
+        static = {{ port_details['static'] }}
+        {% endif %}
+        {% if port_details.get('to') %}
+        to = {{ port_details['to'] }}
+        {% endif %}
+      }
+      {% endfor %}
+    }
+
+    task "geth" {
+      driver = "exec"
+
+      artifact {
+        source = "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.14.11-f3c696fa.tar.gz"
+      }
+
+      config {
+        command = "local/geth-linux-amd64-1.14.11-f3c696fa/geth"
+        args = [
+          "--dev",
+          "--http",
+          "--http.addr", "0.0.0.0",
+          "--http.api", "eth,net,web3",
+          "--dev.period", "12",
+        ]
+      }
+    }
+  }
+}

--- a/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
@@ -43,15 +43,33 @@ job "{{ job.name }}" {
         source = "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.14.11-f3c696fa.tar.gz"
       }
 
+      template {
+        data = <<-EOH
+          #!/usr/bin/env bash
+
+          GETH_BIN="local/geth-linux-amd64-1.14.11-f3c696fa/geth"
+
+          # Mutate genesis file to only have a single alloc to 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
+          ${GETH_BIN} --dev dumpgenesis > local/custom_genesis.json
+          jq '.alloc = {"f39fd6e51aad88f6f4ce6ab8827279cfffb92266": {"balance": "0x45"}}' local/custom_genesis.json > local/temp.json && mv local/temp.json local/custom_genesis.json
+          ${GETH_BIN} --datadir local/data init local/custom_genesis.json
+
+          exec ${GETH_BIN} \
+            --dev \
+            --http \
+            --http.addr 0.0.0.0 \
+            --http.api eth,net,web3 \
+            --dev.period 12
+            --datadir local/data
+        EOH
+        destination = "local/run.sh"
+        change_mode = "noop"
+        perms = "0755"
+      }
+
       config {
-        command = "local/geth-linux-amd64-1.14.11-f3c696fa/geth"
-        args = [
-          "--dev",
-          "--http",
-          "--http.addr", "0.0.0.0",
-          "--http.api", "eth,net,web3",
-          "--dev.period", "12",
-        ]
+        command = "bash"
+        args = ["-c", "exec local/run.sh"]
       }
     }
   }

--- a/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
@@ -59,7 +59,7 @@ job "{{ job.name }}" {
             --http \
             --http.addr 0.0.0.0 \
             --http.api eth,net,web3 \
-            --dev.period 12
+            --dev.period 12 \
             --datadir local/data
         EOH
         destination = "local/run.sh"

--- a/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
@@ -46,12 +46,26 @@ job "{{ job.name }}" {
       template {
         data = <<-EOH
           #!/usr/bin/env bash
+          {% raw %}
+          CONTRACT_DEPLOYER_KEYSTORE_FILENAME="{{ with secret "secret/data/mev-commit" }}{{ .Data.data.contract_deployer_keystore_filename }}{{ end }}"
+          {% endraw %}
+        EOH
+        destination = "secrets/.env"
+        env = true
+      }
+
+      template {
+        data = <<-EOH
+          #!/usr/bin/env bash
 
           GETH_BIN="local/geth-linux-amd64-1.14.11-f3c696fa/geth"
 
-          # Mutate genesis file to only have a single alloc to 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
+          # Mutate genesis file to only have a single alloc to contract deployer
           ${GETH_BIN} --dev dumpgenesis > local/custom_genesis.json
-          jq '.alloc = {"f39fd6e51aad88f6f4ce6ab8827279cfffb92266": {"balance": "0x45"}}' local/custom_genesis.json > local/temp.json && mv local/temp.json local/custom_genesis.json
+          TO_ALLOC=$(echo "${CONTRACT_DEPLOYER_KEYSTORE_FILENAME}" | sed 's/.*--//')
+          AMOUNT="0x45"
+          echo "Allocating ${AMOUNT} on genesis to: ${TO_ALLOC}"
+          jq ".alloc = {\"${TO_ALLOC}\": {\"balance\": \"${AMOUNT}\"}}" local/custom_genesis.json > local/temp.json && mv local/temp.json local/custom_genesis.json
           ${GETH_BIN} --datadir local/data init local/custom_genesis.json
 
           exec ${GETH_BIN} \

--- a/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
@@ -63,7 +63,7 @@ job "{{ job.name }}" {
           # Mutate genesis file to only have a single alloc to contract deployer
           ${GETH_BIN} --dev dumpgenesis > local/custom_genesis.json
           TO_ALLOC=$(echo "${CONTRACT_DEPLOYER_KEYSTORE_FILENAME}" | sed 's/.*--//')
-          AMOUNT="0x45"
+          AMOUNT="0x10000000000000000000" # 10 ether
           echo "Allocating ${AMOUNT} on genesis to: ${TO_ALLOC}"
           jq ".alloc = {\"${TO_ALLOC}\": {\"balance\": \"${AMOUNT}\"}}" local/custom_genesis.json > local/temp.json && mv local/temp.json local/custom_genesis.json
           ${GETH_BIN} --datadir local/data init local/custom_genesis.json

--- a/infrastructure/nomad/playbooks/variables/profiles.yml
+++ b/infrastructure/nomad/playbooks/variables/profiles.yml
@@ -561,6 +561,19 @@ jobs:
           to: 80
         metrics:
           to: 8888
+  
+  mock_l1: &mock_l1_job
+    name: mock-l1
+    template: mock-l1.nomad.j2
+    count: 1
+    ports:
+      - http:
+          static: 9545
+          to: 8545
+    env:
+      ip: 0.0.0.0
+      public_ip: 0.0.0.0
+      net_restrict: 0.0.0.0/0
 
 profiles:
   ci:
@@ -576,6 +589,7 @@ profiles:
       - *mev_commit_bidder_node1_job
       - *mev_commit_bidder_node1_funder_job
       - *mev_commit_faucet_job
+      - *mock_l1_job
 
   devnet:
     jobs:
@@ -596,6 +610,7 @@ profiles:
       - *mev_commit_bidder_emulator_node1_job
       - *mev_commit_faucet_job
       - *datadog_agent_metrics_collector_job
+      - *mock_l1_job
 
   testnet:
     jobs:
@@ -645,6 +660,7 @@ profiles:
       - *mev_commit_bidder_emulator_nodes_job
       - *mev_commit_faucet_job
       - *datadog_agent_metrics_collector_job
+      - *mock_l1_job
 
   manual-test:
     jobs:
@@ -666,6 +682,7 @@ profiles:
       - *mev_commit_oracle_job
       - *mev_commit_faucet_job
       - *datadog_agent_metrics_collector_job
+      - *mock_l1_job
 
   archive:
     jobs:

--- a/infrastructure/nomad/playbooks/variables/profiles.yml
+++ b/infrastructure/nomad/playbooks/variables/profiles.yml
@@ -581,6 +581,7 @@ profiles:
       - *artifacts_job
       - *mev_commit_geth_bootnode1_job
       - *mev_commit_geth_signer_node1_job
+      - *mock_l1_job
       - *contracts_deployer_job
       - *mev_commit_bootnode1_job
       - *mev_commit_provider_node1_job
@@ -589,7 +590,6 @@ profiles:
       - *mev_commit_bidder_node1_job
       - *mev_commit_bidder_node1_funder_job
       - *mev_commit_faucet_job
-      - *mock_l1_job
 
   devnet:
     jobs:
@@ -599,6 +599,7 @@ profiles:
       - *mev_commit_geth_bootnode1_job
       - *mev_commit_geth_signer_node1_job
       - *mev_commit_geth_member_node_job
+      - *mock_l1_job
       - *contracts_deployer_job
       - *mev_commit_bootnode1_job
       - *mev_commit_provider_node1_job
@@ -610,7 +611,6 @@ profiles:
       - *mev_commit_bidder_emulator_node1_job
       - *mev_commit_faucet_job
       - *datadog_agent_metrics_collector_job
-      - *mock_l1_job
 
   testnet:
     jobs:
@@ -637,6 +637,7 @@ profiles:
       - *mev_commit_geth_bootnode1_job
       - *mev_commit_geth_signer_node1_job
       - *mev_commit_geth_member_node_job
+      - *mock_l1_job
       - *contracts_deployer_job
       - *mev_commit_bootnode1_job
       - *mev_commit_provider_node1_job
@@ -660,7 +661,6 @@ profiles:
       - *mev_commit_bidder_emulator_nodes_job
       - *mev_commit_faucet_job
       - *datadog_agent_metrics_collector_job
-      - *mock_l1_job
 
   manual-test:
     jobs:
@@ -670,6 +670,7 @@ profiles:
       - *mev_commit_geth_bootnode1_job
       - *mev_commit_geth_signer_node1_job
       - *mev_commit_geth_member_node_job
+      - *mock_l1_job
       - *contracts_deployer_job
       - *mev_commit_bootnode1_job
       - *mev_commit_provider_node1_job
@@ -682,7 +683,6 @@ profiles:
       - *mev_commit_oracle_job
       - *mev_commit_faucet_job
       - *datadog_agent_metrics_collector_job
-      - *mock_l1_job
 
   archive:
     jobs:


### PR DESCRIPTION
## Describe your changes

Closes #288 

This PR simply spins up a local [geth dev mode](https://geth.ethereum.org/docs/developers/dapp-developer/dev-mode) chain from the latest geth release, with 10 ETH only allocated to the contract deployer. The mock L1 is available at port 9545.

Using geth's dev mode is simpler and easier to configure than the [previous solution](https://github.com/primev/mev-commit-geth/tree/master/geth-poa/local-l1) which spun up a clique chain. 

This PR will enable further efforts in bridge and validator registry devnet testing

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
