### PR TITLE
fix: increase bid processing timeout

### DIFF
--- a/p2p/pkg/preconfirmation/preconfirmation.go
+++ b/p2p/pkg/preconfirmation/preconfirmation.go
@@ -293,7 +293,7 @@ func (p *Preconfirmation) handleBid(
 	}()
 
 	// try to enqueue for 5 seconds
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
 	statusC, err := p.processer.ProcessBid(ctx, bid)

--- a/p2p/pkg/preconfirmation/preconfirmation.go
+++ b/p2p/pkg/preconfirmation/preconfirmation.go
@@ -292,7 +292,7 @@ func (p *Preconfirmation) handleBid(
 		}
 	}()
 
-	// try to get a decision within 30secs seconds
+	// try to get a decision within 30 seconds
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/p2p/pkg/preconfirmation/preconfirmation.go
+++ b/p2p/pkg/preconfirmation/preconfirmation.go
@@ -292,8 +292,8 @@ func (p *Preconfirmation) handleBid(
 		}
 	}()
 
-	// try to enqueue for 5 seconds
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	// try to get a decision within 30secs seconds
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	statusC, err := p.processer.ProcessBid(ctx, bid)


### PR DESCRIPTION
## Describe your changes
The timeout for `ProcessBid` operation which communicates with the provider API is too small. Increasing it to 15 secs.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
