### PR TITLE
fix: malicious user can dos bridge transfer finalization 

### DIFF
--- a/contracts-abi/abi/L1Gateway.abi
+++ b/contracts-abi/abi/L1Gateway.abi
@@ -253,6 +253,25 @@
   },
   {
     "type": "function",
+    "name": "transferredFundsNeedingWithdrawal",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "unpause",
     "inputs": [],
     "outputs": [],
@@ -275,6 +294,19 @@
     ],
     "outputs": [],
     "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "_recipient",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
     "type": "event",
@@ -391,6 +423,44 @@
         "name": "transferIdx",
         "type": "uint256",
         "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TransferNeedsWithdrawal",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TransferSuccess",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
         "internalType": "uint256"
       }
     ],
@@ -540,6 +610,17 @@
   },
   {
     "type": "error",
+    "name": "NoFundsNeedingWithdrawal",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
     "name": "NotInitializing",
     "inputs": []
   },
@@ -594,11 +675,6 @@
         "name": "recipient",
         "type": "address",
         "internalType": "address"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
       }
     ]
   },

--- a/contracts-abi/clients/L1Gateway/L1Gateway.go
+++ b/contracts-abi/clients/L1Gateway/L1Gateway.go
@@ -31,7 +31,7 @@ var (
 
 // L1gatewayMetaData contains all meta data concerning the L1gateway contract.
 var L1gatewayMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"counterpartyFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizationFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizeTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_relayer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_finalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initiateTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"returnIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"relayer\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferFinalizedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferInitiatedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferFinalized\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferInitiated\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"transferIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"AmountTooSmall\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IncorrectEtherValueSent\",\"inputs\":[{\"name\":\"msgValue\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountExpected\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InsufficientContractBalance\",\"inputs\":[{\"name\":\"thisContractBalance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountRequested\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidCounterpartyIndex\",\"inputs\":[{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"transferFinalizedIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SenderNotRelayer\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"relayer\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"TransferFailed\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"counterpartyFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizationFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizeTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_relayer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_finalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initiateTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"returnIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"relayer\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferFinalizedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferInitiatedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferredFundsNeedingWithdrawal\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"withdraw\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferFinalized\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferInitiated\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"transferIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferNeedsWithdrawal\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferSuccess\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"AmountTooSmall\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IncorrectEtherValueSent\",\"inputs\":[{\"name\":\"msgValue\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountExpected\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InsufficientContractBalance\",\"inputs\":[{\"name\":\"thisContractBalance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountRequested\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidCounterpartyIndex\",\"inputs\":[{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"transferFinalizedIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoFundsNeedingWithdrawal\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SenderNotRelayer\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"relayer\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"TransferFailed\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]",
 }
 
 // L1gatewayABI is the input ABI used to generate the binding from.
@@ -490,6 +490,37 @@ func (_L1gateway *L1gatewayCallerSession) TransferInitiatedIdx() (*big.Int, erro
 	return _L1gateway.Contract.TransferInitiatedIdx(&_L1gateway.CallOpts)
 }
 
+// TransferredFundsNeedingWithdrawal is a free data retrieval call binding the contract method 0x22396f1d.
+//
+// Solidity: function transferredFundsNeedingWithdrawal(address recipient) view returns(uint256 amount)
+func (_L1gateway *L1gatewayCaller) TransferredFundsNeedingWithdrawal(opts *bind.CallOpts, recipient common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _L1gateway.contract.Call(opts, &out, "transferredFundsNeedingWithdrawal", recipient)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TransferredFundsNeedingWithdrawal is a free data retrieval call binding the contract method 0x22396f1d.
+//
+// Solidity: function transferredFundsNeedingWithdrawal(address recipient) view returns(uint256 amount)
+func (_L1gateway *L1gatewaySession) TransferredFundsNeedingWithdrawal(recipient common.Address) (*big.Int, error) {
+	return _L1gateway.Contract.TransferredFundsNeedingWithdrawal(&_L1gateway.CallOpts, recipient)
+}
+
+// TransferredFundsNeedingWithdrawal is a free data retrieval call binding the contract method 0x22396f1d.
+//
+// Solidity: function transferredFundsNeedingWithdrawal(address recipient) view returns(uint256 amount)
+func (_L1gateway *L1gatewayCallerSession) TransferredFundsNeedingWithdrawal(recipient common.Address) (*big.Int, error) {
+	return _L1gateway.Contract.TransferredFundsNeedingWithdrawal(&_L1gateway.CallOpts, recipient)
+}
+
 // AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
 //
 // Solidity: function acceptOwnership() returns()
@@ -677,6 +708,27 @@ func (_L1gateway *L1gatewaySession) UpgradeToAndCall(newImplementation common.Ad
 // Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
 func (_L1gateway *L1gatewayTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
 	return _L1gateway.Contract.UpgradeToAndCall(&_L1gateway.TransactOpts, newImplementation, data)
+}
+
+// Withdraw is a paid mutator transaction binding the contract method 0x51cff8d9.
+//
+// Solidity: function withdraw(address _recipient) returns()
+func (_L1gateway *L1gatewayTransactor) Withdraw(opts *bind.TransactOpts, _recipient common.Address) (*types.Transaction, error) {
+	return _L1gateway.contract.Transact(opts, "withdraw", _recipient)
+}
+
+// Withdraw is a paid mutator transaction binding the contract method 0x51cff8d9.
+//
+// Solidity: function withdraw(address _recipient) returns()
+func (_L1gateway *L1gatewaySession) Withdraw(_recipient common.Address) (*types.Transaction, error) {
+	return _L1gateway.Contract.Withdraw(&_L1gateway.TransactOpts, _recipient)
+}
+
+// Withdraw is a paid mutator transaction binding the contract method 0x51cff8d9.
+//
+// Solidity: function withdraw(address _recipient) returns()
+func (_L1gateway *L1gatewayTransactorSession) Withdraw(_recipient common.Address) (*types.Transaction, error) {
+	return _L1gateway.Contract.Withdraw(&_L1gateway.TransactOpts, _recipient)
 }
 
 // Fallback is a paid mutator transaction binding the contract fallback function.
@@ -1610,6 +1662,296 @@ func (_L1gateway *L1gatewayFilterer) WatchTransferInitiated(opts *bind.WatchOpts
 func (_L1gateway *L1gatewayFilterer) ParseTransferInitiated(log types.Log) (*L1gatewayTransferInitiated, error) {
 	event := new(L1gatewayTransferInitiated)
 	if err := _L1gateway.contract.UnpackLog(event, "TransferInitiated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// L1gatewayTransferNeedsWithdrawalIterator is returned from FilterTransferNeedsWithdrawal and is used to iterate over the raw logs and unpacked data for TransferNeedsWithdrawal events raised by the L1gateway contract.
+type L1gatewayTransferNeedsWithdrawalIterator struct {
+	Event *L1gatewayTransferNeedsWithdrawal // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *L1gatewayTransferNeedsWithdrawalIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(L1gatewayTransferNeedsWithdrawal)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(L1gatewayTransferNeedsWithdrawal)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *L1gatewayTransferNeedsWithdrawalIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *L1gatewayTransferNeedsWithdrawalIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// L1gatewayTransferNeedsWithdrawal represents a TransferNeedsWithdrawal event raised by the L1gateway contract.
+type L1gatewayTransferNeedsWithdrawal struct {
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterTransferNeedsWithdrawal is a free log retrieval operation binding the contract event 0xdb8894f6f59b9443ce412bc397f0e4a129eae066a787972c7c5e077deccf1db0.
+//
+// Solidity: event TransferNeedsWithdrawal(address indexed recipient, uint256 amount)
+func (_L1gateway *L1gatewayFilterer) FilterTransferNeedsWithdrawal(opts *bind.FilterOpts, recipient []common.Address) (*L1gatewayTransferNeedsWithdrawalIterator, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _L1gateway.contract.FilterLogs(opts, "TransferNeedsWithdrawal", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &L1gatewayTransferNeedsWithdrawalIterator{contract: _L1gateway.contract, event: "TransferNeedsWithdrawal", logs: logs, sub: sub}, nil
+}
+
+// WatchTransferNeedsWithdrawal is a free log subscription operation binding the contract event 0xdb8894f6f59b9443ce412bc397f0e4a129eae066a787972c7c5e077deccf1db0.
+//
+// Solidity: event TransferNeedsWithdrawal(address indexed recipient, uint256 amount)
+func (_L1gateway *L1gatewayFilterer) WatchTransferNeedsWithdrawal(opts *bind.WatchOpts, sink chan<- *L1gatewayTransferNeedsWithdrawal, recipient []common.Address) (event.Subscription, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _L1gateway.contract.WatchLogs(opts, "TransferNeedsWithdrawal", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(L1gatewayTransferNeedsWithdrawal)
+				if err := _L1gateway.contract.UnpackLog(event, "TransferNeedsWithdrawal", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTransferNeedsWithdrawal is a log parse operation binding the contract event 0xdb8894f6f59b9443ce412bc397f0e4a129eae066a787972c7c5e077deccf1db0.
+//
+// Solidity: event TransferNeedsWithdrawal(address indexed recipient, uint256 amount)
+func (_L1gateway *L1gatewayFilterer) ParseTransferNeedsWithdrawal(log types.Log) (*L1gatewayTransferNeedsWithdrawal, error) {
+	event := new(L1gatewayTransferNeedsWithdrawal)
+	if err := _L1gateway.contract.UnpackLog(event, "TransferNeedsWithdrawal", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// L1gatewayTransferSuccessIterator is returned from FilterTransferSuccess and is used to iterate over the raw logs and unpacked data for TransferSuccess events raised by the L1gateway contract.
+type L1gatewayTransferSuccessIterator struct {
+	Event *L1gatewayTransferSuccess // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *L1gatewayTransferSuccessIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(L1gatewayTransferSuccess)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(L1gatewayTransferSuccess)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *L1gatewayTransferSuccessIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *L1gatewayTransferSuccessIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// L1gatewayTransferSuccess represents a TransferSuccess event raised by the L1gateway contract.
+type L1gatewayTransferSuccess struct {
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterTransferSuccess is a free log retrieval operation binding the contract event 0x2e1ece5fb4a04cb9407bb825ceb4c6d6d402c18ba1cbe2054241fb1a86fd58da.
+//
+// Solidity: event TransferSuccess(address indexed recipient, uint256 amount)
+func (_L1gateway *L1gatewayFilterer) FilterTransferSuccess(opts *bind.FilterOpts, recipient []common.Address) (*L1gatewayTransferSuccessIterator, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _L1gateway.contract.FilterLogs(opts, "TransferSuccess", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &L1gatewayTransferSuccessIterator{contract: _L1gateway.contract, event: "TransferSuccess", logs: logs, sub: sub}, nil
+}
+
+// WatchTransferSuccess is a free log subscription operation binding the contract event 0x2e1ece5fb4a04cb9407bb825ceb4c6d6d402c18ba1cbe2054241fb1a86fd58da.
+//
+// Solidity: event TransferSuccess(address indexed recipient, uint256 amount)
+func (_L1gateway *L1gatewayFilterer) WatchTransferSuccess(opts *bind.WatchOpts, sink chan<- *L1gatewayTransferSuccess, recipient []common.Address) (event.Subscription, error) {
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _L1gateway.contract.WatchLogs(opts, "TransferSuccess", recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(L1gatewayTransferSuccess)
+				if err := _L1gateway.contract.UnpackLog(event, "TransferSuccess", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTransferSuccess is a log parse operation binding the contract event 0x2e1ece5fb4a04cb9407bb825ceb4c6d6d402c18ba1cbe2054241fb1a86fd58da.
+//
+// Solidity: event TransferSuccess(address indexed recipient, uint256 amount)
+func (_L1gateway *L1gatewayFilterer) ParseTransferSuccess(log types.Log) (*L1gatewayTransferSuccess, error) {
+	event := new(L1gatewayTransferSuccess)
+	if err := _L1gateway.contract.UnpackLog(event, "TransferSuccess", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/contracts/contracts/interfaces/IAllocator.sol
+++ b/contracts/contracts/interfaces/IAllocator.sol
@@ -3,16 +3,16 @@ pragma solidity 0.8.26;
 
 interface IAllocator {
 
-    error SenderNotWhitelisted(address sender);
-    error InsufficientContractBalance(uint256 contractBalance, uint256 amountRequested);
-    error NoFundsNeedingWithdrawal(address recipient);
-    error TransferFailed(address recipient);
-
     /// @dev Emitted when a transfer needs withdrawal.
     event TransferNeedsWithdrawal(address indexed recipient, uint256 amount);
 
     /// @dev Emitted when a transfer is successful.
     event TransferSuccess(address indexed recipient, uint256 amount);
+
+    error SenderNotWhitelisted(address sender);
+    error InsufficientContractBalance(uint256 contractBalance, uint256 amountRequested);
+    error NoFundsNeedingWithdrawal(address recipient);
+    error TransferFailed(address recipient);
 
     function addToWhitelist(address _address) external;
     function removeFromWhitelist(address _address) external;

--- a/contracts/contracts/interfaces/IAllocator.sol
+++ b/contracts/contracts/interfaces/IAllocator.sol
@@ -5,7 +5,14 @@ interface IAllocator {
 
     error SenderNotWhitelisted(address sender);
     error InsufficientContractBalance(uint256 contractBalance, uint256 amountRequested);
-    error TransferFailed(address recipient, uint256 amount);
+    error NoFundsNeedingWithdrawal(address recipient);
+    error TransferFailed(address recipient);
+
+    /// @dev Emitted when a transfer needs withdrawal.
+    event TransferNeedsWithdrawal(address indexed recipient, uint256 amount);
+
+    /// @dev Emitted when a transfer is successful.
+    event TransferSuccess(address indexed recipient, uint256 amount);
 
     function addToWhitelist(address _address) external;
     function removeFromWhitelist(address _address) external;

--- a/contracts/contracts/standard-bridge/Allocator.sol
+++ b/contracts/contracts/standard-bridge/Allocator.sol
@@ -49,8 +49,7 @@ contract Allocator is AllocatorStorage, IAllocator,
     function mint(address _mintTo, uint256 _amount) external whenNotPaused nonReentrant {
         require(isWhitelisted(msg.sender), SenderNotWhitelisted(msg.sender));
         require(address(this).balance >= _amount, InsufficientContractBalance(address(this).balance, _amount));
-        bool success = payable(_mintTo).send(_amount);
-        if (!success) {
+        if (!payable(_mintTo).send(_amount)) {
             transferredFundsNeedingWithdrawal[_mintTo] += _amount;
             emit TransferNeedsWithdrawal(_mintTo, _amount);
             return;

--- a/contracts/contracts/standard-bridge/Allocator.sol
+++ b/contracts/contracts/standard-bridge/Allocator.sol
@@ -49,8 +49,24 @@ contract Allocator is AllocatorStorage, IAllocator,
     function mint(address _mintTo, uint256 _amount) external whenNotPaused nonReentrant {
         require(isWhitelisted(msg.sender), SenderNotWhitelisted(msg.sender));
         require(address(this).balance >= _amount, InsufficientContractBalance(address(this).balance, _amount));
-        (bool success, ) = _mintTo.call{value: _amount}("");
-        require(success, TransferFailed(_mintTo, _amount));
+        bool success = payable(_mintTo).send(_amount);
+        if (!success) {
+            transferredFundsNeedingWithdrawal[_mintTo] += _amount;
+            emit TransferNeedsWithdrawal(_mintTo, _amount);
+            return;
+        }
+        emit TransferSuccess(_mintTo, _amount);
+    }
+
+    /// @dev Allows any account to manually withdraw funds that failed to be transferred by the relayer.
+    /// @dev The relayer should NEVER call this function.
+    function withdraw(address _recipient) external whenNotPaused nonReentrant {
+        uint256 amount = transferredFundsNeedingWithdrawal[_recipient];
+        require(amount > 0, NoFundsNeedingWithdrawal(_recipient));
+        transferredFundsNeedingWithdrawal[_recipient] = 0;
+        (bool success, ) = _recipient.call{value: amount}("");
+        require(success, TransferFailed(_recipient));
+        emit TransferSuccess(_recipient, amount);
     }
 
     /// @dev Allows the owner to pause the contract.

--- a/contracts/contracts/standard-bridge/Gateway.sol
+++ b/contracts/contracts/standard-bridge/Gateway.sol
@@ -16,6 +16,12 @@ abstract contract Gateway is IGateway, GatewayStorage,
         _;
     }
 
+    /// @dev Initiates a transfer from the source chain gateway to its counterparty gateway on another chain.
+    /// @notice The _recipient is transferred eth on the destination chain via solidity's send function (with built-in gas limit).
+    /// Therefore the _recipient MUST be an EOA on the other chain to gauruntee a successful transfer.
+    /// @notice If _recipient is a contract, manual withdrawal may be required on the counterparty chain.
+    /// @notice The caller of this function takes responsiblity for whatever address is specified as the _recipient.
+    /// That is, if _recipient is a contract with an immutable receiver that reverts, the user would be at fault for loss of funds.
     function initiateTransfer(address _recipient, uint256 _amount) 
         external payable whenNotPaused nonReentrant returns (uint256 returnIdx) {
         require(_amount >= counterpartyFee, AmountTooSmall(_amount, counterpartyFee));
@@ -25,6 +31,8 @@ abstract contract Gateway is IGateway, GatewayStorage,
         return transferInitiatedIdx;
     }
 
+    /// @dev Finalizes a transfer as the destination chain gateway.
+    /// @dev The inheriting contract MUST implement eth transfer failure handling, and the retry capability.
     function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx) 
         external onlyRelayer whenNotPaused nonReentrant {
         require(_amount >= finalizationFee, AmountTooSmall(_amount, finalizationFee));

--- a/contracts/contracts/standard-bridge/L1Gateway.sol
+++ b/contracts/contracts/standard-bridge/L1Gateway.sol
@@ -2,16 +2,25 @@
 pragma solidity 0.8.26;
 
 import {Gateway} from "./Gateway.sol";
+import {L1GatewayStorage} from "./L1GatewayStorage.sol";
 import {Errors} from "../utils/Errors.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 
 /// @title L1Gateway
 /// @notice Gateway contract deployed on L1 enabling the mev-commit standard bridge.
 /// @dev This contract will escrow locked ETH, while a corresponding amount is minted from the SettlementGateway on the mev-commit chain.
-contract L1Gateway is Gateway {
+contract L1Gateway is L1GatewayStorage, Gateway {
 
     error IncorrectEtherValueSent(uint256 msgValue, uint256 amountExpected);
     error InsufficientContractBalance(uint256 thisContractBalance, uint256 amountRequested);
-    error TransferFailed(address recipient, uint256 amount);
+    error NoFundsNeedingWithdrawal(address recipient);
+    error TransferFailed(address recipient);
+
+    /// @dev Emitted when a transfer needs withdrawal.
+    event TransferNeedsWithdrawal(address indexed recipient, uint256 amount);
+
+    /// @dev Emitted when a transfer is successful.
+    event TransferSuccess(address indexed recipient, uint256 amount);
 
     function initialize(
         address _owner, 
@@ -50,8 +59,24 @@ contract L1Gateway is Gateway {
 
     function _fund(uint256 _amount, address _toFund) internal override {
         require(address(this).balance >= _amount, InsufficientContractBalance(address(this).balance, _amount));
-        (bool success, ) = _toFund.call{value: _amount}("");
-        require(success, TransferFailed(_toFund, _amount));
+        bool success = payable(_toFund).send(_amount);
+        if (!success) {
+            transferredFundsNeedingWithdrawal[_toFund] += _amount;
+            emit TransferNeedsWithdrawal(_toFund, _amount);
+            return;
+        } 
+        emit TransferSuccess(_toFund, _amount);
+    }
+
+    /// @dev Allows any account to manually withdraw funds that failed to be transferred by the relayer.
+    /// @dev The relayer should NEVER call this function.
+    function withdraw(address _recipient) external whenNotPaused nonReentrant {
+        uint256 amount = transferredFundsNeedingWithdrawal[_recipient];
+        require(amount > 0, NoFundsNeedingWithdrawal(_recipient));
+        transferredFundsNeedingWithdrawal[_recipient] = 0;
+        (bool success, ) = _recipient.call{value: amount}("");
+        require(success, TransferFailed(_recipient));
+        emit TransferSuccess(_recipient, amount);
     }
 }
 

--- a/contracts/contracts/standard-bridge/L1GatewayStorage.sol
+++ b/contracts/contracts/standard-bridge/L1GatewayStorage.sol
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: BSL 1.1
 pragma solidity 0.8.26;
 
-contract AllocatorStorage {
-    /// @dev Mapping of whitelisted addresses which can mint native ETH on the mev-commit chain.
-    mapping(address => bool) public whitelistedAddresses;
-
+/// @dev Any storage variables defined in this contract must NOT override those defined in GatewayStorage.sol!
+contract L1GatewayStorage {
     /// @dev Mapping that tracks funds which had a failed transfer to the recipient and need manual withdrawal.
     mapping(address recipient => uint256 amount) public transferredFundsNeedingWithdrawal;
 
     /// @dev See https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
-    uint256[48] private __gap;
+    uint256[48] private __l1GatewayStorageGap;
 }

--- a/contracts/test/standard-bridge/EventReceiver.sol
+++ b/contracts/test/standard-bridge/EventReceiver.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+contract EventReceiver {
+    event Received(address indexed sender, uint256 amount);
+
+    receive() external payable {
+        for (uint256 i = 0; i < 5; i++) {
+            emit Received(msg.sender, msg.value);
+        }
+    }
+}

--- a/contracts/test/standard-bridge/L1GatewayTest.sol
+++ b/contracts/test/standard-bridge/L1GatewayTest.sol
@@ -5,6 +5,8 @@ import {Test} from "forge-std/Test.sol";
 import {L1Gateway} from "../../contracts/standard-bridge/L1Gateway.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 import {IGateway} from "../../contracts/interfaces/IGateway.sol";
+import {RevertingReceiver} from "./RevertingReceiver.sol";
+import {EventReceiver} from "./EventReceiver.sol";
 
 contract L1GatewayTest is Test {
     L1Gateway l1Gateway;
@@ -41,6 +43,9 @@ contract L1GatewayTest is Test {
     // Expected event signature emitted in initiateTransfer()
     event TransferInitiated(
         address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx);
+
+    event TransferNeedsWithdrawal(address indexed recipient, uint256 amount);
+    event TransferSuccess(address indexed recipient, uint256 amount);
 
     function test_InitiateTransferSuccess() public {
         vm.deal(bridgeUser, 100 ether);
@@ -137,6 +142,10 @@ contract L1GatewayTest is Test {
 
         // Set up expectation for event
         vm.expectEmit(true, true, true, true);
+        emit TransferSuccess(bridgeUser, amount - finalizationFee);
+        vm.expectEmit(true, true, true, true);
+        emit TransferSuccess(relayer, finalizationFee);
+        vm.expectEmit(true, true, true, true);
         emit TransferFinalized(bridgeUser, amount, counterpartyIdx);
 
         // Call function as relayer
@@ -221,5 +230,113 @@ contract L1GatewayTest is Test {
 
         assertEq(l1Gateway.transferInitiatedIdx(), 0);
         assertEq(l1Gateway.transferFinalizedIdx(), 1);
+    }
+
+    function test_FinalizeTransferRevertingReceiver() public {
+        uint256 amount = 4 ether;
+        uint256 counterpartyIdx = 1;
+
+        vm.deal(address(l1Gateway), 5 ether);
+        vm.deal(relayer, 5 ether);
+
+        RevertingReceiver revertingReceiver = new RevertingReceiver();
+        revertingReceiver.setShouldRevert(true);
+        address receiver = address(revertingReceiver);
+
+        assertEq(address(l1Gateway).balance, 5 ether);
+        assertEq(relayer.balance, 5 ether);
+        assertEq(receiver.balance, 0 ether);
+        assertEq(l1Gateway.transferInitiatedIdx(), 0);
+        assertEq(l1Gateway.transferFinalizedIdx(), 1);
+        assertEq(l1Gateway.transferredFundsNeedingWithdrawal(receiver), 0);
+
+        vm.expectEmit(true, true, false, false);
+        emit TransferNeedsWithdrawal(receiver, amount - finalizationFee);
+        vm.expectEmit(true, true, false, false);
+        emit TransferSuccess(relayer, finalizationFee);
+        vm.expectEmit(true, true, false, false);
+        emit TransferFinalized(receiver, amount, counterpartyIdx);
+
+        vm.prank(relayer);
+        l1Gateway.finalizeTransfer(receiver, amount, counterpartyIdx);
+
+        assertEq(address(l1Gateway).balance, 5 ether - finalizationFee);
+        assertEq(relayer.balance, 5 ether + finalizationFee);
+        assertEq(receiver.balance, 0 ether);
+        assertEq(l1Gateway.transferredFundsNeedingWithdrawal(receiver), amount - finalizationFee);
+        assertEq(l1Gateway.transferInitiatedIdx(), 0);
+        assertEq(l1Gateway.transferFinalizedIdx(), 2);
+
+        // Any account can retry the transfer, but user is responsible for receiver functioning properly.
+        vm.expectRevert(abi.encodeWithSelector(L1Gateway.TransferFailed.selector, receiver));
+        vm.prank(vm.addr(88));
+        l1Gateway.withdraw(receiver);
+
+        revertingReceiver.setShouldRevert(false);
+        vm.expectEmit(true, true, false, false);
+        emit TransferSuccess(receiver, amount - finalizationFee);
+        vm.prank(vm.addr(99));
+        l1Gateway.withdraw(receiver);
+
+        assertEq(address(l1Gateway).balance, 5 ether - amount); // User pays for finalization fee
+        assertEq(relayer.balance, 5.1 ether);
+        assertEq(receiver.balance, 3.9 ether);
+        assertEq(l1Gateway.transferredFundsNeedingWithdrawal(receiver), 0);
+        assertEq(l1Gateway.transferInitiatedIdx(), 0);
+        assertEq(l1Gateway.transferFinalizedIdx(), 2);
+    }
+
+    function test_finalizeTransferEventReceiver() public {
+        uint256 amount = 4 ether;
+        uint256 counterpartyIdx = 1;
+
+        vm.deal(address(l1Gateway), 5 ether);
+        vm.deal(relayer, 5 ether);
+
+        EventReceiver eventReceiver = new EventReceiver();
+        address receiver = address(eventReceiver);
+
+        assertEq(address(l1Gateway).balance, 5 ether);
+        assertEq(relayer.balance, 5 ether);
+        assertEq(receiver.balance, 0 ether);
+        assertEq(l1Gateway.transferInitiatedIdx(), 0);
+        assertEq(l1Gateway.transferFinalizedIdx(), 1);
+        assertEq(l1Gateway.transferredFundsNeedingWithdrawal(receiver), 0);
+
+        // Too much gas usage in receiver, so manual withdrawal is needed.
+        vm.expectEmit(true, true, false, false);
+        emit TransferNeedsWithdrawal(receiver, amount - finalizationFee);
+        vm.expectEmit(true, true, false, false);
+        emit TransferSuccess(relayer, finalizationFee);
+        vm.expectEmit(true, true, false, false);
+        emit TransferFinalized(receiver, amount, counterpartyIdx);
+
+        vm.prank(relayer);
+        l1Gateway.finalizeTransfer(receiver, amount, counterpartyIdx);
+
+        assertEq(address(l1Gateway).balance, 5 ether - finalizationFee);
+        assertEq(relayer.balance, 5 ether + finalizationFee);
+        assertEq(receiver.balance, 0 ether);
+        assertEq(l1Gateway.transferredFundsNeedingWithdrawal(receiver), amount - finalizationFee);
+        assertEq(l1Gateway.transferInitiatedIdx(), 0);
+        assertEq(l1Gateway.transferFinalizedIdx(), 2);
+
+        vm.expectEmit(true, true, false, false);
+        emit TransferSuccess(receiver, amount - finalizationFee);
+        vm.prank(vm.addr(888));
+        l1Gateway.withdraw(receiver);
+
+        assertEq(address(l1Gateway).balance, 5 ether - amount);
+        assertEq(relayer.balance, 5.1 ether);
+        assertEq(receiver.balance, 3.9 ether);
+        assertEq(l1Gateway.transferredFundsNeedingWithdrawal(receiver), 0);
+        assertEq(l1Gateway.transferInitiatedIdx(), 0);
+        assertEq(l1Gateway.transferFinalizedIdx(), 2);
+    }
+
+    function test_WithdrawNoFundsNeedingWithdrawal() public {
+        vm.expectRevert(abi.encodeWithSelector(L1Gateway.NoFundsNeedingWithdrawal.selector, vm.addr(999)));
+        vm.prank(vm.addr(888));
+        l1Gateway.withdraw(vm.addr(999));
     }
 }

--- a/contracts/test/standard-bridge/RevertingReceiver.sol
+++ b/contracts/test/standard-bridge/RevertingReceiver.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+contract RevertingReceiver {
+    bool internal shouldRevert;
+
+    function setShouldRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+
+    receive() external payable {
+        if (shouldRevert) revert("RevertingReceiver: Revert on receiving Ether");
+    }
+}


### PR DESCRIPTION
## Describe your changes

Fixes https://cantina.xyz/code/4ee8716d-3e0e-4f59-b90d-aa56bf3b484c/findings/775. Note there were a lot of duplicates for this finding in the audit competition.

The solution taken in this PR is to handle failed ETH transfers in `finalizeTransfer`, by allowing those failed transfers to be manually retried again on the destination chain. 

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
