### PR TITLE
fix: update time setting

### DIFF
--- a/cl/cmd/redisapp/main.go
+++ b/cl/cmd/redisapp/main.go
@@ -83,7 +83,7 @@ func main() {
 			Name:    "genesis-block-hash",
 			Usage:   "Genesis block hash",
 			EnvVars: []string{"RAPP_GENESIS_BLOCK_HASH"},
-			Value:   "c9810c36e1e8bb2adaa677338b43870f73c3a39abebdffb582a668ca63e523d2",
+			Value:   "dfc7fa546e1268f5bb65b9ec67759307d2435ad1bf609307c7c306e9bb0edcde",
 			Action: func(_ *cli.Context, s string) error {
 				if len(s) != 64 {
 					return fmt.Errorf("invalid genesis-block-hash: must be 64 hex characters")
@@ -117,7 +117,7 @@ func main() {
 			Name:    "evm-build-delay",
 			Usage:   "EVM build delay",
 			EnvVars: []string{"RAPP_EVM_BUILD_DELAY"},
-			Value:   time.Second,
+			Value:   200 * time.Millisecond,
 		}),
 	}
 

--- a/cl/geth-setup/genesis.json
+++ b/cl/geth-setup/genesis.json
@@ -15,14 +15,14 @@
 		"londonBlock": 0,
 		"arrowGlacierBlock": 0,
 		"grayGlacierBlock": 0,
-                "mergeNetsplitBlock": 0,
-		"shanghaiTime": 1694203366,
-                "cancunTime": 1694203367,
+        "mergeNetsplitBlock": 0,
+		"shanghaiTime": 0,
+        "cancunTime": 0,
 		"terminalTotalDifficulty": 0,
 		"terminalTotalDifficultyPassed": true
 	},
 	"nonce": "0x0",
-	"timestamp": "0x64fb7de6",
+	"timestamp": "0x0",
 	"gasLimit": "0x1c9c380",
 	"difficulty": "0x1",
 	"mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -51,4 +51,3 @@
 	"excessBlobGas": null,
 	"blobGasUsed": null
 }
-

--- a/cl/redisapp/leader.go
+++ b/cl/redisapp/leader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/heyvito/go-leader/leader"
 	"github.com/primev/mev-commit/cl/redisapp/types"
@@ -69,6 +70,7 @@ func (l *Leader) leaderLoop(ctx context.Context) {
 						if err != nil {
 							l.logger.Error("Leader: Failed to stop leader election", "error", err)
 						}
+						l.stepsManager.lastCallTime = time.Time{}
 					}
 
 					continue
@@ -86,6 +88,7 @@ func (l *Leader) leaderLoop(ctx context.Context) {
 						if err != nil {
 							l.logger.Error("Leader: Failed to stop leader election", "error", err)
 						}
+						l.stepsManager.lastCallTime = time.Time{}
 					}
 
 					continue

--- a/cl/redisapp/rapp.go
+++ b/cl/redisapp/rapp.go
@@ -98,6 +98,7 @@ func NewMevCommitChain(instanceID, ecURL, jwtSecret, genesisBlockHash string, lo
 		engineCl:     engineCL,
 		logger:       logger,
 		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 	}
 
 	follower := &Follower{

--- a/cl/redisapp/state.go
+++ b/cl/redisapp/state.go
@@ -92,7 +92,7 @@ func (s *RedisStateManager) LoadExecutionHead(ctx context.Context) (*types.Execu
 				s.logger.Error("Error decoding genesis block hash", "error", decodeErr)
 				return nil, decodeErr
 			}
-			head := &types.ExecutionHead{BlockHash: hashBytes}
+			head := &types.ExecutionHead{BlockHash: hashBytes, BlockTime: uint64(time.Now().UnixMilli())}
 			if saveErr := s.SaveExecutionHead(ctx, head); saveErr != nil {
 				return nil, saveErr
 			}

--- a/cl/redisapp/steps.go
+++ b/cl/redisapp/steps.go
@@ -81,23 +81,22 @@ func (s *StepsManager) getPayload(ctx context.Context) error {
 	prevTimestamp := head.BlockTime
 
 	var ts uint64
-	buildDelayMillis := s.buildDelay.Milliseconds()
 
 	if s.lastCallTime.IsZero() {
 		// First block, initialize lastCallTime and set default timestamp
-		ts = uint64(time.Now().UnixMilli()) + uint64(buildDelayMillis)
+		ts = uint64(time.Now().UnixMilli()) + s.buildDelayMs
 		s.lastCallTime = currentCallTime
 	} else {
 		// Compute diff in milliseconds
 		diff := currentCallTime.Sub(s.lastCallTime)
 		diffMillis := diff.Milliseconds()
 
-		if diffMillis <= buildDelayMillis {
-			ts = prevTimestamp + uint64(buildDelayMillis)
+		if uint64(diffMillis) <= s.buildDelayMs {
+			ts = prevTimestamp + s.buildDelayMs
 		} else {
 			// For every multiple of buildDelay that diff exceeds, increment the block time by that multiple.
-			multiples := (diffMillis + buildDelayMillis - 1) / buildDelayMillis // Round up to next multiple of buildDelay
-			ts = prevTimestamp + uint64(multiples*buildDelayMillis)
+			multiples := (uint64(diffMillis) + s.buildDelayMs - 1) / s.buildDelayMs // Round up to next multiple of buildDelay
+			ts = prevTimestamp + multiples*s.buildDelayMs
 		}
 
 		s.lastCallTime = currentCallTime

--- a/cl/redisapp/steps.go
+++ b/cl/redisapp/steps.go
@@ -25,17 +25,18 @@ type StepsManager struct {
 	engineCl     EngineClient
 	logger       Logger
 	buildDelay   time.Duration
+	buildDelayMs uint64
+	lastCallTime time.Time
 	ctx          context.Context
 }
 
-func (s *StepsManager) startBuild(ctx context.Context, feeRecipient common.Address, timestamp time.Time) (engine.ForkChoiceResponse, error) {
+func (s *StepsManager) startBuild(ctx context.Context, feeRecipient common.Address, ts uint64) (engine.ForkChoiceResponse, error) {
 	head, err := s.stateManager.LoadExecutionHead(ctx)
 	if err != nil {
 		return engine.ForkChoiceResponse{}, fmt.Errorf("latest execution block: %w", err)
 	}
 
 	// Use provided time as timestamp for the next block.
-	ts := uint64(timestamp.UnixMilli())
 	if ts <= head.BlockTime {
 		ts = head.BlockTime + 1 // Subsequent blocks must have a higher timestamp.
 	}
@@ -48,7 +49,7 @@ func (s *StepsManager) startBuild(ctx context.Context, feeRecipient common.Addre
 		FinalizedBlockHash: hash,
 	}
 
-	s.logger.Info("Leader: Submit new EVM payload", "timestamp", timestamp)
+	s.logger.Info("Leader: Submit new EVM payload", "timestamp", ts)
 
 	attrs := &engine.PayloadAttributes{
 		Timestamp:             ts,
@@ -69,8 +70,41 @@ func (s *StepsManager) startBuild(ctx context.Context, feeRecipient common.Addre
 func (s *StepsManager) getPayload(ctx context.Context) error {
 	var payloadID *engine.PayloadID
 
+	currentCallTime := time.Now()
+
+	// Load execution head to get previous block timestamp
+	head, err := s.stateManager.LoadExecutionHead(ctx)
+	if err != nil {
+		return fmt.Errorf("latest execution block: %w", err)
+	}
+
+	prevTimestamp := head.BlockTime
+
+	var ts uint64
+	buildDelayMillis := s.buildDelay.Milliseconds()
+
+	if s.lastCallTime.IsZero() {
+		// First block, initialize lastCallTime and set default timestamp
+		ts = prevTimestamp + uint64(buildDelayMillis)
+		s.lastCallTime = currentCallTime
+	} else {
+		// Compute diff in milliseconds
+		diff := currentCallTime.Sub(s.lastCallTime)
+		diffMillis := diff.Milliseconds()
+
+		if diffMillis <= buildDelayMillis {
+			ts = prevTimestamp + uint64(buildDelayMillis)
+		} else {
+			// For every multiple of buildDelay that diff exceeds, increment the block time by that multiple.
+			multiples := (diffMillis + buildDelayMillis - 1) / buildDelayMillis // Round up to next multiple of buildDelay
+			ts = prevTimestamp + uint64(multiples*buildDelayMillis)
+		}
+
+		s.lastCallTime = currentCallTime
+	}
+
 	success, err := retryWithLimitedAttempts(ctx, func() (bool, error) {
-		response, err := s.startBuild(ctx, common.Address{}, time.Now())
+		response, err := s.startBuild(ctx, common.Address{}, ts)
 		if err != nil {
 			s.logger.Warn("failed to build new evm payload, will retry", "error", err)
 			return false, nil
@@ -336,7 +370,7 @@ func (s *StepsManager) validateExecutionPayload(executionPayload engine.Executab
 		return fmt.Errorf("invalid parent hash: %s, head: %s", executionPayload.ParentHash, head.BlockHash)
 	}
 	minTimestamp := head.BlockTime + 1
-	if executionPayload.Timestamp < minTimestamp {
+	if executionPayload.Timestamp < minTimestamp && executionPayload.Number != 1 {
 		return fmt.Errorf("invalid timestamp: %d, min: %d", executionPayload.Timestamp, minTimestamp)
 	}
 	hash := common.BytesToHash(head.BlockHash)

--- a/cl/redisapp/steps.go
+++ b/cl/redisapp/steps.go
@@ -85,7 +85,7 @@ func (s *StepsManager) getPayload(ctx context.Context) error {
 
 	if s.lastCallTime.IsZero() {
 		// First block, initialize lastCallTime and set default timestamp
-		ts = prevTimestamp + uint64(buildDelayMillis)
+		ts = uint64(time.Now().UnixMilli()) + uint64(buildDelayMillis)
 		s.lastCallTime = currentCallTime
 	} else {
 		// Compute diff in milliseconds

--- a/cl/redisapp/steps_test.go
+++ b/cl/redisapp/steps_test.go
@@ -29,6 +29,7 @@ var handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 	Level: slog.LevelInfo,
 })
 var stLog = slog.New(handler)
+var buildDelay = time.Duration(1 * time.Second)
 
 type MockEngineClient struct {
 	mock.Mock
@@ -70,7 +71,8 @@ func TestStepsManager_startBuild(t *testing.T) {
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}
@@ -103,7 +105,7 @@ func TestStepsManager_startBuild(t *testing.T) {
 	}
 	mockEngineClient.On("ForkchoiceUpdatedV3", mock.Anything, expectedFCS, expectedAttrs).Return(forkChoiceResponse, nil)
 
-	resp, err := stepsManager.startBuild(ctx, feeRecipient, timestamp)
+	resp, err := stepsManager.startBuild(ctx, feeRecipient, uint64(timestamp.UnixMilli()))
 
 	require.NoError(t, err)
 	assert.Equal(t, forkChoiceResponse, resp)
@@ -152,7 +154,8 @@ func TestStepsManager_getPayload(t *testing.T) {
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}
@@ -225,7 +228,8 @@ func TestStepsManager_finalizeBlock(t *testing.T) {
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}
@@ -304,7 +308,8 @@ func TestStepsManager_startBuild_LoadExecutionHeadError(t *testing.T) {
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}
@@ -312,7 +317,7 @@ func TestStepsManager_startBuild_LoadExecutionHeadError(t *testing.T) {
 	feeRecipient := common.Address{}
 	timestamp := time.Now()
 
-	resp, err := stepsManager.startBuild(ctx, feeRecipient, timestamp)
+	resp, err := stepsManager.startBuild(ctx, feeRecipient, uint64(timestamp.UnixMilli()))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "latest execution block")
@@ -341,7 +346,8 @@ func TestStepsManager_startBuild_ForkchoiceUpdatedError(t *testing.T) {
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}
@@ -369,7 +375,7 @@ func TestStepsManager_startBuild_ForkchoiceUpdatedError(t *testing.T) {
 
 	mockEngineClient.On("ForkchoiceUpdatedV3", mock.Anything, expectedFCS, expectedAttrs).Return(engine.ForkChoiceResponse{}, errors.New("engine error"))
 
-	resp, err := stepsManager.startBuild(ctx, feeRecipient, timestamp)
+	resp, err := stepsManager.startBuild(ctx, feeRecipient, uint64(timestamp.UnixMilli()))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forkchoice update")
@@ -399,7 +405,8 @@ func TestStepsManager_startBuild_InvalidPayloadStatus(t *testing.T) {
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}
@@ -433,7 +440,7 @@ func TestStepsManager_startBuild_InvalidPayloadStatus(t *testing.T) {
 	}
 	mockEngineClient.On("ForkchoiceUpdatedV3", mock.Anything, expectedFCS, expectedAttrs).Return(forkChoiceResponse, nil)
 
-	resp, err := stepsManager.startBuild(ctx, feeRecipient, timestamp)
+	resp, err := stepsManager.startBuild(ctx, feeRecipient, uint64(timestamp.UnixMilli()))
 
 	require.NoError(t, err)
 	assert.Equal(t, forkChoiceResponse, resp)
@@ -451,7 +458,8 @@ func TestStepsManager_getPayload_startBuildFails(t *testing.T) {
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}
@@ -549,7 +557,8 @@ func TestStepsManager_finalizeBlock_InvalidBlockHeight(t *testing.T) {
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}
@@ -603,7 +612,8 @@ func TestStepsManager_finalizeBlock_NewPayloadInvalidStatus(t *testing.T) {
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}
@@ -664,7 +674,8 @@ func TestStepsManager_finalizeBlock_ForkchoiceUpdatedInvalidStatus(t *testing.T)
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}
@@ -736,7 +747,8 @@ func TestStepsManager_finalizeBlock_SaveExecutionHeadError(t *testing.T) {
 	stepsManager := &StepsManager{
 		stateManager: stateManager,
 		engineCl:     mockEngineClient,
-		buildDelay:   time.Duration(1 * time.Second),
+		buildDelay:   buildDelay,
+		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 		ctx:          ctx,
 	}


### PR DESCRIPTION
## Describe your changes

### Timestamping Blocks without Using System Time
In our consensus layer, we aim to timestamp blocks without relying on the system clock to avoid inconsistencies due to system time adjustments or drifts. Instead, we will use the time difference between engine API calls for setting the block time.

**Block Processing with Engine API Calls:**
For each block, we make 4 engine API calls.
The block time is set in the first engine API call of each block.
**Measuring Time between Blocks:**
To avoid relying on system clock time, we measure the difference in time (let's call this diff) between the first engine API call of Block 1 and the first engine API call of Block 2.
This diff gives us a precise indication of how much time has passed between blocks without depending on the system clock.

**Setting the Timestamp Based on Measured Diff**:
If diff <= 200ms: We assume that block times are proceeding as expected and simply set the new block’s timestamp to:
previous block timestamp + 200ms
If 200ms < diff <= 400ms: We account for the delay between the blocks and set the new timestamp as:
previous block timestamp + 400ms

**This pattern continues for larger differences, where:**
For every multiple of 200ms that the diff exceeds, we increment the block time by that multiple.

By using the measured time difference (diff) between the engine API calls, we eliminate any dependency on the system time for block timestamping. This approach ensures that block time remains predictable and consistent, even in environments where the system clock may fluctuate.

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
