### PR TITLE
fix: invalid character in keystore artifact path

### DIFF
--- a/infrastructure/nomad/playbooks/deploy.yml
+++ b/infrastructure/nomad/playbooks/deploy.yml
@@ -269,7 +269,7 @@
 
               RESULT=$(
                 {{ keystore_generator.stdout }} generate \
-                  --keystore-dir="${DESTINATION_DIR}->{{ keystore_name }}" \
+                  --keystore-dir="${DESTINATION_DIR}--{{ keystore_name }}" \
                   --passphrase="${PASSPHRASE}" \
                   --log-fmt="json"
               )


### PR DESCRIPTION
## Describe your changes

Fixes an invalid character in keystore path that might occur in some environments:
```
Error: The path for one of the files in artifact is not valid: tmp/dist/bridge-emulator->bridge_emulator_account1_keystore/UTC--2024-11-05T19-40-55.053748510Z--4e43fc14501505b04258262dd99cc6eff5b97daa. Contains the following character:  Greater than >
```

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
