### PR TITLE
fix: allocate faucet keystore in genesis

### DIFF
--- a/infrastructure/nomad/playbooks/deploy.yml
+++ b/infrastructure/nomad/playbooks/deploy.yml
@@ -489,13 +489,18 @@
           exit 1
         fi
 
-        ALLOC=$(jq -n --arg address "0x${ALLOCATIONS}" '
-          {
-            ($address): {
-              "balance": "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-            }
-          }
-        ')
+        ALLOC=$(echo '{}' | jq '.')
+        for ADDRESS in ${ALLOCATIONS}; do
+          ALLOC=$(
+            echo "${ALLOC}" | jq --arg address "0x${ADDRESS}" '
+              . + {
+                ($address): {
+                    "balance": "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+                }
+              }
+            '
+         )
+        done
 
         ADDRESS_COUNT=0
         EXTRADATA="0x$(printf '0%.0s' {1..64})"

--- a/infrastructure/nomad/playbooks/variables/profiles.yml
+++ b/infrastructure/nomad/playbooks/variables/profiles.yml
@@ -559,6 +559,7 @@ jobs:
     artifacts:
       - keystores:
           faucet_keystore:
+            allocation: true
     count: 1
     ports:
       - http:


### PR DESCRIPTION
## Describe your changes

Allocates faucet keystore in genesis for testnet/devnet.

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
