### PR TITLE
refactor: change the log level from error to warn for failed grpc dial

### DIFF
--- a/p2p/integrationtest/provider/client.go
+++ b/p2p/integrationtest/provider/client.go
@@ -59,7 +59,7 @@ func NewProviderClient(
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		)
 		if err != nil {
-			logger.Error("failed to dial grpc server", "error", err)
+			logger.Warn("failed to dial grpc server", "error", err)
 			cancel()
 			continue
 		}

--- a/p2p/pkg/node/node.go
+++ b/p2p/pkg/node/node.go
@@ -638,7 +638,7 @@ func NewNode(opts *Options) (*Node, error) {
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		)
 		if err != nil {
-			opts.Logger.Error("failed to dial grpc server", "error", err)
+			opts.Logger.Warn("failed to dial grpc server", "error", err)
 			cancel()
 			continue
 		}

--- a/testing/pkg/orchestrator/orchestrator.go
+++ b/testing/pkg/orchestrator/orchestrator.go
@@ -131,7 +131,7 @@ func newNode(rpcAddr string, logger *slog.Logger) (any, error) {
 			grpc.WithTransportCredentials(e.credential),
 		)
 		if err != nil {
-			logger.Error("failed to dial grpc server", "error", err)
+			logger.Warn("failed to dial grpc server", "error", err)
 			continue
 		}
 


### PR DESCRIPTION
## Describe your changes

Changes the log level from error to warning for unsuccessful GRPC dial attempt(s).

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
