### PR TITLE
chore: scripts for getting validator registry params on mainnet

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -20,3 +20,9 @@ run-withdraw-example:
 
 run-slash-example:
 	forge script scripts/validator-registry/ValidatorExampleScript.s.sol:SlashExample --rpc-url http://localhost:8545 --private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d --via-ir --broadcast
+
+get-vanilla-registry-params:
+	forge script scripts/validator-registry/GetParams.s.sol:GetVanillaRegistryParams --via-ir --rpc-url https://eth.llamarpc.com
+
+get-mev-commit-avs-params:
+	forge script scripts/validator-registry/GetParams.s.sol:GetMevCommitAVSParams --via-ir --rpc-url https://eth.llamarpc.com

--- a/contracts/scripts/validator-registry/GetParams.s.sol
+++ b/contracts/scripts/validator-registry/GetParams.s.sol
@@ -42,7 +42,9 @@ contract GetMevCommitAVSParams is Script {
         bool isPaused = MevCommitAVS(payable(avsAddr)).paused();
         console.log("MevCommitAVS isPaused:", isPaused);
         address[] memory restakeableStrategies = MevCommitAVS(payable(avsAddr)).getRestakeableStrategies();
-        for (uint256 i = 0; i < restakeableStrategies.length; i++) {
+        uint256 len = restakeableStrategies.length;
+        console.log("MevCommitAVS restakeableStrategies length:", len);
+        for (uint256 i = 0; i < len; ++i) {
             console.log("MevCommitAVS restakeableStrategy:", restakeableStrategies[i]);
         }
         address freezeOracle = MevCommitAVSStorage(payable(avsAddr)).freezeOracle();

--- a/contracts/scripts/validator-registry/GetParams.s.sol
+++ b/contracts/scripts/validator-registry/GetParams.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BSL 1.1
+
+// solhint-disable no-console
+// solhint-disable one-contract-per-file
+
+pragma solidity 0.8.26;
+
+import {Script} from "forge-std/Script.sol";
+import {VanillaRegistry} from "../../contracts/validator-registry/VanillaRegistry.sol";
+import {console} from "forge-std/console.sol";
+import {VanillaRegistryStorage} from "../../contracts/validator-registry/VanillaRegistryStorage.sol";
+import {MevCommitAVS} from "../../contracts/validator-registry/avs/MevCommitAVS.sol";
+import {MevCommitAVSStorage} from "../../contracts/validator-registry/avs/MevCommitAVSStorage.sol";
+
+contract GetVanillaRegistryParams is Script {
+    function run() external view {
+        console.log("Getting params for VanillaRegistry on chain:", block.chainid);
+        address vanillaRegAddr = 0x47afdcB2B089C16CEe354811EA1Bbe0DB7c335E9;
+
+        address owner = VanillaRegistry(payable(vanillaRegAddr)).owner();
+        console.log("VanillaRegistry owner:", owner);
+        bool isPaused = VanillaRegistry(payable(vanillaRegAddr)).paused();
+        console.log("VanillaRegistry isPaused:", isPaused);
+        uint256 minStake = VanillaRegistryStorage(payable(vanillaRegAddr)).minStake();
+        console.log("VanillaRegistry minStake:", minStake);
+        address slashOracle = VanillaRegistryStorage(payable(vanillaRegAddr)).slashOracle();
+        console.log("VanillaRegistry slashOracle:", slashOracle);
+        uint256 unstakePeriodBlocks = VanillaRegistryStorage(payable(vanillaRegAddr)).unstakePeriodBlocks();
+        console.log("VanillaRegistry unstakePeriodBlocks:", unstakePeriodBlocks);
+        uint256 accumulatedFunds = VanillaRegistry(payable(vanillaRegAddr)).getAccumulatedSlashingFunds();
+        console.log("VanillaRegistry accumulatedFunds:", accumulatedFunds);
+    }
+}
+
+contract GetMevCommitAVSParams is Script {
+    function run() external view {
+        console.log("Getting params for MevCommitAVS on chain:", block.chainid);
+        address avsAddr = 0xBc77233855e3274E1903771675Eb71E602D9DC2e;
+
+        address avsOwner = MevCommitAVS(payable(avsAddr)).owner();
+        console.log("MevCommitAVS owner:", avsOwner);
+        bool isPaused = MevCommitAVS(payable(avsAddr)).paused();
+        console.log("MevCommitAVS isPaused:", isPaused);
+        address[] memory restakeableStrategies = MevCommitAVS(payable(avsAddr)).getRestakeableStrategies();
+        for (uint256 i = 0; i < restakeableStrategies.length; i++) {
+            console.log("MevCommitAVS restakeableStrategy:", restakeableStrategies[i]);
+        }
+        address freezeOracle = MevCommitAVSStorage(payable(avsAddr)).freezeOracle();
+        console.log("MevCommitAVS freezeOracle:", freezeOracle);
+        uint256 unfreezeFee = MevCommitAVSStorage(payable(avsAddr)).unfreezeFee();
+        console.log("MevCommitAVS unfreezeFee:", unfreezeFee);
+        address unfreezeReceiver = MevCommitAVSStorage(payable(avsAddr)).unfreezeReceiver();
+        console.log("MevCommitAVS unfreezeReceiver:", unfreezeReceiver);
+        uint256 unfreezePeriodBlocks = MevCommitAVSStorage(payable(avsAddr)).unfreezePeriodBlocks();
+        console.log("MevCommitAVS unfreezePeriodBlocks:", unfreezePeriodBlocks);
+        uint256 operatorDeregPeriodBlocks = MevCommitAVSStorage(payable(avsAddr)).operatorDeregPeriodBlocks();
+        console.log("MevCommitAVS operatorDeregPeriodBlocks:", operatorDeregPeriodBlocks);
+        uint256 validatorDeregPeriodBlocks = MevCommitAVSStorage(payable(avsAddr)).validatorDeregPeriodBlocks();
+        console.log("MevCommitAVS validatorDeregPeriod:", validatorDeregPeriodBlocks);
+        uint256 lstRestakerDeregPeriodBlocks = MevCommitAVSStorage(payable(avsAddr)).lstRestakerDeregPeriodBlocks();
+        console.log("MevCommitAVS lstRestakerDeregPeriodBlocks:", lstRestakerDeregPeriodBlocks);
+    }
+}

--- a/contracts/scripts/validator-registry/avs/DeployAVS.s.sol
+++ b/contracts/scripts/validator-registry/avs/DeployAVS.s.sol
@@ -81,7 +81,7 @@ contract DeployMainnet is BaseDeploy {
     function run() external {
         require(block.chainid == 1, "must deploy on mainnet");
         vm.startBroadcast();
-        address[] memory restakeableStrategies = new address[](11);
+        address[] memory restakeableStrategies = new address[](13);
         restakeableStrategies[0] = EigenMainnetReleaseConsts.STRATEGY_BASE_CBETH;
         restakeableStrategies[1] = EigenMainnetReleaseConsts.STRATEGY_BASE_STETH;
         restakeableStrategies[2] = EigenMainnetReleaseConsts.STRATEGY_BASE_RETH;


### PR DESCRIPTION
## Describe your changes

Adds scripts for querying current on-chain params for mainnet contracts. Changes to docs will accompany this PR once merged 

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
