### PR TITLE
fix: ignore errors in preconf tracker and bump handshake

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
@@ -39,6 +39,10 @@ job "{{ job.name }}" {
     task "geth" {
       driver = "exec"
 
+      resources {
+        memory = 4096
+      }
+
       {% for port_name in job.ports[0] %}
       service {
         name = "{{ job.name }}"

--- a/p2p/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/p2p/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	ProtocolName    = "handshake"
-	ProtocolVersion = "6.0.0"
+	ProtocolVersion = "7.0.0"
 	StreamName      = "handshake"
 )
 

--- a/p2p/pkg/preconfirmation/store/store.go
+++ b/p2p/pkg/preconfirmation/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -142,7 +143,7 @@ func (s *Store) SetCommitmentIndexByDigest(cDigest, cIndex [32]byte) error {
 	blkNumBuf, err := s.st.Get(cmtIndexKey(cDigest[:]))
 	s.mu.RUnlock()
 	switch {
-	case err == storage.ErrKeyNotFound:
+	case errors.Is(err, storage.ErrKeyNotFound):
 		// this would happen for most of the commitments as the node only
 		// stores the commitments it is involved in.
 		return nil

--- a/p2p/pkg/storage/pebble/pebble.go
+++ b/p2p/pkg/storage/pebble/pebble.go
@@ -28,8 +28,8 @@ func (s *pebbleStorage) Close() error {
 func (s *pebbleStorage) Get(key string) ([]byte, error) {
 	buf, closer, err := s.db.Get([]byte(key))
 	if err != nil {
-		if err == pebble.ErrNotFound {
-			return nil, storage.ErrKeyNotFound
+		if errors.Is(err, pebble.ErrNotFound) {
+			return nil, errors.Join(storage.ErrKeyNotFound, err)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes
Minor fixes in preconf tracker package to not stop on error. This routine is essential for tracking and opening commitments. So we should not error out unless it is some critical issue.

Also bumping handshake version for release.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
