### PR TITLE
feat: support for operator specific delegators

### DIFF
--- a/contracts/contracts/validator-registry/middleware/MevCommitMiddleware.sol
+++ b/contracts/contracts/validator-registry/middleware/MevCommitMiddleware.sol
@@ -613,7 +613,8 @@ contract MevCommitMiddleware is IMevCommitMiddleware, MevCommitMiddlewareStorage
         IEntity delegator = IEntity(IVault(vault).delegator());
         if (delegator.TYPE() == _FULL_RESTAKE_DELEGATOR_TYPE) {
             revert FullRestakeDelegatorNotSupported(vault);
-        } else if (delegator.TYPE() != _NETWORK_RESTAKE_DELEGATOR_TYPE) {
+        // Only two delegator types are supported, network-restake and operator-specific.
+        } else if (delegator.TYPE() != _NETWORK_RESTAKE_DELEGATOR_TYPE && delegator.TYPE() != _OPERATOR_SPECIFIC_DELEGATOR_TYPE) {
             revert UnknownDelegatorType(vault, delegator.TYPE());
         }
 

--- a/contracts/contracts/validator-registry/middleware/MevCommitMiddlewareStorage.sol
+++ b/contracts/contracts/validator-registry/middleware/MevCommitMiddlewareStorage.sol
@@ -16,6 +16,9 @@ abstract contract MevCommitMiddlewareStorage {
     /// @notice Enum TYPE for Symbiotic core FullRestakeDelegator.
     uint64 internal constant _FULL_RESTAKE_DELEGATOR_TYPE = 1;
 
+    /// @notice Enum TYPE for Symbiotic core OperatorSpecificDelegator.
+    uint64 internal constant _OPERATOR_SPECIFIC_DELEGATOR_TYPE = 2;
+
     /// @notice Enum TYPE for Symbiotic core InstantSlasher.
     uint64 internal constant _INSTANT_SLASHER_TYPE = 0;
 

--- a/contracts/contracts/validator-registry/middleware/README.md
+++ b/contracts/contracts/validator-registry/middleware/README.md
@@ -16,7 +16,7 @@ For L1 validators to be *opted-in to mev-commit*, some collateral stake must be 
 
 Operators for the mev-commit network are responsible for bulk registering groups of L1 validator pubkeys to an associated vault. Every registered validator is represented by restaked collateral from a single Vault and Operator. Each Vault’s total collateral can be split up to secure/represent many validators in groups**.**
 
-Our network middleware contract requires any Vault registering with the contract to have a delegator of the `NetworkRestakeDelegator` type. `FullRestakeDelegator` is disallowed due to its ability for vaults to reuse stake within the same network to multiple Operators. In other words, a single instance of `slashAmount` vault collateral can only be used to secure a single validator.
+Our network middleware contract requires any Vault registering with the contract to have a delegator of the `NetworkRestakeDelegator` type or `OperatorSpecificDelegator` type. `FullRestakeDelegator` is disallowed due to its ability for vaults to reuse stake within the same network to multiple Operators. In other words, a single instance of `slashAmount` vault collateral can only be used to secure a single validator, through a single Operator. Vaults are still able to split their slashable collateral across multiple Operators.
 
 # Steps for validator opt-in via symbiotic
 

--- a/contracts/test/validator-registry/middleware/MevCommitMiddlewareTest.sol
+++ b/contracts/test/validator-registry/middleware/MevCommitMiddlewareTest.sol
@@ -583,9 +583,10 @@ contract MevCommitMiddlewareTest is Test {
         mevCommitMiddleware.registerVaults(vaults, slashAmounts);
 
         uint64 networkRestakeDelegatorType = 0;
+        uint64 operatorSpecificDelegatorType = 2;
 
         mockDelegator1.setType(networkRestakeDelegatorType);
-        mockDelegator2.setType(networkRestakeDelegatorType);
+        mockDelegator2.setType(operatorSpecificDelegatorType);
 
         vm.prank(owner);
         vm.expectRevert(


### PR DESCRIPTION
## Describe your changes

Adds support for Symbiotic's operator specific delegators. These types of delegators should be fully compatible with our middleware and are the most simple type of delegator (a vault can only allocate stake to a single operator).

See https://docs.symbiotic.fi/modules/vault/delegator#operatorspecificdelegator

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
