### PR TITLE
fix: set L1 chain ID for holesky

### DIFF
--- a/bridge/standard/cmd/user_cli/main.go
+++ b/bridge/standard/cmd/user_cli/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/primev/mev-commit/bridge/standard/pkg/transfer"
+	"github.com/primev/mev-commit/contracts-abi/config"
 	"github.com/primev/mev-commit/x/keysigner"
 	"github.com/theckman/yacspin"
 	"github.com/urfave/cli/v2"
@@ -49,24 +50,28 @@ var (
 		Usage:    "URL for L1 RPC",
 		EnvVars:  []string{"L1_RPC_URL"},
 		Required: true,
+		Value:    "https://ethereum-holesky-rpc.publicnode.com",
 	}
 	optionSettlementRPCUrl = &cli.StringFlag{
 		Name:     "settlement-rpc-url",
 		Usage:    "URL for settlement RPC",
 		EnvVars:  []string{"SETTLEMENT_RPC_URL"},
 		Required: true,
+		Value:    "https://chainrpc.testnet.mev-commit.xyz",
 	}
 	optionL1ContractAddr = &cli.StringFlag{
 		Name:     "l1-contract-addr",
 		Usage:    "address of the L1 gateway contract",
 		EnvVars:  []string{"L1_CONTRACT_ADDR"},
 		Required: true,
+		Value:    config.HoleskyContracts.L1Gateway,
 	}
 	optionSettlementContractAddr = &cli.StringFlag{
 		Name:     "settlement-contract-addr",
 		Usage:    "address of the settlement gateway contract",
 		EnvVars:  []string{"SETTLEMENT_CONTRACT_ADDR"},
 		Required: true,
+		Value:    config.TestnetContracts.SettlementGateway,
 	}
 	optionSilent = &cli.BoolFlag{
 		Name:    "silent",

--- a/contracts-abi/config/testnet.go
+++ b/contracts-abi/config/testnet.go
@@ -1,17 +1,19 @@
 package config
 
 type Contracts struct {
-	BidderRegistry   string
-	ProviderRegistry string
-	PreconfManager   string
-	Oracle           string
-	BlockTracker     string
+	BidderRegistry    string
+	ProviderRegistry  string
+	PreconfManager    string
+	Oracle            string
+	BlockTracker      string
+	SettlementGateway string
 }
 
 type L1Contracts struct {
 	ValidatorOptInRouter string
 	VanillaRegistry      string
 	MevCommitAVS         string
+	L1Gateway            string
 }
 
 var TestnetContracts = Contracts{

--- a/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
@@ -216,6 +216,7 @@ job "{{ job.name }}" {
 
           {%- if profile == 'testnet' %}
           export RPC_URL="{{ job.env['l1_rpc_url'] }}"
+          export CHAIN_ID="17000"
           {%- endif %}
 
           {%- raw %}


### PR DESCRIPTION
## Describe your changes
Currently it is using our mev-commit chain ID to issue the transaction to holesky for contract deployment.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
