### PR TITLE
feat: symbiotic burner router integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "contracts/lib/openzeppelin-upgrades"]
 	path = contracts/lib/openzeppelin-upgrades
 	url = https://github.com/OpenZeppelin/openzeppelin-upgrades.git
+[submodule "contracts/lib/burners"]
+	path = contracts/lib/burners
+	url = https://github.com/symbioticfi/burners

--- a/contracts-abi/abi/MevCommitMiddleware.abi
+++ b/contracts-abi/abi/MevCommitMiddleware.abi
@@ -47,6 +47,19 @@
   },
   {
     "type": "function",
+    "name": "burnerRouterFactory",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IRegistry"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "deregisterOperators",
     "inputs": [
       {
@@ -200,6 +213,11 @@
         "internalType": "contract IRegistry"
       },
       {
+        "name": "_burnerRouterFactory",
+        "type": "address",
+        "internalType": "contract IRegistry"
+      },
+      {
         "name": "_network",
         "type": "address",
         "internalType": "address"
@@ -213,6 +231,16 @@
         "name": "_slashOracle",
         "type": "address",
         "internalType": "address"
+      },
+      {
+        "name": "_slashReceiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_minBurnerRouterDelay",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
         "name": "_owner",
@@ -257,6 +285,62 @@
         "name": "",
         "type": "bool",
         "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isVaultBurnerValid",
+    "inputs": [
+      {
+        "name": "vault",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isVaultBurnerValidAgainstOperator",
+    "inputs": [
+      {
+        "name": "vault",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "minBurnerRouterDelay",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "stateMutability": "view"
@@ -550,6 +634,32 @@
   },
   {
     "type": "function",
+    "name": "setBurnerRouterFactory",
+    "inputs": [
+      {
+        "name": "_burnerRouterFactory",
+        "type": "address",
+        "internalType": "contract IRegistry"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMinBurnerRouterDelay",
+    "inputs": [
+      {
+        "name": "minBurnerRouterDelay_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "setNetwork",
     "inputs": [
       {
@@ -615,6 +725,19 @@
   },
   {
     "type": "function",
+    "name": "setSlashReceiver",
+    "inputs": [
+      {
+        "name": "slashReceiver_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "setVaultFactory",
     "inputs": [
       {
@@ -648,6 +771,19 @@
         "name": "",
         "type": "uint256",
         "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "slashReceiver",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
       }
     ],
     "stateMutability": "view"
@@ -947,6 +1083,19 @@
   },
   {
     "type": "event",
+    "name": "BurnerRouterFactorySet",
+    "inputs": [
+      {
+        "name": "burnerRouterFactory",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "Initialized",
     "inputs": [
       {
@@ -954,6 +1103,19 @@
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MinBurnerRouterDelaySet",
+    "inputs": [
+      {
+        "name": "minBurnerRouterDelay",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
       }
     ],
     "anonymous": false
@@ -1148,6 +1310,19 @@
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SlashReceiverSet",
+    "inputs": [
+      {
+        "name": "slashReceiver",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
       }
     ],
     "anonymous": false
@@ -1538,6 +1713,33 @@
     "type": "error",
     "name": "InvalidReceive",
     "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidVaultBurner",
+    "inputs": [
+      {
+        "name": "vault",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidVaultBurnerConsideringOperator",
+    "inputs": [
+      {
+        "name": "vault",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
   },
   {
     "type": "error",

--- a/contracts-abi/clients/MevCommitMiddleware/MevCommitMiddleware.go
+++ b/contracts-abi/clients/MevCommitMiddleware/MevCommitMiddleware.go
@@ -48,7 +48,7 @@ type TimestampOccurrenceOccurrence struct {
 
 // MevcommitmiddlewareMetaData contains all meta data concerning the Mevcommitmiddleware contract.
 var MevcommitmiddlewareMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"blacklistOperators\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregisterOperators\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregisterValidators\",\"inputs\":[{\"name\":\"blsPubkeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregisterVaults\",\"inputs\":[{\"name\":\"vaults\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getLatestSlashAmount\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint160\",\"internalType\":\"uint160\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNumSlashableVals\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getPositionInValset\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getSlashAmountAt\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"blockTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint160\",\"internalType\":\"uint160\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_networkRegistry\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"},{\"name\":\"_operatorRegistry\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"},{\"name\":\"_vaultFactory\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"},{\"name\":\"_network\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_slashPeriodSeconds\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_slashOracle\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isValidatorOptedIn\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorSlashable\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"network\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"networkRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"operatorRecords\",\"inputs\":[{\"name\":\"operatorAddress\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"deregRequestOccurrence\",\"type\":\"tuple\",\"internalType\":\"structTimestampOccurrence.Occurrence\",\"components\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"timestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"isBlacklisted\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"operatorRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"potentialSlashableValidators\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pubkeyAtPositionInValset\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"registerOperators\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registerValidators\",\"inputs\":[{\"name\":\"blsPubkeys\",\"type\":\"bytes[][]\",\"internalType\":\"bytes[][]\"},{\"name\":\"vaults\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registerVaults\",\"inputs\":[{\"name\":\"vaults\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"slashAmounts\",\"type\":\"uint160[]\",\"internalType\":\"uint160[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestOperatorDeregistrations\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestValDeregistrations\",\"inputs\":[{\"name\":\"blsPubkeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestVaultDeregistrations\",\"inputs\":[{\"name\":\"vaults\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setNetwork\",\"inputs\":[{\"name\":\"_network\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setNetworkRegistry\",\"inputs\":[{\"name\":\"_networkRegistry\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setOperatorRegistry\",\"inputs\":[{\"name\":\"_operatorRegistry\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setSlashOracle\",\"inputs\":[{\"name\":\"slashOracle_\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setSlashPeriodSeconds\",\"inputs\":[{\"name\":\"slashPeriodSeconds_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setVaultFactory\",\"inputs\":[{\"name\":\"_vaultFactory\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"slashOracle\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashPeriodSeconds\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashRecords\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"blockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"numSlashed\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"numRegistered\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashValidators\",\"inputs\":[{\"name\":\"blsPubkeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"},{\"name\":\"captureTimestamps\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unblacklistOperators\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"updateSlashAmounts\",\"inputs\":[{\"name\":\"vaults\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"slashAmounts\",\"type\":\"uint160[]\",\"internalType\":\"uint160[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"validatorRecords\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"deregRequestOccurrence\",\"type\":\"tuple\",\"internalType\":\"structTimestampOccurrence.Occurrence\",\"components\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"timestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"valsetLength\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"vaultFactory\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"vaultRecords\",\"inputs\":[{\"name\":\"vaultAddress\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"deregRequestOccurrence\",\"type\":\"tuple\",\"internalType\":\"structTimestampOccurrence.Occurrence\",\"components\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"timestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"slashAmountHistory\",\"type\":\"tuple\",\"internalType\":\"structCheckpoints.Trace160\",\"components\":[{\"name\":\"_checkpoints\",\"type\":\"tuple[]\",\"internalType\":\"structCheckpoints.Checkpoint160[]\",\"components\":[{\"name\":\"_key\",\"type\":\"uint96\",\"internalType\":\"uint96\"},{\"name\":\"_value\",\"type\":\"uint160\",\"internalType\":\"uint160\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"wouldVaultBeValidWith\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"potentialSLashPeriodSeconds\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"NetworkRegistrySet\",\"inputs\":[{\"name\":\"networkRegistry\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"NetworkSet\",\"inputs\":[{\"name\":\"network\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorBlacklisted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorDeregistered\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorDeregistrationRequested\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorRegistered\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorRegistrySet\",\"inputs\":[{\"name\":\"operatorRegistry\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorUnblacklisted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashOracleSet\",\"inputs\":[{\"name\":\"slashOracle\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashPeriodBlocksSet\",\"inputs\":[{\"name\":\"slashPeriodBlocks\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashPeriodSecondsSet\",\"inputs\":[{\"name\":\"slashPeriodSeconds\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValRecordAdded\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"position\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValRecordDeleted\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"msgSender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorDeregistrationRequested\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"msgSender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"position\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorPositionsSwapped\",\"inputs\":[{\"name\":\"blsPubkeys\",\"type\":\"bytes[]\",\"indexed\":false,\"internalType\":\"bytes[]\"},{\"name\":\"vaults\",\"type\":\"address[]\",\"indexed\":false,\"internalType\":\"address[]\"},{\"name\":\"operators\",\"type\":\"address[]\",\"indexed\":false,\"internalType\":\"address[]\"},{\"name\":\"newPositions\",\"type\":\"uint256[]\",\"indexed\":false,\"internalType\":\"uint256[]\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorSlashed\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"slashedAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VaultDeregistered\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VaultDeregistrationRequested\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VaultFactorySet\",\"inputs\":[{\"name\":\"vaultFactory\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VaultRegistered\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"slashAmount\",\"type\":\"uint160\",\"indexed\":false,\"internalType\":\"uint160\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VaultSlashAmountUpdated\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"slashAmount\",\"type\":\"uint160\",\"indexed\":false,\"internalType\":\"uint160\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"CaptureTimestampMustBeNonZero\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CheckpointUnorderedInsertion\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedToAddValidatorToValset\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"FullRestakeDelegatorNotSupported\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"FutureTimestampDisallowed\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidArrayLengths\",\"inputs\":[{\"name\":\"vaultLen\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pubkeyLen\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidBLSPubKeyLength\",\"inputs\":[{\"name\":\"expectedLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"actualLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReceive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidVaultEpochDuration\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"vaultEpochDurationSec\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"slashPeriodSec\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"MissingOperatorRecord\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"MissingValRecord\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"MissingValidatorRecord\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"MissingVaultRecord\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NetworkNotEntity\",\"inputs\":[{\"name\":\"network\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NoRegisteredValidators\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NoSlashAmountAtTimestamp\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OnlyOperator\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OnlySlashOracle\",\"inputs\":[{\"name\":\"slashOracle\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OnlyVetoSlashersRequireExecution\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"slasherType\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"OperatorAlreadyBlacklisted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorAlreadyRegistered\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorDeregRequestExists\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorIsBlacklisted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorNotBlacklisted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorNotEntity\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorNotReadyToDeregister\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"currentTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deregRequestTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"OperatorNotRegistered\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"SafeCastOverflowedUintDowncast\",\"inputs\":[{\"name\":\"bits\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"SlashAmountMustBeNonZero\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"SlasherNotSetForVault\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnknownDelegatorType\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegatorType\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UnknownSlasherType\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"slasherType\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ValidatorDeregRequestExists\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotInValset\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotReadyToDeregister\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"currentTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deregRequestTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotRemovedFromValset\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotSlashable\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ValidatorRecordAlreadyExists\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorsNotSlashable\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"numRequested\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"potentialSlashableVals\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"VaultAlreadyRegistered\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"VaultDeregNotRequested\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"VaultDeregRequestExists\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"VaultNotEntity\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"VaultNotReadyToDeregister\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"currentTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deregRequestTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"VaultNotRegistered\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"VetoDurationTooShort\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"vetoDuration\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"VetoSlasherMustHaveZeroResolver\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddressNotAllowed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroUintNotAllowed\",\"inputs\":[]}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"blacklistOperators\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"burnerRouterFactory\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"deregisterOperators\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregisterValidators\",\"inputs\":[{\"name\":\"blsPubkeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregisterVaults\",\"inputs\":[{\"name\":\"vaults\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getLatestSlashAmount\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint160\",\"internalType\":\"uint160\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNumSlashableVals\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getPositionInValset\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getSlashAmountAt\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"blockTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint160\",\"internalType\":\"uint160\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_networkRegistry\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"},{\"name\":\"_operatorRegistry\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"},{\"name\":\"_vaultFactory\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"},{\"name\":\"_burnerRouterFactory\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"},{\"name\":\"_network\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_slashPeriodSeconds\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_slashOracle\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_slashReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_minBurnerRouterDelay\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isValidatorOptedIn\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorSlashable\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isVaultBurnerValid\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isVaultBurnerValidAgainstOperator\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"minBurnerRouterDelay\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"network\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"networkRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"operatorRecords\",\"inputs\":[{\"name\":\"operatorAddress\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"deregRequestOccurrence\",\"type\":\"tuple\",\"internalType\":\"structTimestampOccurrence.Occurrence\",\"components\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"timestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"isBlacklisted\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"operatorRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"potentialSlashableValidators\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pubkeyAtPositionInValset\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"registerOperators\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registerValidators\",\"inputs\":[{\"name\":\"blsPubkeys\",\"type\":\"bytes[][]\",\"internalType\":\"bytes[][]\"},{\"name\":\"vaults\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registerVaults\",\"inputs\":[{\"name\":\"vaults\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"slashAmounts\",\"type\":\"uint160[]\",\"internalType\":\"uint160[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestOperatorDeregistrations\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestValDeregistrations\",\"inputs\":[{\"name\":\"blsPubkeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestVaultDeregistrations\",\"inputs\":[{\"name\":\"vaults\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setBurnerRouterFactory\",\"inputs\":[{\"name\":\"_burnerRouterFactory\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMinBurnerRouterDelay\",\"inputs\":[{\"name\":\"minBurnerRouterDelay_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setNetwork\",\"inputs\":[{\"name\":\"_network\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setNetworkRegistry\",\"inputs\":[{\"name\":\"_networkRegistry\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setOperatorRegistry\",\"inputs\":[{\"name\":\"_operatorRegistry\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setSlashOracle\",\"inputs\":[{\"name\":\"slashOracle_\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setSlashPeriodSeconds\",\"inputs\":[{\"name\":\"slashPeriodSeconds_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setSlashReceiver\",\"inputs\":[{\"name\":\"slashReceiver_\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setVaultFactory\",\"inputs\":[{\"name\":\"_vaultFactory\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"slashOracle\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashPeriodSeconds\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashReceiver\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashRecords\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"blockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"numSlashed\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"numRegistered\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashValidators\",\"inputs\":[{\"name\":\"blsPubkeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"},{\"name\":\"captureTimestamps\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unblacklistOperators\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"updateSlashAmounts\",\"inputs\":[{\"name\":\"vaults\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"slashAmounts\",\"type\":\"uint160[]\",\"internalType\":\"uint160[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"validatorRecords\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"deregRequestOccurrence\",\"type\":\"tuple\",\"internalType\":\"structTimestampOccurrence.Occurrence\",\"components\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"timestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"valsetLength\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"vaultFactory\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"vaultRecords\",\"inputs\":[{\"name\":\"vaultAddress\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"deregRequestOccurrence\",\"type\":\"tuple\",\"internalType\":\"structTimestampOccurrence.Occurrence\",\"components\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"timestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"slashAmountHistory\",\"type\":\"tuple\",\"internalType\":\"structCheckpoints.Trace160\",\"components\":[{\"name\":\"_checkpoints\",\"type\":\"tuple[]\",\"internalType\":\"structCheckpoints.Checkpoint160[]\",\"components\":[{\"name\":\"_key\",\"type\":\"uint96\",\"internalType\":\"uint96\"},{\"name\":\"_value\",\"type\":\"uint160\",\"internalType\":\"uint160\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"wouldVaultBeValidWith\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"potentialSLashPeriodSeconds\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"BurnerRouterFactorySet\",\"inputs\":[{\"name\":\"burnerRouterFactory\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MinBurnerRouterDelaySet\",\"inputs\":[{\"name\":\"minBurnerRouterDelay\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"NetworkRegistrySet\",\"inputs\":[{\"name\":\"networkRegistry\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"NetworkSet\",\"inputs\":[{\"name\":\"network\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorBlacklisted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorDeregistered\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorDeregistrationRequested\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorRegistered\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorRegistrySet\",\"inputs\":[{\"name\":\"operatorRegistry\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorUnblacklisted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashOracleSet\",\"inputs\":[{\"name\":\"slashOracle\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashPeriodBlocksSet\",\"inputs\":[{\"name\":\"slashPeriodBlocks\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashPeriodSecondsSet\",\"inputs\":[{\"name\":\"slashPeriodSeconds\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashReceiverSet\",\"inputs\":[{\"name\":\"slashReceiver\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValRecordAdded\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"position\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValRecordDeleted\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"msgSender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorDeregistrationRequested\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"msgSender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"position\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorPositionsSwapped\",\"inputs\":[{\"name\":\"blsPubkeys\",\"type\":\"bytes[]\",\"indexed\":false,\"internalType\":\"bytes[]\"},{\"name\":\"vaults\",\"type\":\"address[]\",\"indexed\":false,\"internalType\":\"address[]\"},{\"name\":\"operators\",\"type\":\"address[]\",\"indexed\":false,\"internalType\":\"address[]\"},{\"name\":\"newPositions\",\"type\":\"uint256[]\",\"indexed\":false,\"internalType\":\"uint256[]\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorSlashed\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"slashedAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VaultDeregistered\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VaultDeregistrationRequested\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VaultFactorySet\",\"inputs\":[{\"name\":\"vaultFactory\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VaultRegistered\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"slashAmount\",\"type\":\"uint160\",\"indexed\":false,\"internalType\":\"uint160\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VaultSlashAmountUpdated\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"slashAmount\",\"type\":\"uint160\",\"indexed\":false,\"internalType\":\"uint160\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"CaptureTimestampMustBeNonZero\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CheckpointUnorderedInsertion\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedToAddValidatorToValset\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"FullRestakeDelegatorNotSupported\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"FutureTimestampDisallowed\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidArrayLengths\",\"inputs\":[{\"name\":\"vaultLen\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pubkeyLen\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidBLSPubKeyLength\",\"inputs\":[{\"name\":\"expectedLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"actualLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReceive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidVaultBurner\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"InvalidVaultBurnerConsideringOperator\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"InvalidVaultEpochDuration\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"vaultEpochDurationSec\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"slashPeriodSec\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"MissingOperatorRecord\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"MissingValRecord\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"MissingValidatorRecord\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"MissingVaultRecord\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NetworkNotEntity\",\"inputs\":[{\"name\":\"network\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NoRegisteredValidators\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NoSlashAmountAtTimestamp\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OnlyOperator\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OnlySlashOracle\",\"inputs\":[{\"name\":\"slashOracle\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OnlyVetoSlashersRequireExecution\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"slasherType\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"OperatorAlreadyBlacklisted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorAlreadyRegistered\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorDeregRequestExists\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorIsBlacklisted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorNotBlacklisted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorNotEntity\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OperatorNotReadyToDeregister\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"currentTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deregRequestTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"OperatorNotRegistered\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"SafeCastOverflowedUintDowncast\",\"inputs\":[{\"name\":\"bits\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"SlashAmountMustBeNonZero\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"SlasherNotSetForVault\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnknownDelegatorType\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegatorType\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UnknownSlasherType\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"slasherType\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ValidatorDeregRequestExists\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotInValset\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotReadyToDeregister\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"currentTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deregRequestTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotRemovedFromValset\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotSlashable\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ValidatorRecordAlreadyExists\",\"inputs\":[{\"name\":\"blsPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorsNotSlashable\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"numRequested\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"potentialSlashableVals\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"VaultAlreadyRegistered\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"VaultDeregNotRequested\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"VaultDeregRequestExists\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"VaultNotEntity\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"VaultNotReadyToDeregister\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"currentTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deregRequestTimestamp\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"VaultNotRegistered\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"VetoDurationTooShort\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"vetoDuration\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"VetoSlasherMustHaveZeroResolver\",\"inputs\":[{\"name\":\"vault\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddressNotAllowed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroUintNotAllowed\",\"inputs\":[]}]",
 }
 
 // MevcommitmiddlewareABI is the input ABI used to generate the binding from.
@@ -226,6 +226,37 @@ func (_Mevcommitmiddleware *MevcommitmiddlewareSession) UPGRADEINTERFACEVERSION(
 // Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
 func (_Mevcommitmiddleware *MevcommitmiddlewareCallerSession) UPGRADEINTERFACEVERSION() (string, error) {
 	return _Mevcommitmiddleware.Contract.UPGRADEINTERFACEVERSION(&_Mevcommitmiddleware.CallOpts)
+}
+
+// BurnerRouterFactory is a free data retrieval call binding the contract method 0xc70a3c5f.
+//
+// Solidity: function burnerRouterFactory() view returns(address)
+func (_Mevcommitmiddleware *MevcommitmiddlewareCaller) BurnerRouterFactory(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Mevcommitmiddleware.contract.Call(opts, &out, "burnerRouterFactory")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// BurnerRouterFactory is a free data retrieval call binding the contract method 0xc70a3c5f.
+//
+// Solidity: function burnerRouterFactory() view returns(address)
+func (_Mevcommitmiddleware *MevcommitmiddlewareSession) BurnerRouterFactory() (common.Address, error) {
+	return _Mevcommitmiddleware.Contract.BurnerRouterFactory(&_Mevcommitmiddleware.CallOpts)
+}
+
+// BurnerRouterFactory is a free data retrieval call binding the contract method 0xc70a3c5f.
+//
+// Solidity: function burnerRouterFactory() view returns(address)
+func (_Mevcommitmiddleware *MevcommitmiddlewareCallerSession) BurnerRouterFactory() (common.Address, error) {
+	return _Mevcommitmiddleware.Contract.BurnerRouterFactory(&_Mevcommitmiddleware.CallOpts)
 }
 
 // GetLatestSlashAmount is a free data retrieval call binding the contract method 0xb39edc0f.
@@ -412,6 +443,99 @@ func (_Mevcommitmiddleware *MevcommitmiddlewareSession) IsValidatorSlashable(bls
 // Solidity: function isValidatorSlashable(bytes blsPubkey) view returns(bool)
 func (_Mevcommitmiddleware *MevcommitmiddlewareCallerSession) IsValidatorSlashable(blsPubkey []byte) (bool, error) {
 	return _Mevcommitmiddleware.Contract.IsValidatorSlashable(&_Mevcommitmiddleware.CallOpts, blsPubkey)
+}
+
+// IsVaultBurnerValid is a free data retrieval call binding the contract method 0x80bd4e93.
+//
+// Solidity: function isVaultBurnerValid(address vault) view returns(bool)
+func (_Mevcommitmiddleware *MevcommitmiddlewareCaller) IsVaultBurnerValid(opts *bind.CallOpts, vault common.Address) (bool, error) {
+	var out []interface{}
+	err := _Mevcommitmiddleware.contract.Call(opts, &out, "isVaultBurnerValid", vault)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsVaultBurnerValid is a free data retrieval call binding the contract method 0x80bd4e93.
+//
+// Solidity: function isVaultBurnerValid(address vault) view returns(bool)
+func (_Mevcommitmiddleware *MevcommitmiddlewareSession) IsVaultBurnerValid(vault common.Address) (bool, error) {
+	return _Mevcommitmiddleware.Contract.IsVaultBurnerValid(&_Mevcommitmiddleware.CallOpts, vault)
+}
+
+// IsVaultBurnerValid is a free data retrieval call binding the contract method 0x80bd4e93.
+//
+// Solidity: function isVaultBurnerValid(address vault) view returns(bool)
+func (_Mevcommitmiddleware *MevcommitmiddlewareCallerSession) IsVaultBurnerValid(vault common.Address) (bool, error) {
+	return _Mevcommitmiddleware.Contract.IsVaultBurnerValid(&_Mevcommitmiddleware.CallOpts, vault)
+}
+
+// IsVaultBurnerValidAgainstOperator is a free data retrieval call binding the contract method 0x7d194fdf.
+//
+// Solidity: function isVaultBurnerValidAgainstOperator(address vault, address operator) view returns(bool)
+func (_Mevcommitmiddleware *MevcommitmiddlewareCaller) IsVaultBurnerValidAgainstOperator(opts *bind.CallOpts, vault common.Address, operator common.Address) (bool, error) {
+	var out []interface{}
+	err := _Mevcommitmiddleware.contract.Call(opts, &out, "isVaultBurnerValidAgainstOperator", vault, operator)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsVaultBurnerValidAgainstOperator is a free data retrieval call binding the contract method 0x7d194fdf.
+//
+// Solidity: function isVaultBurnerValidAgainstOperator(address vault, address operator) view returns(bool)
+func (_Mevcommitmiddleware *MevcommitmiddlewareSession) IsVaultBurnerValidAgainstOperator(vault common.Address, operator common.Address) (bool, error) {
+	return _Mevcommitmiddleware.Contract.IsVaultBurnerValidAgainstOperator(&_Mevcommitmiddleware.CallOpts, vault, operator)
+}
+
+// IsVaultBurnerValidAgainstOperator is a free data retrieval call binding the contract method 0x7d194fdf.
+//
+// Solidity: function isVaultBurnerValidAgainstOperator(address vault, address operator) view returns(bool)
+func (_Mevcommitmiddleware *MevcommitmiddlewareCallerSession) IsVaultBurnerValidAgainstOperator(vault common.Address, operator common.Address) (bool, error) {
+	return _Mevcommitmiddleware.Contract.IsVaultBurnerValidAgainstOperator(&_Mevcommitmiddleware.CallOpts, vault, operator)
+}
+
+// MinBurnerRouterDelay is a free data retrieval call binding the contract method 0x8f55b4f0.
+//
+// Solidity: function minBurnerRouterDelay() view returns(uint256)
+func (_Mevcommitmiddleware *MevcommitmiddlewareCaller) MinBurnerRouterDelay(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Mevcommitmiddleware.contract.Call(opts, &out, "minBurnerRouterDelay")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MinBurnerRouterDelay is a free data retrieval call binding the contract method 0x8f55b4f0.
+//
+// Solidity: function minBurnerRouterDelay() view returns(uint256)
+func (_Mevcommitmiddleware *MevcommitmiddlewareSession) MinBurnerRouterDelay() (*big.Int, error) {
+	return _Mevcommitmiddleware.Contract.MinBurnerRouterDelay(&_Mevcommitmiddleware.CallOpts)
+}
+
+// MinBurnerRouterDelay is a free data retrieval call binding the contract method 0x8f55b4f0.
+//
+// Solidity: function minBurnerRouterDelay() view returns(uint256)
+func (_Mevcommitmiddleware *MevcommitmiddlewareCallerSession) MinBurnerRouterDelay() (*big.Int, error) {
+	return _Mevcommitmiddleware.Contract.MinBurnerRouterDelay(&_Mevcommitmiddleware.CallOpts)
 }
 
 // Network is a free data retrieval call binding the contract method 0x6739afca.
@@ -805,6 +929,37 @@ func (_Mevcommitmiddleware *MevcommitmiddlewareCallerSession) SlashPeriodSeconds
 	return _Mevcommitmiddleware.Contract.SlashPeriodSeconds(&_Mevcommitmiddleware.CallOpts)
 }
 
+// SlashReceiver is a free data retrieval call binding the contract method 0x1bc4e5fb.
+//
+// Solidity: function slashReceiver() view returns(address)
+func (_Mevcommitmiddleware *MevcommitmiddlewareCaller) SlashReceiver(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Mevcommitmiddleware.contract.Call(opts, &out, "slashReceiver")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// SlashReceiver is a free data retrieval call binding the contract method 0x1bc4e5fb.
+//
+// Solidity: function slashReceiver() view returns(address)
+func (_Mevcommitmiddleware *MevcommitmiddlewareSession) SlashReceiver() (common.Address, error) {
+	return _Mevcommitmiddleware.Contract.SlashReceiver(&_Mevcommitmiddleware.CallOpts)
+}
+
+// SlashReceiver is a free data retrieval call binding the contract method 0x1bc4e5fb.
+//
+// Solidity: function slashReceiver() view returns(address)
+func (_Mevcommitmiddleware *MevcommitmiddlewareCallerSession) SlashReceiver() (common.Address, error) {
+	return _Mevcommitmiddleware.Contract.SlashReceiver(&_Mevcommitmiddleware.CallOpts)
+}
+
 // SlashRecords is a free data retrieval call binding the contract method 0x1da9f192.
 //
 // Solidity: function slashRecords(address vault, address operator, uint256 blockNumber) view returns(bool exists, uint256 numSlashed, uint256 numRegistered)
@@ -1158,25 +1313,25 @@ func (_Mevcommitmiddleware *MevcommitmiddlewareTransactorSession) DeregisterVaul
 	return _Mevcommitmiddleware.Contract.DeregisterVaults(&_Mevcommitmiddleware.TransactOpts, vaults)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0x0eaf43f2.
+// Initialize is a paid mutator transaction binding the contract method 0xc6636056.
 //
-// Solidity: function initialize(address _networkRegistry, address _operatorRegistry, address _vaultFactory, address _network, uint256 _slashPeriodSeconds, address _slashOracle, address _owner) returns()
-func (_Mevcommitmiddleware *MevcommitmiddlewareTransactor) Initialize(opts *bind.TransactOpts, _networkRegistry common.Address, _operatorRegistry common.Address, _vaultFactory common.Address, _network common.Address, _slashPeriodSeconds *big.Int, _slashOracle common.Address, _owner common.Address) (*types.Transaction, error) {
-	return _Mevcommitmiddleware.contract.Transact(opts, "initialize", _networkRegistry, _operatorRegistry, _vaultFactory, _network, _slashPeriodSeconds, _slashOracle, _owner)
+// Solidity: function initialize(address _networkRegistry, address _operatorRegistry, address _vaultFactory, address _burnerRouterFactory, address _network, uint256 _slashPeriodSeconds, address _slashOracle, address _slashReceiver, uint256 _minBurnerRouterDelay, address _owner) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareTransactor) Initialize(opts *bind.TransactOpts, _networkRegistry common.Address, _operatorRegistry common.Address, _vaultFactory common.Address, _burnerRouterFactory common.Address, _network common.Address, _slashPeriodSeconds *big.Int, _slashOracle common.Address, _slashReceiver common.Address, _minBurnerRouterDelay *big.Int, _owner common.Address) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.contract.Transact(opts, "initialize", _networkRegistry, _operatorRegistry, _vaultFactory, _burnerRouterFactory, _network, _slashPeriodSeconds, _slashOracle, _slashReceiver, _minBurnerRouterDelay, _owner)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0x0eaf43f2.
+// Initialize is a paid mutator transaction binding the contract method 0xc6636056.
 //
-// Solidity: function initialize(address _networkRegistry, address _operatorRegistry, address _vaultFactory, address _network, uint256 _slashPeriodSeconds, address _slashOracle, address _owner) returns()
-func (_Mevcommitmiddleware *MevcommitmiddlewareSession) Initialize(_networkRegistry common.Address, _operatorRegistry common.Address, _vaultFactory common.Address, _network common.Address, _slashPeriodSeconds *big.Int, _slashOracle common.Address, _owner common.Address) (*types.Transaction, error) {
-	return _Mevcommitmiddleware.Contract.Initialize(&_Mevcommitmiddleware.TransactOpts, _networkRegistry, _operatorRegistry, _vaultFactory, _network, _slashPeriodSeconds, _slashOracle, _owner)
+// Solidity: function initialize(address _networkRegistry, address _operatorRegistry, address _vaultFactory, address _burnerRouterFactory, address _network, uint256 _slashPeriodSeconds, address _slashOracle, address _slashReceiver, uint256 _minBurnerRouterDelay, address _owner) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareSession) Initialize(_networkRegistry common.Address, _operatorRegistry common.Address, _vaultFactory common.Address, _burnerRouterFactory common.Address, _network common.Address, _slashPeriodSeconds *big.Int, _slashOracle common.Address, _slashReceiver common.Address, _minBurnerRouterDelay *big.Int, _owner common.Address) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.Contract.Initialize(&_Mevcommitmiddleware.TransactOpts, _networkRegistry, _operatorRegistry, _vaultFactory, _burnerRouterFactory, _network, _slashPeriodSeconds, _slashOracle, _slashReceiver, _minBurnerRouterDelay, _owner)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0x0eaf43f2.
+// Initialize is a paid mutator transaction binding the contract method 0xc6636056.
 //
-// Solidity: function initialize(address _networkRegistry, address _operatorRegistry, address _vaultFactory, address _network, uint256 _slashPeriodSeconds, address _slashOracle, address _owner) returns()
-func (_Mevcommitmiddleware *MevcommitmiddlewareTransactorSession) Initialize(_networkRegistry common.Address, _operatorRegistry common.Address, _vaultFactory common.Address, _network common.Address, _slashPeriodSeconds *big.Int, _slashOracle common.Address, _owner common.Address) (*types.Transaction, error) {
-	return _Mevcommitmiddleware.Contract.Initialize(&_Mevcommitmiddleware.TransactOpts, _networkRegistry, _operatorRegistry, _vaultFactory, _network, _slashPeriodSeconds, _slashOracle, _owner)
+// Solidity: function initialize(address _networkRegistry, address _operatorRegistry, address _vaultFactory, address _burnerRouterFactory, address _network, uint256 _slashPeriodSeconds, address _slashOracle, address _slashReceiver, uint256 _minBurnerRouterDelay, address _owner) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareTransactorSession) Initialize(_networkRegistry common.Address, _operatorRegistry common.Address, _vaultFactory common.Address, _burnerRouterFactory common.Address, _network common.Address, _slashPeriodSeconds *big.Int, _slashOracle common.Address, _slashReceiver common.Address, _minBurnerRouterDelay *big.Int, _owner common.Address) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.Contract.Initialize(&_Mevcommitmiddleware.TransactOpts, _networkRegistry, _operatorRegistry, _vaultFactory, _burnerRouterFactory, _network, _slashPeriodSeconds, _slashOracle, _slashReceiver, _minBurnerRouterDelay, _owner)
 }
 
 // Pause is a paid mutator transaction binding the contract method 0x8456cb59.
@@ -1347,6 +1502,48 @@ func (_Mevcommitmiddleware *MevcommitmiddlewareTransactorSession) RequestVaultDe
 	return _Mevcommitmiddleware.Contract.RequestVaultDeregistrations(&_Mevcommitmiddleware.TransactOpts, vaults)
 }
 
+// SetBurnerRouterFactory is a paid mutator transaction binding the contract method 0xd0352521.
+//
+// Solidity: function setBurnerRouterFactory(address _burnerRouterFactory) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareTransactor) SetBurnerRouterFactory(opts *bind.TransactOpts, _burnerRouterFactory common.Address) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.contract.Transact(opts, "setBurnerRouterFactory", _burnerRouterFactory)
+}
+
+// SetBurnerRouterFactory is a paid mutator transaction binding the contract method 0xd0352521.
+//
+// Solidity: function setBurnerRouterFactory(address _burnerRouterFactory) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareSession) SetBurnerRouterFactory(_burnerRouterFactory common.Address) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.Contract.SetBurnerRouterFactory(&_Mevcommitmiddleware.TransactOpts, _burnerRouterFactory)
+}
+
+// SetBurnerRouterFactory is a paid mutator transaction binding the contract method 0xd0352521.
+//
+// Solidity: function setBurnerRouterFactory(address _burnerRouterFactory) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareTransactorSession) SetBurnerRouterFactory(_burnerRouterFactory common.Address) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.Contract.SetBurnerRouterFactory(&_Mevcommitmiddleware.TransactOpts, _burnerRouterFactory)
+}
+
+// SetMinBurnerRouterDelay is a paid mutator transaction binding the contract method 0x9c8c3022.
+//
+// Solidity: function setMinBurnerRouterDelay(uint256 minBurnerRouterDelay_) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareTransactor) SetMinBurnerRouterDelay(opts *bind.TransactOpts, minBurnerRouterDelay_ *big.Int) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.contract.Transact(opts, "setMinBurnerRouterDelay", minBurnerRouterDelay_)
+}
+
+// SetMinBurnerRouterDelay is a paid mutator transaction binding the contract method 0x9c8c3022.
+//
+// Solidity: function setMinBurnerRouterDelay(uint256 minBurnerRouterDelay_) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareSession) SetMinBurnerRouterDelay(minBurnerRouterDelay_ *big.Int) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.Contract.SetMinBurnerRouterDelay(&_Mevcommitmiddleware.TransactOpts, minBurnerRouterDelay_)
+}
+
+// SetMinBurnerRouterDelay is a paid mutator transaction binding the contract method 0x9c8c3022.
+//
+// Solidity: function setMinBurnerRouterDelay(uint256 minBurnerRouterDelay_) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareTransactorSession) SetMinBurnerRouterDelay(minBurnerRouterDelay_ *big.Int) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.Contract.SetMinBurnerRouterDelay(&_Mevcommitmiddleware.TransactOpts, minBurnerRouterDelay_)
+}
+
 // SetNetwork is a paid mutator transaction binding the contract method 0xa1d71142.
 //
 // Solidity: function setNetwork(address _network) returns()
@@ -1450,6 +1647,27 @@ func (_Mevcommitmiddleware *MevcommitmiddlewareSession) SetSlashPeriodSeconds(sl
 // Solidity: function setSlashPeriodSeconds(uint256 slashPeriodSeconds_) returns()
 func (_Mevcommitmiddleware *MevcommitmiddlewareTransactorSession) SetSlashPeriodSeconds(slashPeriodSeconds_ *big.Int) (*types.Transaction, error) {
 	return _Mevcommitmiddleware.Contract.SetSlashPeriodSeconds(&_Mevcommitmiddleware.TransactOpts, slashPeriodSeconds_)
+}
+
+// SetSlashReceiver is a paid mutator transaction binding the contract method 0x1a6933d5.
+//
+// Solidity: function setSlashReceiver(address slashReceiver_) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareTransactor) SetSlashReceiver(opts *bind.TransactOpts, slashReceiver_ common.Address) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.contract.Transact(opts, "setSlashReceiver", slashReceiver_)
+}
+
+// SetSlashReceiver is a paid mutator transaction binding the contract method 0x1a6933d5.
+//
+// Solidity: function setSlashReceiver(address slashReceiver_) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareSession) SetSlashReceiver(slashReceiver_ common.Address) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.Contract.SetSlashReceiver(&_Mevcommitmiddleware.TransactOpts, slashReceiver_)
+}
+
+// SetSlashReceiver is a paid mutator transaction binding the contract method 0x1a6933d5.
+//
+// Solidity: function setSlashReceiver(address slashReceiver_) returns()
+func (_Mevcommitmiddleware *MevcommitmiddlewareTransactorSession) SetSlashReceiver(slashReceiver_ common.Address) (*types.Transaction, error) {
+	return _Mevcommitmiddleware.Contract.SetSlashReceiver(&_Mevcommitmiddleware.TransactOpts, slashReceiver_)
 }
 
 // SetVaultFactory is a paid mutator transaction binding the contract method 0x3ea7fbdb.
@@ -1641,6 +1859,140 @@ func (_Mevcommitmiddleware *MevcommitmiddlewareTransactorSession) Receive() (*ty
 	return _Mevcommitmiddleware.Contract.Receive(&_Mevcommitmiddleware.TransactOpts)
 }
 
+// MevcommitmiddlewareBurnerRouterFactorySetIterator is returned from FilterBurnerRouterFactorySet and is used to iterate over the raw logs and unpacked data for BurnerRouterFactorySet events raised by the Mevcommitmiddleware contract.
+type MevcommitmiddlewareBurnerRouterFactorySetIterator struct {
+	Event *MevcommitmiddlewareBurnerRouterFactorySet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MevcommitmiddlewareBurnerRouterFactorySetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MevcommitmiddlewareBurnerRouterFactorySet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MevcommitmiddlewareBurnerRouterFactorySet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MevcommitmiddlewareBurnerRouterFactorySetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MevcommitmiddlewareBurnerRouterFactorySetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MevcommitmiddlewareBurnerRouterFactorySet represents a BurnerRouterFactorySet event raised by the Mevcommitmiddleware contract.
+type MevcommitmiddlewareBurnerRouterFactorySet struct {
+	BurnerRouterFactory common.Address
+	Raw                 types.Log // Blockchain specific contextual infos
+}
+
+// FilterBurnerRouterFactorySet is a free log retrieval operation binding the contract event 0x9c214079845899d94b3bd881a14e996ebd153ef99fdc98ee4681eacf19c62f38.
+//
+// Solidity: event BurnerRouterFactorySet(address burnerRouterFactory)
+func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) FilterBurnerRouterFactorySet(opts *bind.FilterOpts) (*MevcommitmiddlewareBurnerRouterFactorySetIterator, error) {
+
+	logs, sub, err := _Mevcommitmiddleware.contract.FilterLogs(opts, "BurnerRouterFactorySet")
+	if err != nil {
+		return nil, err
+	}
+	return &MevcommitmiddlewareBurnerRouterFactorySetIterator{contract: _Mevcommitmiddleware.contract, event: "BurnerRouterFactorySet", logs: logs, sub: sub}, nil
+}
+
+// WatchBurnerRouterFactorySet is a free log subscription operation binding the contract event 0x9c214079845899d94b3bd881a14e996ebd153ef99fdc98ee4681eacf19c62f38.
+//
+// Solidity: event BurnerRouterFactorySet(address burnerRouterFactory)
+func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) WatchBurnerRouterFactorySet(opts *bind.WatchOpts, sink chan<- *MevcommitmiddlewareBurnerRouterFactorySet) (event.Subscription, error) {
+
+	logs, sub, err := _Mevcommitmiddleware.contract.WatchLogs(opts, "BurnerRouterFactorySet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MevcommitmiddlewareBurnerRouterFactorySet)
+				if err := _Mevcommitmiddleware.contract.UnpackLog(event, "BurnerRouterFactorySet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBurnerRouterFactorySet is a log parse operation binding the contract event 0x9c214079845899d94b3bd881a14e996ebd153ef99fdc98ee4681eacf19c62f38.
+//
+// Solidity: event BurnerRouterFactorySet(address burnerRouterFactory)
+func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) ParseBurnerRouterFactorySet(log types.Log) (*MevcommitmiddlewareBurnerRouterFactorySet, error) {
+	event := new(MevcommitmiddlewareBurnerRouterFactorySet)
+	if err := _Mevcommitmiddleware.contract.UnpackLog(event, "BurnerRouterFactorySet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
 // MevcommitmiddlewareInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Mevcommitmiddleware contract.
 type MevcommitmiddlewareInitializedIterator struct {
 	Event *MevcommitmiddlewareInitialized // Event containing the contract specifics and raw log
@@ -1769,6 +2121,140 @@ func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) WatchInitialized(opts *
 func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) ParseInitialized(log types.Log) (*MevcommitmiddlewareInitialized, error) {
 	event := new(MevcommitmiddlewareInitialized)
 	if err := _Mevcommitmiddleware.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// MevcommitmiddlewareMinBurnerRouterDelaySetIterator is returned from FilterMinBurnerRouterDelaySet and is used to iterate over the raw logs and unpacked data for MinBurnerRouterDelaySet events raised by the Mevcommitmiddleware contract.
+type MevcommitmiddlewareMinBurnerRouterDelaySetIterator struct {
+	Event *MevcommitmiddlewareMinBurnerRouterDelaySet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MevcommitmiddlewareMinBurnerRouterDelaySetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MevcommitmiddlewareMinBurnerRouterDelaySet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MevcommitmiddlewareMinBurnerRouterDelaySet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MevcommitmiddlewareMinBurnerRouterDelaySetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MevcommitmiddlewareMinBurnerRouterDelaySetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MevcommitmiddlewareMinBurnerRouterDelaySet represents a MinBurnerRouterDelaySet event raised by the Mevcommitmiddleware contract.
+type MevcommitmiddlewareMinBurnerRouterDelaySet struct {
+	MinBurnerRouterDelay *big.Int
+	Raw                  types.Log // Blockchain specific contextual infos
+}
+
+// FilterMinBurnerRouterDelaySet is a free log retrieval operation binding the contract event 0x1692318fc65bb45681dfd5556f2d21be7659c6809c725f503ad03240998b4b18.
+//
+// Solidity: event MinBurnerRouterDelaySet(uint256 minBurnerRouterDelay)
+func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) FilterMinBurnerRouterDelaySet(opts *bind.FilterOpts) (*MevcommitmiddlewareMinBurnerRouterDelaySetIterator, error) {
+
+	logs, sub, err := _Mevcommitmiddleware.contract.FilterLogs(opts, "MinBurnerRouterDelaySet")
+	if err != nil {
+		return nil, err
+	}
+	return &MevcommitmiddlewareMinBurnerRouterDelaySetIterator{contract: _Mevcommitmiddleware.contract, event: "MinBurnerRouterDelaySet", logs: logs, sub: sub}, nil
+}
+
+// WatchMinBurnerRouterDelaySet is a free log subscription operation binding the contract event 0x1692318fc65bb45681dfd5556f2d21be7659c6809c725f503ad03240998b4b18.
+//
+// Solidity: event MinBurnerRouterDelaySet(uint256 minBurnerRouterDelay)
+func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) WatchMinBurnerRouterDelaySet(opts *bind.WatchOpts, sink chan<- *MevcommitmiddlewareMinBurnerRouterDelaySet) (event.Subscription, error) {
+
+	logs, sub, err := _Mevcommitmiddleware.contract.WatchLogs(opts, "MinBurnerRouterDelaySet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MevcommitmiddlewareMinBurnerRouterDelaySet)
+				if err := _Mevcommitmiddleware.contract.UnpackLog(event, "MinBurnerRouterDelaySet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMinBurnerRouterDelaySet is a log parse operation binding the contract event 0x1692318fc65bb45681dfd5556f2d21be7659c6809c725f503ad03240998b4b18.
+//
+// Solidity: event MinBurnerRouterDelaySet(uint256 minBurnerRouterDelay)
+func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) ParseMinBurnerRouterDelaySet(log types.Log) (*MevcommitmiddlewareMinBurnerRouterDelaySet, error) {
+	event := new(MevcommitmiddlewareMinBurnerRouterDelaySet)
+	if err := _Mevcommitmiddleware.contract.UnpackLog(event, "MinBurnerRouterDelaySet", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
@@ -3733,6 +4219,140 @@ func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) WatchSlashPeriodSeconds
 func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) ParseSlashPeriodSecondsSet(log types.Log) (*MevcommitmiddlewareSlashPeriodSecondsSet, error) {
 	event := new(MevcommitmiddlewareSlashPeriodSecondsSet)
 	if err := _Mevcommitmiddleware.contract.UnpackLog(event, "SlashPeriodSecondsSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// MevcommitmiddlewareSlashReceiverSetIterator is returned from FilterSlashReceiverSet and is used to iterate over the raw logs and unpacked data for SlashReceiverSet events raised by the Mevcommitmiddleware contract.
+type MevcommitmiddlewareSlashReceiverSetIterator struct {
+	Event *MevcommitmiddlewareSlashReceiverSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MevcommitmiddlewareSlashReceiverSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MevcommitmiddlewareSlashReceiverSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MevcommitmiddlewareSlashReceiverSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MevcommitmiddlewareSlashReceiverSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MevcommitmiddlewareSlashReceiverSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MevcommitmiddlewareSlashReceiverSet represents a SlashReceiverSet event raised by the Mevcommitmiddleware contract.
+type MevcommitmiddlewareSlashReceiverSet struct {
+	SlashReceiver common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashReceiverSet is a free log retrieval operation binding the contract event 0x1299adc355601236099496a2d2b5de5dadc58ddf4628bd4e9ca3d2560931f9a6.
+//
+// Solidity: event SlashReceiverSet(address slashReceiver)
+func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) FilterSlashReceiverSet(opts *bind.FilterOpts) (*MevcommitmiddlewareSlashReceiverSetIterator, error) {
+
+	logs, sub, err := _Mevcommitmiddleware.contract.FilterLogs(opts, "SlashReceiverSet")
+	if err != nil {
+		return nil, err
+	}
+	return &MevcommitmiddlewareSlashReceiverSetIterator{contract: _Mevcommitmiddleware.contract, event: "SlashReceiverSet", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashReceiverSet is a free log subscription operation binding the contract event 0x1299adc355601236099496a2d2b5de5dadc58ddf4628bd4e9ca3d2560931f9a6.
+//
+// Solidity: event SlashReceiverSet(address slashReceiver)
+func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) WatchSlashReceiverSet(opts *bind.WatchOpts, sink chan<- *MevcommitmiddlewareSlashReceiverSet) (event.Subscription, error) {
+
+	logs, sub, err := _Mevcommitmiddleware.contract.WatchLogs(opts, "SlashReceiverSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MevcommitmiddlewareSlashReceiverSet)
+				if err := _Mevcommitmiddleware.contract.UnpackLog(event, "SlashReceiverSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashReceiverSet is a log parse operation binding the contract event 0x1299adc355601236099496a2d2b5de5dadc58ddf4628bd4e9ca3d2560931f9a6.
+//
+// Solidity: event SlashReceiverSet(address slashReceiver)
+func (_Mevcommitmiddleware *MevcommitmiddlewareFilterer) ParseSlashReceiverSet(log types.Log) (*MevcommitmiddlewareSlashReceiverSet, error) {
+	event := new(MevcommitmiddlewareSlashReceiverSet)
+	if err := _Mevcommitmiddleware.contract.UnpackLog(event, "SlashReceiverSet", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/contracts/contracts/interfaces/IMevCommitMiddleware.sol
+++ b/contracts/contracts/interfaces/IMevCommitMiddleware.sol
@@ -98,6 +98,9 @@ interface IMevCommitMiddleware {
     /// @notice Emmitted when the vault factory is set
     event VaultFactorySet(address vaultFactory);
 
+    /// @notice Emmitted when the burner router factory is set
+    event BurnerRouterFactorySet(address burnerRouterFactory);
+
     /// @notice Emmitted when the network is set
     event NetworkSet(address network);
 
@@ -109,6 +112,12 @@ interface IMevCommitMiddleware {
 
     /// @notice Emmitted when the slash oracle is set
     event SlashOracleSet(address slashOracle);
+
+    /// @notice Emmitted when the slash receiver is set
+    event SlashReceiverSet(address slashReceiver);
+
+    /// @notice Emmitted when the minimum burner router delay is set
+    event MinBurnerRouterDelaySet(uint256 minBurnerRouterDelay);
 
     /// @notice Emmitted when validator positions are swapped as a part of slashing
     /// @dev Each array index corresponds to a swap instance. ie. all lists should be of equal length.
@@ -181,6 +190,10 @@ interface IMevCommitMiddleware {
     error VaultNotRegistered(address vault);
 
     error VaultDeregRequestExists(address vault);
+
+    error InvalidVaultBurner(address vault);
+
+    error InvalidVaultBurnerConsideringOperator(address vault, address operator);
 
     error ValidatorNotInValset(bytes blsPubkey, address vault, address operator);
 

--- a/contracts/contracts/validator-registry/middleware/MevCommitMiddleware.sol
+++ b/contracts/contracts/validator-registry/middleware/MevCommitMiddleware.sol
@@ -20,8 +20,7 @@ import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Errors} from "../../utils/Errors.sol";
 import {IVetoSlasher} from "symbiotic-core/interfaces/slasher/IVetoSlasher.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
-// TODO: Remove this and use symbiotic burner repo
-import {IBurnerRouter} from "../../interfaces/IBurner.sol";
+import {IBurnerRouter} from "symbiotic-burners/interfaces/router/IBurnerRouter.sol";
 
 /// @notice This contracts serve as an entrypoint for L1 validators
 /// to *opt-in* to mev-commit, ie. attest to the rules of mev-commit,

--- a/contracts/contracts/validator-registry/middleware/MevCommitMiddlewareStorage.sol
+++ b/contracts/contracts/validator-registry/middleware/MevCommitMiddlewareStorage.sol
@@ -34,6 +34,9 @@ abstract contract MevCommitMiddlewareStorage {
     /// @notice Symbiotic core vault factory.
     IRegistry public vaultFactory;
 
+    /// @notice Symbiotic core burner router factory.
+    IRegistry public burnerRouterFactory;
+
     /// @notice The network address, which must have registered with the NETWORK_REGISTRY.
     address public network;
 
@@ -44,6 +47,14 @@ abstract contract MevCommitMiddlewareStorage {
 
     /// @notice Address of the mev-commit slash oracle.
     address public slashOracle;
+
+    /// @notice Address of the mev-commit slash receiver.
+    /// @dev This address should be immutable in practice, as it is used to validate every vault.
+    /// @dev If this address is ever changed by the owner, all vaults would then need to update their burnerRouter. This is by-design.
+    address public slashReceiver;
+
+    /// @notice Minimum burner router delay.
+    uint256 public minBurnerRouterDelay;
 
     /// @notice Mapping of a validator's BLS public key to its validator record.
     mapping(bytes blsPubkey => IMevCommitMiddleware.ValidatorRecord) public validatorRecords;

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -6,3 +6,4 @@ forge-std/=lib/forge-std/src/
 @openzeppelin-contracts/=lib/openzeppelin-contracts/
 eigenlayer-contracts/=lib/eigenlayer-contracts/
 symbiotic-core/=lib/core/src/
+symbiotic-burners/=lib/burners/src/

--- a/contracts/scripts/validator-registry/middleware/DeployMiddleware.s.sol
+++ b/contracts/scripts/validator-registry/middleware/DeployMiddleware.s.sol
@@ -20,9 +20,12 @@ contract BaseDeploy is Script {
         IRegistry networkRegistry,
         IRegistry operatorRegistry,
         IRegistry vaultFactory,
+        IRegistry burnerRouterFactory,
         address network,
         uint256 slashPeriodSeconds,
         address slashOracle,
+        address slashReceiver,
+        uint256 minBurnerRouterDelay,
         address owner
     ) public returns (address) {
         console.log("Deploying MevCommitMiddleware on chain:", block.chainid);
@@ -32,9 +35,12 @@ contract BaseDeploy is Script {
                 networkRegistry, 
                 operatorRegistry, 
                 vaultFactory, 
+                burnerRouterFactory,
                 network, 
                 slashPeriodSeconds,
                 slashOracle,
+                slashReceiver,
+                minBurnerRouterDelay,
                 owner
             ))
         );
@@ -50,12 +56,15 @@ contract DeployHolesky is BaseDeploy {
     IRegistry constant public NETWORK_REGISTRY = IRegistry(SymbioticHoleskyDevnetConsts.NETWORK_REGISTRY);
     IRegistry constant public OPERATOR_REGISTRY = IRegistry(SymbioticHoleskyDevnetConsts.OPERATOR_REGISTRY);
     IRegistry constant public VAULT_FACTORY = IRegistry(SymbioticHoleskyDevnetConsts.VAULT_FACTORY);
-    
+    IRegistry constant public BURNER_ROUTER_FACTORY = IRegistry(SymbioticHoleskyDevnetConsts.BURNER_ROUTER_FACTORY);
+
     // On Holesky, use dev keystore account. On mainnet these will be the primev multisig.
     address constant public EXPECTED_MSG_SENDER = 0x4535bd6fF24860b5fd2889857651a85fb3d3C6b1;
     address constant public OWNER = EXPECTED_MSG_SENDER;
     address constant public NETWORK = EXPECTED_MSG_SENDER;
     address constant public SLASH_ORACLE = EXPECTED_MSG_SENDER; // Temporary placeholder until oracle implements slashing.
+    address constant public SLASH_RECEIVER = EXPECTED_MSG_SENDER; 
+    uint256 constant public MIN_BURNER_ROUTER_DELAY = 2 days;
 
     uint96 constant public SUBNETWORK_ID = 1;
     uint256 constant public VAULT1_MAX_NETWORK_LIMIT = 100000 ether;
@@ -76,9 +85,12 @@ contract DeployHolesky is BaseDeploy {
             NETWORK_REGISTRY, 
             OPERATOR_REGISTRY, 
             VAULT_FACTORY, 
+            BURNER_ROUTER_FACTORY,
             NETWORK, 
             SLASH_PERIOD_SECONDS, 
             SLASH_ORACLE, 
+            SLASH_RECEIVER,
+            MIN_BURNER_ROUTER_DELAY,
             OWNER
         );
 

--- a/contracts/scripts/validator-registry/middleware/DeployMiddlewareWithMocks.s.sol
+++ b/contracts/scripts/validator-registry/middleware/DeployMiddlewareWithMocks.s.sol
@@ -12,6 +12,7 @@ import {MockDelegator} from "../../../test/validator-registry/middleware/MockDel
 import {MockVault} from "../../../test/validator-registry/middleware/MockVault.sol";
 import {RegistryMock} from "../../../test/validator-registry/middleware/RegistryMock.sol";
 import {IRegistry} from "symbiotic-core/interfaces/common/IRegistry.sol";
+import {MockBurnerRouter} from "../../../test/validator-registry/middleware/MockBurnerRouter.sol";
 
 contract DeployMiddlewareWithMocks is Script {
     function run() external {
@@ -52,8 +53,10 @@ contract DeployMiddlewareWithMocks is Script {
 
         MockDelegator mockDelegator1 = new MockDelegator(15);
         MockDelegator mockDelegator2 = new MockDelegator(16);
-        MockVault vault1 = new MockVault(address(mockDelegator1), address(0), 10);
-        MockVault vault2 = new MockVault(address(mockDelegator2), address(0), 10);
+        MockBurnerRouter mockBurnerRouter = new MockBurnerRouter(15 minutes);
+        MockBurnerRouter mockBurnerRouter2 = new MockBurnerRouter(15 minutes);
+        MockVault vault1 = new MockVault(address(mockDelegator1), address(0), address(mockBurnerRouter), 10);
+        MockVault vault2 = new MockVault(address(mockDelegator2), address(0), address(mockBurnerRouter2), 10);
 
         console.log("MockDelegator 1 deployed to:", address(mockDelegator1));
         console.log("MockDelegator 2 deployed to:", address(mockDelegator2));

--- a/contracts/scripts/validator-registry/middleware/DeployMiddlewareWithMocks.s.sol
+++ b/contracts/scripts/validator-registry/middleware/DeployMiddlewareWithMocks.s.sol
@@ -21,11 +21,14 @@ contract DeployMiddlewareWithMocks is Script {
         RegistryMock networkRegistryMock = new RegistryMock();
         RegistryMock operatorRegistryMock = new RegistryMock();
         RegistryMock vaultFactoryMock = new RegistryMock();
+        RegistryMock burnerRouterFactoryMock = new RegistryMock();
 
         uint256 slashPeriodSeconds = 150;
         address network = msg.sender;
         address slashOracle = msg.sender;
+        address slashReceiver = msg.sender;
         address owner = msg.sender;
+        uint256 minBurnerRouterDelay = 15 minutes;
 
         networkRegistryMock.register();
 
@@ -35,9 +38,12 @@ contract DeployMiddlewareWithMocks is Script {
                 IRegistry(networkRegistryMock), 
                 IRegistry(operatorRegistryMock), 
                 IRegistry(vaultFactoryMock), 
+                IRegistry(burnerRouterFactoryMock),
                 network, 
                 slashPeriodSeconds,
                 slashOracle,
+                slashReceiver,
+                minBurnerRouterDelay,
                 owner
             ))
         );

--- a/contracts/scripts/validator-registry/middleware/ReleaseAddrConsts.s.sol
+++ b/contracts/scripts/validator-registry/middleware/ReleaseAddrConsts.s.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BSL 1.1
 pragma solidity 0.8.26;
 
-/// @notice Constants from https://docs.symbiotic.fi/deployments/
-/// @notice Last updated 10-28-2024
+/// @notice Constants from https://docs.symbiotic.fi/deployments/current
+/// @notice Last updated 11-30-2024
 library SymbioticHoleskyDevnetConsts {
     address internal constant VAULT_FACTORY = 0x407A039D94948484D356eFB765b3c74382A050B4;
     address internal constant DELEGATOR_FACTORY = 0x890CA3f95E0f40a79885B7400926544B2214B03f;
@@ -21,4 +21,6 @@ library SymbioticHoleskyDevnetConsts {
     address internal constant VAULT_1 = 0xd88dDf98fE4d161a66FB836bee4Ca469eb0E4a75;
     address internal constant VAULT_1_DELEGATOR = 0x85CF967A8DDFAf8C0DFB9c75d9E92a3C785A6532;
     address internal constant VAULT_1_SLASHER = 0x57e5Fb61981fa1b43a074B2aeb47CCF157b19223;
+
+    address internal constant BURNER_ROUTER_FACTORY = 0x32e2AfbdAffB1e675898ABA75868d92eE1E68f3b;
 }

--- a/contracts/test/validator-registry/middleware/MevCommitMiddlewareTest.sol
+++ b/contracts/test/validator-registry/middleware/MevCommitMiddlewareTest.sol
@@ -22,9 +22,12 @@ contract MevCommitMiddlewareTest is Test {
     RegistryMock public networkRegistryMock;
     RegistryMock public operatorRegistryMock;
     RegistryMock public vaultFactoryMock;
+    RegistryMock public burnerRouterFactoryMock;
     address public network;
     uint256 public slashPeriodSeconds;
     address public slashOracle;
+    address public slashReceiver;
+    uint256 public minBurnerRouterDelay;
     address public owner;
 
     MevCommitMiddleware public mevCommitMiddleware;
@@ -70,11 +73,14 @@ contract MevCommitMiddlewareTest is Test {
         networkRegistryMock = new RegistryMock();
         operatorRegistryMock = new RegistryMock();
         vaultFactoryMock = new RegistryMock();
+        burnerRouterFactoryMock = new RegistryMock();
 
         network = vm.addr(0x1);
         slashPeriodSeconds = 150 hours;
         slashOracle = vm.addr(0x2);
-        owner = vm.addr(0x3);
+        slashReceiver = vm.addr(0x3);
+        minBurnerRouterDelay = 2 days;
+        owner = vm.addr(0x4);
 
         // Network addr must be registered with the network registry
         vm.prank(network);
@@ -86,9 +92,12 @@ contract MevCommitMiddlewareTest is Test {
                 IRegistry(networkRegistryMock), 
                 IRegistry(operatorRegistryMock), 
                 IRegistry(vaultFactoryMock), 
+                IRegistry(burnerRouterFactoryMock),
                 network, 
                 slashPeriodSeconds,
                 slashOracle,
+                slashReceiver,
+                minBurnerRouterDelay,
                 owner
             ))
         );

--- a/contracts/test/validator-registry/middleware/MevCommitMiddlewareTestCont.sol
+++ b/contracts/test/validator-registry/middleware/MevCommitMiddlewareTestCont.sol
@@ -8,6 +8,7 @@ import {MevCommitMiddlewareTest} from "./MevCommitMiddlewareTest.sol";
 import {MockVetoSlasher} from "./MockVetoSlasher.sol";
 import {MockInstantSlasher} from "./MockInstantSlasher.sol";
 import {MockDelegator} from "./MockDelegator.sol";
+import {MockBurnerRouter} from "./MockBurnerRouter.sol";
 
 contract MevCommitMiddlewareTestCont is MevCommitMiddlewareTest {
 
@@ -71,6 +72,17 @@ contract MevCommitMiddlewareTestCont is MevCommitMiddlewareTest {
         vaultFactoryMock.register();
         vm.prank(address(vault2));
         vaultFactoryMock.register();
+
+        mockBurnerRouter = new MockBurnerRouter(2 days);
+        mockBurnerRouter2 = new MockBurnerRouter(2 days);
+        vm.prank(address(mockBurnerRouter));
+        burnerRouterFactoryMock.register();
+        vm.prank(address(mockBurnerRouter2));
+        burnerRouterFactoryMock.register();
+        vault1.setBurner(address(mockBurnerRouter));
+        vault2.setBurner(address(mockBurnerRouter2));
+        mockBurnerRouter.setNetworkReceiver(network, slashReceiver);
+        mockBurnerRouter2.setNetworkReceiver(network, slashReceiver);
 
         vm.prank(owner);
         mevCommitMiddleware.registerVaults(vaults, slashAmounts);
@@ -136,6 +148,17 @@ contract MevCommitMiddlewareTestCont is MevCommitMiddlewareTest {
 
         vault1.setEpochDuration(151 hours);
         vault2.setEpochDuration(151 hours + 5 hours);
+
+        mockBurnerRouter = new MockBurnerRouter(3 days);
+        mockBurnerRouter2 = new MockBurnerRouter(3 days);
+        vm.prank(address(mockBurnerRouter));
+        burnerRouterFactoryMock.register();
+        vm.prank(address(mockBurnerRouter2));
+        burnerRouterFactoryMock.register();
+        vault1.setBurner(address(mockBurnerRouter));
+        vault2.setBurner(address(mockBurnerRouter2));
+        mockBurnerRouter.setNetworkReceiver(network, slashReceiver);
+        mockBurnerRouter2.setNetworkReceiver(network, slashReceiver);
 
         vm.prank(owner);
         mevCommitMiddleware.registerVaults(vaults, slashAmounts);

--- a/contracts/test/validator-registry/middleware/MockBurnerRouter.sol
+++ b/contracts/test/validator-registry/middleware/MockBurnerRouter.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSL 1.1
+pragma solidity 0.8.26;
+
+contract MockBurnerRouter {
+    uint256 public delay;
+    mapping(address network => address receiver) public networkReceiver;
+    mapping(address network => mapping(address operator => address receiver)) public operatorNetworkReceiver;
+
+    constructor(uint256 delay_) {
+        delay = delay_;
+    }
+
+    function setDelay(uint256 delay_) external {
+        delay = delay_;
+    }
+
+    function setNetworkReceiver(address network, address receiver) external {
+        networkReceiver[network] = receiver;
+    }
+
+    function setOperatorNetworkReceiver(address network, address operator, address receiver) external {
+        operatorNetworkReceiver[network][operator] = receiver;
+    }
+}

--- a/contracts/test/validator-registry/middleware/MockVault.sol
+++ b/contracts/test/validator-registry/middleware/MockVault.sol
@@ -4,11 +4,13 @@ pragma solidity 0.8.26;
 contract MockVault {
     address public delegator;
     address public slasher;
+    address public burner;
     uint48 private _epochDuration;
 
-    constructor(address _delegator, address _slasher, uint48 epochDuration_) {
+    constructor(address _delegator, address _slasher, address _burner, uint48 epochDuration_) {
         delegator = _delegator;
         slasher = _slasher;
+        burner = _burner;
         _epochDuration = epochDuration_;
     }
 
@@ -18,6 +20,10 @@ contract MockVault {
 
     function setEpochDuration(uint48 epochDuration_) external {
         _epochDuration = epochDuration_;
+    }
+
+    function setBurner(address _burner) external {
+        burner = _burner;
     }
 
     function epochDuration() external view returns (uint48) {


### PR DESCRIPTION
## Describe your changes

Vaults are now required to use a [burner router](https://docs.symbiotic.fi/modules/extensions/burners#burner-router) to integrate with our middleware contract. 

Concrete changes w.r.t above goal:

* Added vault config validation around integration with burner router. Delay and receiver config is enforced. 
* Added middleware storage for enforced slash receiver, enforced min router delay, and symbiotic `burnerRouterFactory` contract. 
*  Added forge dependency to https://github.com/symbioticfi/burners/tree/main
* Added related setters
* Docs to explain burner router requirements, and required trust assumptions with vaults. 

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
