### PR TITLE
fix: use single on-chain bridge fee 

### DIFF
--- a/bridge/standard/pkg/gwcontract/gateway.go
+++ b/bridge/standard/pkg/gwcontract/gateway.go
@@ -19,6 +19,7 @@ type GatewayTransactor interface {
 		_recipient common.Address,
 		_amount *big.Int,
 		_counterpartyIdx *big.Int,
+		_finalizationFee *big.Int,
 	) (*types.Transaction, error)
 }
 
@@ -71,6 +72,7 @@ func (g *Gateway[EventType]) FinalizeTransfer(
 	recipient common.Address,
 	amount *big.Int,
 	counterpartyIdx *big.Int,
+	finalizationFee *big.Int,
 ) error {
 	switch settled, err := g.store.IsSettled(ctx, counterpartyIdx); {
 	case err != nil:
@@ -92,6 +94,7 @@ func (g *Gateway[EventType]) FinalizeTransfer(
 		recipient,
 		amount,
 		counterpartyIdx,
+		finalizationFee,
 	)
 	if err != nil {
 		g.logger.Error(

--- a/bridge/standard/pkg/gwcontract/gateway_test.go
+++ b/bridge/standard/pkg/gwcontract/gateway_test.go
@@ -100,6 +100,7 @@ func (t *testGatewayTransactor) FinalizeTransfer(
 	recipient common.Address,
 	amount *big.Int,
 	counterpartyIdx *big.Int,
+	finalizationFee *big.Int,
 ) (*types.Transaction, error) {
 	newNonce := t.nonce
 	t.nonce++
@@ -143,22 +144,25 @@ func TestGateway(t *testing.T) {
 
 	transfers := []*l1gateway.L1gatewayTransferInitiated{
 		{
-			Sender:      common.HexToAddress("0x1234"),
-			Recipient:   common.HexToAddress("0x5678"),
-			Amount:      big.NewInt(100),
-			TransferIdx: big.NewInt(1),
+			Sender:                      common.HexToAddress("0x1234"),
+			Recipient:                   common.HexToAddress("0x5678"),
+			Amount:                      big.NewInt(100),
+			TransferIdx:                 big.NewInt(1),
+			CounterpartyFinalizationFee: big.NewInt(10),
 		},
 		{
-			Sender:      common.HexToAddress("0x5678"),
-			Recipient:   common.HexToAddress("0x1234"),
-			Amount:      big.NewInt(200),
-			TransferIdx: big.NewInt(2),
+			Sender:                      common.HexToAddress("0x5678"),
+			Recipient:                   common.HexToAddress("0x1234"),
+			Amount:                      big.NewInt(200),
+			TransferIdx:                 big.NewInt(2),
+			CounterpartyFinalizationFee: big.NewInt(20),
 		},
 		{
-			Sender:      common.HexToAddress("0x1234"),
-			Recipient:   common.HexToAddress("0x5678"),
-			Amount:      big.NewInt(300),
-			TransferIdx: big.NewInt(3),
+			Sender:                      common.HexToAddress("0x1234"),
+			Recipient:                   common.HexToAddress("0x5678"),
+			Amount:                      big.NewInt(300),
+			TransferIdx:                 big.NewInt(3),
+			CounterpartyFinalizationFee: big.NewInt(30),
 		},
 	}
 
@@ -208,6 +212,7 @@ func TestGateway(t *testing.T) {
 			transfer.Recipient,
 			transfer.Amount,
 			transfer.TransferIdx,
+			transfer.CounterpartyFinalizationFee,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -229,6 +234,7 @@ func TestGateway(t *testing.T) {
 		transfers[0].Recipient,
 		transfers[0].Amount,
 		transfers[0].TransferIdx,
+		transfers[0].CounterpartyFinalizationFee,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -241,6 +247,7 @@ func TestGateway(t *testing.T) {
 		common.HexToAddress("0x1234"),
 		big.NewInt(100),
 		big.NewInt(4),
+		big.NewInt(10),
 	); err == nil {
 		t.Fatal("expected error")
 	}
@@ -254,6 +261,7 @@ func publishTransfer(
 	event := brABI.Events["TransferInitiated"]
 	buf, err := event.Inputs.NonIndexed().Pack(
 		transfer.Amount,
+		transfer.CounterpartyFinalizationFee,
 	)
 	if err != nil {
 		return err

--- a/bridge/standard/pkg/relayer/relayer.go
+++ b/bridge/standard/pkg/relayer/relayer.go
@@ -14,12 +14,12 @@ import (
 
 type L1Gateway interface {
 	Subscribe(ctx context.Context) (<-chan *l1gateway.L1gatewayTransferInitiated, <-chan error)
-	FinalizeTransfer(ctx context.Context, recipient common.Address, amount *big.Int, transferIdx *big.Int) error
+	FinalizeTransfer(ctx context.Context, recipient common.Address, amount *big.Int, transferIdx *big.Int, finalizationFee *big.Int) error
 }
 
 type SettlementGateway interface {
 	Subscribe(ctx context.Context) (<-chan *settlementgateway.SettlementgatewayTransferInitiated, <-chan error)
-	FinalizeTransfer(ctx context.Context, recipient common.Address, amount *big.Int, transferIdx *big.Int) error
+	FinalizeTransfer(ctx context.Context, recipient common.Address, amount *big.Int, transferIdx *big.Int, finalizationFee *big.Int) error
 }
 
 type Relayer struct {
@@ -72,6 +72,7 @@ func (r *Relayer) Start(ctx context.Context) <-chan struct{} {
 					upd.Recipient,
 					upd.Amount,
 					upd.TransferIdx,
+					upd.CounterpartyFinalizationFee,
 				)
 				if err != nil {
 					r.logger.Error(
@@ -104,6 +105,7 @@ func (r *Relayer) Start(ctx context.Context) <-chan struct{} {
 					upd.Recipient,
 					upd.Amount,
 					upd.TransferIdx,
+					upd.CounterpartyFinalizationFee,
 				)
 				if err != nil {
 					r.logger.Error(

--- a/contracts-abi/abi/L1Gateway.abi
+++ b/contracts-abi/abi/L1Gateway.abi
@@ -34,20 +34,7 @@
   },
   {
     "type": "function",
-    "name": "counterpartyFee",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "finalizationFee",
+    "name": "counterpartyFinalizationFee",
     "inputs": [],
     "outputs": [
       {
@@ -76,6 +63,11 @@
         "name": "_counterpartyIdx",
         "type": "uint256",
         "internalType": "uint256"
+      },
+      {
+        "name": "_finalizationFee",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "outputs": [],
@@ -96,12 +88,7 @@
         "internalType": "address"
       },
       {
-        "name": "_finalizationFee",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "_counterpartyFee",
+        "name": "_counterpartyFinalizationFee",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -214,23 +201,10 @@
   },
   {
     "type": "function",
-    "name": "setCounterpartyFee",
+    "name": "setCounterpartyFinalizationFee",
     "inputs": [
       {
-        "name": "_counterpartyFee",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setFinalizationFee",
-    "inputs": [
-      {
-        "name": "_finalizationFee",
+        "name": "_counterpartyFinalizationFee",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -349,23 +323,10 @@
   },
   {
     "type": "event",
-    "name": "CounterpartyFeeSet",
+    "name": "CounterpartyFinalizationFeeSet",
     "inputs": [
       {
-        "name": "counterpartyFee",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "FinalizationFeeSet",
-    "inputs": [
-      {
-        "name": "finalizationFee",
+        "name": "counterpartyFinalizationFee",
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
@@ -502,6 +463,12 @@
         "type": "uint256",
         "indexed": true,
         "internalType": "uint256"
+      },
+      {
+        "name": "counterpartyFinalizationFee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
       }
     ],
     "anonymous": false
@@ -591,7 +558,7 @@
         "internalType": "uint256"
       },
       {
-        "name": "counterpartyFee",
+        "name": "counterpartyFinalizationFee",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -599,10 +566,10 @@
   },
   {
     "type": "error",
-    "name": "CounterpartyFeeTooSmall",
+    "name": "CounterpartyFinalizationFeeTooSmall",
     "inputs": [
       {
-        "name": "_counterpartyFee",
+        "name": "_counterpartyFinalizationFee",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -638,17 +605,6 @@
     "type": "error",
     "name": "FailedInnerCall",
     "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "FinalizationFeeTooSmall",
-    "inputs": [
-      {
-        "name": "_finalizationFee",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
   },
   {
     "type": "error",

--- a/contracts-abi/abi/SettlementGateway.abi
+++ b/contracts-abi/abi/SettlementGateway.abi
@@ -47,20 +47,7 @@
   },
   {
     "type": "function",
-    "name": "counterpartyFee",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "finalizationFee",
+    "name": "counterpartyFinalizationFee",
     "inputs": [],
     "outputs": [
       {
@@ -89,6 +76,11 @@
         "name": "_counterpartyIdx",
         "type": "uint256",
         "internalType": "uint256"
+      },
+      {
+        "name": "_finalizationFee",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "outputs": [],
@@ -114,12 +106,7 @@
         "internalType": "address"
       },
       {
-        "name": "_finalizationFee",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "_counterpartyFee",
+        "name": "_counterpartyFinalizationFee",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -232,23 +219,10 @@
   },
   {
     "type": "function",
-    "name": "setCounterpartyFee",
+    "name": "setCounterpartyFinalizationFee",
     "inputs": [
       {
-        "name": "_counterpartyFee",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setFinalizationFee",
-    "inputs": [
-      {
-        "name": "_finalizationFee",
+        "name": "_counterpartyFinalizationFee",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -335,23 +309,10 @@
   },
   {
     "type": "event",
-    "name": "CounterpartyFeeSet",
+    "name": "CounterpartyFinalizationFeeSet",
     "inputs": [
       {
-        "name": "counterpartyFee",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "FinalizationFeeSet",
-    "inputs": [
-      {
-        "name": "finalizationFee",
+        "name": "counterpartyFinalizationFee",
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
@@ -488,6 +449,12 @@
         "type": "uint256",
         "indexed": true,
         "internalType": "uint256"
+      },
+      {
+        "name": "counterpartyFinalizationFee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
       }
     ],
     "anonymous": false
@@ -539,7 +506,7 @@
         "internalType": "uint256"
       },
       {
-        "name": "counterpartyFee",
+        "name": "counterpartyFinalizationFee",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -547,10 +514,10 @@
   },
   {
     "type": "error",
-    "name": "CounterpartyFeeTooSmall",
+    "name": "CounterpartyFinalizationFeeTooSmall",
     "inputs": [
       {
-        "name": "_counterpartyFee",
+        "name": "_counterpartyFinalizationFee",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -586,17 +553,6 @@
     "type": "error",
     "name": "FailedInnerCall",
     "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "FinalizationFeeTooSmall",
-    "inputs": [
-      {
-        "name": "_finalizationFee",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
   },
   {
     "type": "error",

--- a/contracts-abi/clients/L1Gateway/L1Gateway.go
+++ b/contracts-abi/clients/L1Gateway/L1Gateway.go
@@ -31,7 +31,7 @@ var (
 
 // L1gatewayMetaData contains all meta data concerning the L1gateway contract.
 var L1gatewayMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"counterpartyFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizationFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizeTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_relayer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_finalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initiateTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"returnIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"relayer\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setCounterpartyFee\",\"inputs\":[{\"name\":\"_counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setFinalizationFee\",\"inputs\":[{\"name\":\"_finalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRelayer\",\"inputs\":[{\"name\":\"_relayer\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferFinalizedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferInitiatedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferredFundsNeedingWithdrawal\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"withdraw\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"CounterpartyFeeSet\",\"inputs\":[{\"name\":\"counterpartyFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"FinalizationFeeSet\",\"inputs\":[{\"name\":\"finalizationFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RelayerSet\",\"inputs\":[{\"name\":\"relayer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferFinalized\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferInitiated\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"transferIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferNeedsWithdrawal\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferSuccess\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"AmountTooSmall\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"CounterpartyFeeTooSmall\",\"inputs\":[{\"name\":\"_counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FinalizationFeeTooSmall\",\"inputs\":[{\"name\":\"_finalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"IncorrectEtherValueSent\",\"inputs\":[{\"name\":\"msgValue\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountExpected\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InsufficientContractBalance\",\"inputs\":[{\"name\":\"thisContractBalance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountRequested\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidCounterpartyIndex\",\"inputs\":[{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"transferFinalizedIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoFundsNeedingWithdrawal\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RelayerCannotBeZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SenderNotRelayer\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"relayer\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"TransferFailed\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"counterpartyFinalizationFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizeTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_finalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_relayer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_counterpartyFinalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initiateTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"returnIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"relayer\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setCounterpartyFinalizationFee\",\"inputs\":[{\"name\":\"_counterpartyFinalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRelayer\",\"inputs\":[{\"name\":\"_relayer\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferFinalizedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferInitiatedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferredFundsNeedingWithdrawal\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"withdraw\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"CounterpartyFinalizationFeeSet\",\"inputs\":[{\"name\":\"counterpartyFinalizationFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RelayerSet\",\"inputs\":[{\"name\":\"relayer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferFinalized\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferInitiated\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"transferIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"counterpartyFinalizationFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferNeedsWithdrawal\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferSuccess\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"AmountTooSmall\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"counterpartyFinalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"CounterpartyFinalizationFeeTooSmall\",\"inputs\":[{\"name\":\"_counterpartyFinalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IncorrectEtherValueSent\",\"inputs\":[{\"name\":\"msgValue\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountExpected\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InsufficientContractBalance\",\"inputs\":[{\"name\":\"thisContractBalance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountRequested\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidCounterpartyIndex\",\"inputs\":[{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"transferFinalizedIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoFundsNeedingWithdrawal\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RelayerCannotBeZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SenderNotRelayer\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"relayer\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"TransferFailed\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]",
 }
 
 // L1gatewayABI is the input ABI used to generate the binding from.
@@ -211,12 +211,12 @@ func (_L1gateway *L1gatewayCallerSession) UPGRADEINTERFACEVERSION() (string, err
 	return _L1gateway.Contract.UPGRADEINTERFACEVERSION(&_L1gateway.CallOpts)
 }
 
-// CounterpartyFee is a free data retrieval call binding the contract method 0x97599011.
+// CounterpartyFinalizationFee is a free data retrieval call binding the contract method 0xce4ab0ad.
 //
-// Solidity: function counterpartyFee() view returns(uint256)
-func (_L1gateway *L1gatewayCaller) CounterpartyFee(opts *bind.CallOpts) (*big.Int, error) {
+// Solidity: function counterpartyFinalizationFee() view returns(uint256)
+func (_L1gateway *L1gatewayCaller) CounterpartyFinalizationFee(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _L1gateway.contract.Call(opts, &out, "counterpartyFee")
+	err := _L1gateway.contract.Call(opts, &out, "counterpartyFinalizationFee")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -228,49 +228,18 @@ func (_L1gateway *L1gatewayCaller) CounterpartyFee(opts *bind.CallOpts) (*big.In
 
 }
 
-// CounterpartyFee is a free data retrieval call binding the contract method 0x97599011.
+// CounterpartyFinalizationFee is a free data retrieval call binding the contract method 0xce4ab0ad.
 //
-// Solidity: function counterpartyFee() view returns(uint256)
-func (_L1gateway *L1gatewaySession) CounterpartyFee() (*big.Int, error) {
-	return _L1gateway.Contract.CounterpartyFee(&_L1gateway.CallOpts)
+// Solidity: function counterpartyFinalizationFee() view returns(uint256)
+func (_L1gateway *L1gatewaySession) CounterpartyFinalizationFee() (*big.Int, error) {
+	return _L1gateway.Contract.CounterpartyFinalizationFee(&_L1gateway.CallOpts)
 }
 
-// CounterpartyFee is a free data retrieval call binding the contract method 0x97599011.
+// CounterpartyFinalizationFee is a free data retrieval call binding the contract method 0xce4ab0ad.
 //
-// Solidity: function counterpartyFee() view returns(uint256)
-func (_L1gateway *L1gatewayCallerSession) CounterpartyFee() (*big.Int, error) {
-	return _L1gateway.Contract.CounterpartyFee(&_L1gateway.CallOpts)
-}
-
-// FinalizationFee is a free data retrieval call binding the contract method 0x78d3d576.
-//
-// Solidity: function finalizationFee() view returns(uint256)
-func (_L1gateway *L1gatewayCaller) FinalizationFee(opts *bind.CallOpts) (*big.Int, error) {
-	var out []interface{}
-	err := _L1gateway.contract.Call(opts, &out, "finalizationFee")
-
-	if err != nil {
-		return *new(*big.Int), err
-	}
-
-	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
-
-	return out0, err
-
-}
-
-// FinalizationFee is a free data retrieval call binding the contract method 0x78d3d576.
-//
-// Solidity: function finalizationFee() view returns(uint256)
-func (_L1gateway *L1gatewaySession) FinalizationFee() (*big.Int, error) {
-	return _L1gateway.Contract.FinalizationFee(&_L1gateway.CallOpts)
-}
-
-// FinalizationFee is a free data retrieval call binding the contract method 0x78d3d576.
-//
-// Solidity: function finalizationFee() view returns(uint256)
-func (_L1gateway *L1gatewayCallerSession) FinalizationFee() (*big.Int, error) {
-	return _L1gateway.Contract.FinalizationFee(&_L1gateway.CallOpts)
+// Solidity: function counterpartyFinalizationFee() view returns(uint256)
+func (_L1gateway *L1gatewayCallerSession) CounterpartyFinalizationFee() (*big.Int, error) {
+	return _L1gateway.Contract.CounterpartyFinalizationFee(&_L1gateway.CallOpts)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
@@ -542,46 +511,46 @@ func (_L1gateway *L1gatewayTransactorSession) AcceptOwnership() (*types.Transact
 	return _L1gateway.Contract.AcceptOwnership(&_L1gateway.TransactOpts)
 }
 
-// FinalizeTransfer is a paid mutator transaction binding the contract method 0xc40a7c82.
+// FinalizeTransfer is a paid mutator transaction binding the contract method 0x169235ed.
 //
-// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx) returns()
-func (_L1gateway *L1gatewayTransactor) FinalizeTransfer(opts *bind.TransactOpts, _recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int) (*types.Transaction, error) {
-	return _L1gateway.contract.Transact(opts, "finalizeTransfer", _recipient, _amount, _counterpartyIdx)
+// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx, uint256 _finalizationFee) returns()
+func (_L1gateway *L1gatewayTransactor) FinalizeTransfer(opts *bind.TransactOpts, _recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int, _finalizationFee *big.Int) (*types.Transaction, error) {
+	return _L1gateway.contract.Transact(opts, "finalizeTransfer", _recipient, _amount, _counterpartyIdx, _finalizationFee)
 }
 
-// FinalizeTransfer is a paid mutator transaction binding the contract method 0xc40a7c82.
+// FinalizeTransfer is a paid mutator transaction binding the contract method 0x169235ed.
 //
-// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx) returns()
-func (_L1gateway *L1gatewaySession) FinalizeTransfer(_recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int) (*types.Transaction, error) {
-	return _L1gateway.Contract.FinalizeTransfer(&_L1gateway.TransactOpts, _recipient, _amount, _counterpartyIdx)
+// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx, uint256 _finalizationFee) returns()
+func (_L1gateway *L1gatewaySession) FinalizeTransfer(_recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int, _finalizationFee *big.Int) (*types.Transaction, error) {
+	return _L1gateway.Contract.FinalizeTransfer(&_L1gateway.TransactOpts, _recipient, _amount, _counterpartyIdx, _finalizationFee)
 }
 
-// FinalizeTransfer is a paid mutator transaction binding the contract method 0xc40a7c82.
+// FinalizeTransfer is a paid mutator transaction binding the contract method 0x169235ed.
 //
-// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx) returns()
-func (_L1gateway *L1gatewayTransactorSession) FinalizeTransfer(_recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int) (*types.Transaction, error) {
-	return _L1gateway.Contract.FinalizeTransfer(&_L1gateway.TransactOpts, _recipient, _amount, _counterpartyIdx)
+// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx, uint256 _finalizationFee) returns()
+func (_L1gateway *L1gatewayTransactorSession) FinalizeTransfer(_recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int, _finalizationFee *big.Int) (*types.Transaction, error) {
+	return _L1gateway.Contract.FinalizeTransfer(&_L1gateway.TransactOpts, _recipient, _amount, _counterpartyIdx, _finalizationFee)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xeb990c59.
+// Initialize is a paid mutator transaction binding the contract method 0x1794bb3c.
 //
-// Solidity: function initialize(address _owner, address _relayer, uint256 _finalizationFee, uint256 _counterpartyFee) returns()
-func (_L1gateway *L1gatewayTransactor) Initialize(opts *bind.TransactOpts, _owner common.Address, _relayer common.Address, _finalizationFee *big.Int, _counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _L1gateway.contract.Transact(opts, "initialize", _owner, _relayer, _finalizationFee, _counterpartyFee)
+// Solidity: function initialize(address _owner, address _relayer, uint256 _counterpartyFinalizationFee) returns()
+func (_L1gateway *L1gatewayTransactor) Initialize(opts *bind.TransactOpts, _owner common.Address, _relayer common.Address, _counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _L1gateway.contract.Transact(opts, "initialize", _owner, _relayer, _counterpartyFinalizationFee)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xeb990c59.
+// Initialize is a paid mutator transaction binding the contract method 0x1794bb3c.
 //
-// Solidity: function initialize(address _owner, address _relayer, uint256 _finalizationFee, uint256 _counterpartyFee) returns()
-func (_L1gateway *L1gatewaySession) Initialize(_owner common.Address, _relayer common.Address, _finalizationFee *big.Int, _counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _L1gateway.Contract.Initialize(&_L1gateway.TransactOpts, _owner, _relayer, _finalizationFee, _counterpartyFee)
+// Solidity: function initialize(address _owner, address _relayer, uint256 _counterpartyFinalizationFee) returns()
+func (_L1gateway *L1gatewaySession) Initialize(_owner common.Address, _relayer common.Address, _counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _L1gateway.Contract.Initialize(&_L1gateway.TransactOpts, _owner, _relayer, _counterpartyFinalizationFee)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xeb990c59.
+// Initialize is a paid mutator transaction binding the contract method 0x1794bb3c.
 //
-// Solidity: function initialize(address _owner, address _relayer, uint256 _finalizationFee, uint256 _counterpartyFee) returns()
-func (_L1gateway *L1gatewayTransactorSession) Initialize(_owner common.Address, _relayer common.Address, _finalizationFee *big.Int, _counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _L1gateway.Contract.Initialize(&_L1gateway.TransactOpts, _owner, _relayer, _finalizationFee, _counterpartyFee)
+// Solidity: function initialize(address _owner, address _relayer, uint256 _counterpartyFinalizationFee) returns()
+func (_L1gateway *L1gatewayTransactorSession) Initialize(_owner common.Address, _relayer common.Address, _counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _L1gateway.Contract.Initialize(&_L1gateway.TransactOpts, _owner, _relayer, _counterpartyFinalizationFee)
 }
 
 // InitiateTransfer is a paid mutator transaction binding the contract method 0xb504cd1e.
@@ -647,46 +616,25 @@ func (_L1gateway *L1gatewayTransactorSession) RenounceOwnership() (*types.Transa
 	return _L1gateway.Contract.RenounceOwnership(&_L1gateway.TransactOpts)
 }
 
-// SetCounterpartyFee is a paid mutator transaction binding the contract method 0x30ef0586.
+// SetCounterpartyFinalizationFee is a paid mutator transaction binding the contract method 0x55f4bdfc.
 //
-// Solidity: function setCounterpartyFee(uint256 _counterpartyFee) returns()
-func (_L1gateway *L1gatewayTransactor) SetCounterpartyFee(opts *bind.TransactOpts, _counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _L1gateway.contract.Transact(opts, "setCounterpartyFee", _counterpartyFee)
+// Solidity: function setCounterpartyFinalizationFee(uint256 _counterpartyFinalizationFee) returns()
+func (_L1gateway *L1gatewayTransactor) SetCounterpartyFinalizationFee(opts *bind.TransactOpts, _counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _L1gateway.contract.Transact(opts, "setCounterpartyFinalizationFee", _counterpartyFinalizationFee)
 }
 
-// SetCounterpartyFee is a paid mutator transaction binding the contract method 0x30ef0586.
+// SetCounterpartyFinalizationFee is a paid mutator transaction binding the contract method 0x55f4bdfc.
 //
-// Solidity: function setCounterpartyFee(uint256 _counterpartyFee) returns()
-func (_L1gateway *L1gatewaySession) SetCounterpartyFee(_counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _L1gateway.Contract.SetCounterpartyFee(&_L1gateway.TransactOpts, _counterpartyFee)
+// Solidity: function setCounterpartyFinalizationFee(uint256 _counterpartyFinalizationFee) returns()
+func (_L1gateway *L1gatewaySession) SetCounterpartyFinalizationFee(_counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _L1gateway.Contract.SetCounterpartyFinalizationFee(&_L1gateway.TransactOpts, _counterpartyFinalizationFee)
 }
 
-// SetCounterpartyFee is a paid mutator transaction binding the contract method 0x30ef0586.
+// SetCounterpartyFinalizationFee is a paid mutator transaction binding the contract method 0x55f4bdfc.
 //
-// Solidity: function setCounterpartyFee(uint256 _counterpartyFee) returns()
-func (_L1gateway *L1gatewayTransactorSession) SetCounterpartyFee(_counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _L1gateway.Contract.SetCounterpartyFee(&_L1gateway.TransactOpts, _counterpartyFee)
-}
-
-// SetFinalizationFee is a paid mutator transaction binding the contract method 0x21d411a1.
-//
-// Solidity: function setFinalizationFee(uint256 _finalizationFee) returns()
-func (_L1gateway *L1gatewayTransactor) SetFinalizationFee(opts *bind.TransactOpts, _finalizationFee *big.Int) (*types.Transaction, error) {
-	return _L1gateway.contract.Transact(opts, "setFinalizationFee", _finalizationFee)
-}
-
-// SetFinalizationFee is a paid mutator transaction binding the contract method 0x21d411a1.
-//
-// Solidity: function setFinalizationFee(uint256 _finalizationFee) returns()
-func (_L1gateway *L1gatewaySession) SetFinalizationFee(_finalizationFee *big.Int) (*types.Transaction, error) {
-	return _L1gateway.Contract.SetFinalizationFee(&_L1gateway.TransactOpts, _finalizationFee)
-}
-
-// SetFinalizationFee is a paid mutator transaction binding the contract method 0x21d411a1.
-//
-// Solidity: function setFinalizationFee(uint256 _finalizationFee) returns()
-func (_L1gateway *L1gatewayTransactorSession) SetFinalizationFee(_finalizationFee *big.Int) (*types.Transaction, error) {
-	return _L1gateway.Contract.SetFinalizationFee(&_L1gateway.TransactOpts, _finalizationFee)
+// Solidity: function setCounterpartyFinalizationFee(uint256 _counterpartyFinalizationFee) returns()
+func (_L1gateway *L1gatewayTransactorSession) SetCounterpartyFinalizationFee(_counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _L1gateway.Contract.SetCounterpartyFinalizationFee(&_L1gateway.TransactOpts, _counterpartyFinalizationFee)
 }
 
 // SetRelayer is a paid mutator transaction binding the contract method 0x6548e9bc.
@@ -836,9 +784,9 @@ func (_L1gateway *L1gatewayTransactorSession) Receive() (*types.Transaction, err
 	return _L1gateway.Contract.Receive(&_L1gateway.TransactOpts)
 }
 
-// L1gatewayCounterpartyFeeSetIterator is returned from FilterCounterpartyFeeSet and is used to iterate over the raw logs and unpacked data for CounterpartyFeeSet events raised by the L1gateway contract.
-type L1gatewayCounterpartyFeeSetIterator struct {
-	Event *L1gatewayCounterpartyFeeSet // Event containing the contract specifics and raw log
+// L1gatewayCounterpartyFinalizationFeeSetIterator is returned from FilterCounterpartyFinalizationFeeSet and is used to iterate over the raw logs and unpacked data for CounterpartyFinalizationFeeSet events raised by the L1gateway contract.
+type L1gatewayCounterpartyFinalizationFeeSetIterator struct {
+	Event *L1gatewayCounterpartyFinalizationFeeSet // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -852,7 +800,7 @@ type L1gatewayCounterpartyFeeSetIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *L1gatewayCounterpartyFeeSetIterator) Next() bool {
+func (it *L1gatewayCounterpartyFinalizationFeeSetIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -861,7 +809,7 @@ func (it *L1gatewayCounterpartyFeeSetIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(L1gatewayCounterpartyFeeSet)
+			it.Event = new(L1gatewayCounterpartyFinalizationFeeSet)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -876,7 +824,7 @@ func (it *L1gatewayCounterpartyFeeSetIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(L1gatewayCounterpartyFeeSet)
+		it.Event = new(L1gatewayCounterpartyFinalizationFeeSet)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -892,41 +840,41 @@ func (it *L1gatewayCounterpartyFeeSetIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *L1gatewayCounterpartyFeeSetIterator) Error() error {
+func (it *L1gatewayCounterpartyFinalizationFeeSetIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *L1gatewayCounterpartyFeeSetIterator) Close() error {
+func (it *L1gatewayCounterpartyFinalizationFeeSetIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// L1gatewayCounterpartyFeeSet represents a CounterpartyFeeSet event raised by the L1gateway contract.
-type L1gatewayCounterpartyFeeSet struct {
-	CounterpartyFee *big.Int
-	Raw             types.Log // Blockchain specific contextual infos
+// L1gatewayCounterpartyFinalizationFeeSet represents a CounterpartyFinalizationFeeSet event raised by the L1gateway contract.
+type L1gatewayCounterpartyFinalizationFeeSet struct {
+	CounterpartyFinalizationFee *big.Int
+	Raw                         types.Log // Blockchain specific contextual infos
 }
 
-// FilterCounterpartyFeeSet is a free log retrieval operation binding the contract event 0x05c0c89ce202456ae9a28898a2ea3b1b0bc57c7a775275f31fa6bcd6b5c0effa.
+// FilterCounterpartyFinalizationFeeSet is a free log retrieval operation binding the contract event 0xfd0467d48910fb6e6de1f4e0b9eedc9e04a7c227bad40d827a84a2b650ec0b7f.
 //
-// Solidity: event CounterpartyFeeSet(uint256 counterpartyFee)
-func (_L1gateway *L1gatewayFilterer) FilterCounterpartyFeeSet(opts *bind.FilterOpts) (*L1gatewayCounterpartyFeeSetIterator, error) {
+// Solidity: event CounterpartyFinalizationFeeSet(uint256 counterpartyFinalizationFee)
+func (_L1gateway *L1gatewayFilterer) FilterCounterpartyFinalizationFeeSet(opts *bind.FilterOpts) (*L1gatewayCounterpartyFinalizationFeeSetIterator, error) {
 
-	logs, sub, err := _L1gateway.contract.FilterLogs(opts, "CounterpartyFeeSet")
+	logs, sub, err := _L1gateway.contract.FilterLogs(opts, "CounterpartyFinalizationFeeSet")
 	if err != nil {
 		return nil, err
 	}
-	return &L1gatewayCounterpartyFeeSetIterator{contract: _L1gateway.contract, event: "CounterpartyFeeSet", logs: logs, sub: sub}, nil
+	return &L1gatewayCounterpartyFinalizationFeeSetIterator{contract: _L1gateway.contract, event: "CounterpartyFinalizationFeeSet", logs: logs, sub: sub}, nil
 }
 
-// WatchCounterpartyFeeSet is a free log subscription operation binding the contract event 0x05c0c89ce202456ae9a28898a2ea3b1b0bc57c7a775275f31fa6bcd6b5c0effa.
+// WatchCounterpartyFinalizationFeeSet is a free log subscription operation binding the contract event 0xfd0467d48910fb6e6de1f4e0b9eedc9e04a7c227bad40d827a84a2b650ec0b7f.
 //
-// Solidity: event CounterpartyFeeSet(uint256 counterpartyFee)
-func (_L1gateway *L1gatewayFilterer) WatchCounterpartyFeeSet(opts *bind.WatchOpts, sink chan<- *L1gatewayCounterpartyFeeSet) (event.Subscription, error) {
+// Solidity: event CounterpartyFinalizationFeeSet(uint256 counterpartyFinalizationFee)
+func (_L1gateway *L1gatewayFilterer) WatchCounterpartyFinalizationFeeSet(opts *bind.WatchOpts, sink chan<- *L1gatewayCounterpartyFinalizationFeeSet) (event.Subscription, error) {
 
-	logs, sub, err := _L1gateway.contract.WatchLogs(opts, "CounterpartyFeeSet")
+	logs, sub, err := _L1gateway.contract.WatchLogs(opts, "CounterpartyFinalizationFeeSet")
 	if err != nil {
 		return nil, err
 	}
@@ -936,8 +884,8 @@ func (_L1gateway *L1gatewayFilterer) WatchCounterpartyFeeSet(opts *bind.WatchOpt
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(L1gatewayCounterpartyFeeSet)
-				if err := _L1gateway.contract.UnpackLog(event, "CounterpartyFeeSet", log); err != nil {
+				event := new(L1gatewayCounterpartyFinalizationFeeSet)
+				if err := _L1gateway.contract.UnpackLog(event, "CounterpartyFinalizationFeeSet", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -958,146 +906,12 @@ func (_L1gateway *L1gatewayFilterer) WatchCounterpartyFeeSet(opts *bind.WatchOpt
 	}), nil
 }
 
-// ParseCounterpartyFeeSet is a log parse operation binding the contract event 0x05c0c89ce202456ae9a28898a2ea3b1b0bc57c7a775275f31fa6bcd6b5c0effa.
+// ParseCounterpartyFinalizationFeeSet is a log parse operation binding the contract event 0xfd0467d48910fb6e6de1f4e0b9eedc9e04a7c227bad40d827a84a2b650ec0b7f.
 //
-// Solidity: event CounterpartyFeeSet(uint256 counterpartyFee)
-func (_L1gateway *L1gatewayFilterer) ParseCounterpartyFeeSet(log types.Log) (*L1gatewayCounterpartyFeeSet, error) {
-	event := new(L1gatewayCounterpartyFeeSet)
-	if err := _L1gateway.contract.UnpackLog(event, "CounterpartyFeeSet", log); err != nil {
-		return nil, err
-	}
-	event.Raw = log
-	return event, nil
-}
-
-// L1gatewayFinalizationFeeSetIterator is returned from FilterFinalizationFeeSet and is used to iterate over the raw logs and unpacked data for FinalizationFeeSet events raised by the L1gateway contract.
-type L1gatewayFinalizationFeeSetIterator struct {
-	Event *L1gatewayFinalizationFeeSet // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log        // Log channel receiving the found contract events
-	sub  ethereum.Subscription // Subscription for errors, completion and termination
-	done bool                  // Whether the subscription completed delivering logs
-	fail error                 // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *L1gatewayFinalizationFeeSetIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(L1gatewayFinalizationFeeSet)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(L1gatewayFinalizationFeeSet)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *L1gatewayFinalizationFeeSetIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *L1gatewayFinalizationFeeSetIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// L1gatewayFinalizationFeeSet represents a FinalizationFeeSet event raised by the L1gateway contract.
-type L1gatewayFinalizationFeeSet struct {
-	FinalizationFee *big.Int
-	Raw             types.Log // Blockchain specific contextual infos
-}
-
-// FilterFinalizationFeeSet is a free log retrieval operation binding the contract event 0xd636108a5ebf9fe91b4bf69bc6776a0ef5c6a54e4d945c2aeeaa08a2bf6b0bc5.
-//
-// Solidity: event FinalizationFeeSet(uint256 finalizationFee)
-func (_L1gateway *L1gatewayFilterer) FilterFinalizationFeeSet(opts *bind.FilterOpts) (*L1gatewayFinalizationFeeSetIterator, error) {
-
-	logs, sub, err := _L1gateway.contract.FilterLogs(opts, "FinalizationFeeSet")
-	if err != nil {
-		return nil, err
-	}
-	return &L1gatewayFinalizationFeeSetIterator{contract: _L1gateway.contract, event: "FinalizationFeeSet", logs: logs, sub: sub}, nil
-}
-
-// WatchFinalizationFeeSet is a free log subscription operation binding the contract event 0xd636108a5ebf9fe91b4bf69bc6776a0ef5c6a54e4d945c2aeeaa08a2bf6b0bc5.
-//
-// Solidity: event FinalizationFeeSet(uint256 finalizationFee)
-func (_L1gateway *L1gatewayFilterer) WatchFinalizationFeeSet(opts *bind.WatchOpts, sink chan<- *L1gatewayFinalizationFeeSet) (event.Subscription, error) {
-
-	logs, sub, err := _L1gateway.contract.WatchLogs(opts, "FinalizationFeeSet")
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(L1gatewayFinalizationFeeSet)
-				if err := _L1gateway.contract.UnpackLog(event, "FinalizationFeeSet", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseFinalizationFeeSet is a log parse operation binding the contract event 0xd636108a5ebf9fe91b4bf69bc6776a0ef5c6a54e4d945c2aeeaa08a2bf6b0bc5.
-//
-// Solidity: event FinalizationFeeSet(uint256 finalizationFee)
-func (_L1gateway *L1gatewayFilterer) ParseFinalizationFeeSet(log types.Log) (*L1gatewayFinalizationFeeSet, error) {
-	event := new(L1gatewayFinalizationFeeSet)
-	if err := _L1gateway.contract.UnpackLog(event, "FinalizationFeeSet", log); err != nil {
+// Solidity: event CounterpartyFinalizationFeeSet(uint256 counterpartyFinalizationFee)
+func (_L1gateway *L1gatewayFilterer) ParseCounterpartyFinalizationFeeSet(log types.Log) (*L1gatewayCounterpartyFinalizationFeeSet, error) {
+	event := new(L1gatewayCounterpartyFinalizationFeeSet)
+	if err := _L1gateway.contract.UnpackLog(event, "CounterpartyFinalizationFeeSet", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
@@ -2047,16 +1861,17 @@ func (it *L1gatewayTransferInitiatedIterator) Close() error {
 
 // L1gatewayTransferInitiated represents a TransferInitiated event raised by the L1gateway contract.
 type L1gatewayTransferInitiated struct {
-	Sender      common.Address
-	Recipient   common.Address
-	Amount      *big.Int
-	TransferIdx *big.Int
-	Raw         types.Log // Blockchain specific contextual infos
+	Sender                      common.Address
+	Recipient                   common.Address
+	Amount                      *big.Int
+	TransferIdx                 *big.Int
+	CounterpartyFinalizationFee *big.Int
+	Raw                         types.Log // Blockchain specific contextual infos
 }
 
-// FilterTransferInitiated is a free log retrieval operation binding the contract event 0x6abe792a4e9e702afbc17fdac3c94f6ed1d8c9a8e4917c99672474b3f775ab43.
+// FilterTransferInitiated is a free log retrieval operation binding the contract event 0xb6167f4688b09f3299421570723fc91f0bd78d6f55e8d51fbfca3bfbda7a2664.
 //
-// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx)
+// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx, uint256 counterpartyFinalizationFee)
 func (_L1gateway *L1gatewayFilterer) FilterTransferInitiated(opts *bind.FilterOpts, sender []common.Address, recipient []common.Address, transferIdx []*big.Int) (*L1gatewayTransferInitiatedIterator, error) {
 
 	var senderRule []interface{}
@@ -2080,9 +1895,9 @@ func (_L1gateway *L1gatewayFilterer) FilterTransferInitiated(opts *bind.FilterOp
 	return &L1gatewayTransferInitiatedIterator{contract: _L1gateway.contract, event: "TransferInitiated", logs: logs, sub: sub}, nil
 }
 
-// WatchTransferInitiated is a free log subscription operation binding the contract event 0x6abe792a4e9e702afbc17fdac3c94f6ed1d8c9a8e4917c99672474b3f775ab43.
+// WatchTransferInitiated is a free log subscription operation binding the contract event 0xb6167f4688b09f3299421570723fc91f0bd78d6f55e8d51fbfca3bfbda7a2664.
 //
-// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx)
+// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx, uint256 counterpartyFinalizationFee)
 func (_L1gateway *L1gatewayFilterer) WatchTransferInitiated(opts *bind.WatchOpts, sink chan<- *L1gatewayTransferInitiated, sender []common.Address, recipient []common.Address, transferIdx []*big.Int) (event.Subscription, error) {
 
 	var senderRule []interface{}
@@ -2131,9 +1946,9 @@ func (_L1gateway *L1gatewayFilterer) WatchTransferInitiated(opts *bind.WatchOpts
 	}), nil
 }
 
-// ParseTransferInitiated is a log parse operation binding the contract event 0x6abe792a4e9e702afbc17fdac3c94f6ed1d8c9a8e4917c99672474b3f775ab43.
+// ParseTransferInitiated is a log parse operation binding the contract event 0xb6167f4688b09f3299421570723fc91f0bd78d6f55e8d51fbfca3bfbda7a2664.
 //
-// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx)
+// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx, uint256 counterpartyFinalizationFee)
 func (_L1gateway *L1gatewayFilterer) ParseTransferInitiated(log types.Log) (*L1gatewayTransferInitiated, error) {
 	event := new(L1gatewayTransferInitiated)
 	if err := _L1gateway.contract.UnpackLog(event, "TransferInitiated", log); err != nil {

--- a/contracts-abi/clients/SettlementGateway/SettlementGateway.go
+++ b/contracts-abi/clients/SettlementGateway/SettlementGateway.go
@@ -31,7 +31,7 @@ var (
 
 // SettlementgatewayMetaData contains all meta data concerning the Settlementgateway contract.
 var SettlementgatewayMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"allocatorAddr\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"counterpartyFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizationFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizeTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_allocatorAddr\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_relayer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_finalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initiateTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"returnIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"relayer\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setCounterpartyFee\",\"inputs\":[{\"name\":\"_counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setFinalizationFee\",\"inputs\":[{\"name\":\"_finalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRelayer\",\"inputs\":[{\"name\":\"_relayer\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferFinalizedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferInitiatedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"event\",\"name\":\"CounterpartyFeeSet\",\"inputs\":[{\"name\":\"counterpartyFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"FinalizationFeeSet\",\"inputs\":[{\"name\":\"finalizationFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RelayerSet\",\"inputs\":[{\"name\":\"relayer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferFinalized\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferInitiated\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"transferIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"AmountTooSmall\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"CounterpartyFeeTooSmall\",\"inputs\":[{\"name\":\"_counterpartyFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FinalizationFeeTooSmall\",\"inputs\":[{\"name\":\"_finalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"IncorrectEtherValueSent\",\"inputs\":[{\"name\":\"msgValue\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountExpected\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidCounterpartyIndex\",\"inputs\":[{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"transferFinalizedIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReceive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RelayerCannotBeZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SenderNotRelayer\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"relayer\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"TransferFailed\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"allocatorAddr\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"counterpartyFinalizationFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizeTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_finalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_allocatorAddr\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_relayer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_counterpartyFinalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initiateTransfer\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"returnIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"relayer\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setCounterpartyFinalizationFee\",\"inputs\":[{\"name\":\"_counterpartyFinalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRelayer\",\"inputs\":[{\"name\":\"_relayer\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferFinalizedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferInitiatedIdx\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"event\",\"name\":\"CounterpartyFinalizationFeeSet\",\"inputs\":[{\"name\":\"counterpartyFinalizationFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RelayerSet\",\"inputs\":[{\"name\":\"relayer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferFinalized\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TransferInitiated\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"transferIdx\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"counterpartyFinalizationFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"AmountTooSmall\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"counterpartyFinalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"CounterpartyFinalizationFeeTooSmall\",\"inputs\":[{\"name\":\"_counterpartyFinalizationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IncorrectEtherValueSent\",\"inputs\":[{\"name\":\"msgValue\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountExpected\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidCounterpartyIndex\",\"inputs\":[{\"name\":\"counterpartyIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"transferFinalizedIdx\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReceive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RelayerCannotBeZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SenderNotRelayer\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"relayer\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"TransferFailed\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]",
 }
 
 // SettlementgatewayABI is the input ABI used to generate the binding from.
@@ -242,12 +242,12 @@ func (_Settlementgateway *SettlementgatewayCallerSession) AllocatorAddr() (commo
 	return _Settlementgateway.Contract.AllocatorAddr(&_Settlementgateway.CallOpts)
 }
 
-// CounterpartyFee is a free data retrieval call binding the contract method 0x97599011.
+// CounterpartyFinalizationFee is a free data retrieval call binding the contract method 0xce4ab0ad.
 //
-// Solidity: function counterpartyFee() view returns(uint256)
-func (_Settlementgateway *SettlementgatewayCaller) CounterpartyFee(opts *bind.CallOpts) (*big.Int, error) {
+// Solidity: function counterpartyFinalizationFee() view returns(uint256)
+func (_Settlementgateway *SettlementgatewayCaller) CounterpartyFinalizationFee(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _Settlementgateway.contract.Call(opts, &out, "counterpartyFee")
+	err := _Settlementgateway.contract.Call(opts, &out, "counterpartyFinalizationFee")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -259,49 +259,18 @@ func (_Settlementgateway *SettlementgatewayCaller) CounterpartyFee(opts *bind.Ca
 
 }
 
-// CounterpartyFee is a free data retrieval call binding the contract method 0x97599011.
+// CounterpartyFinalizationFee is a free data retrieval call binding the contract method 0xce4ab0ad.
 //
-// Solidity: function counterpartyFee() view returns(uint256)
-func (_Settlementgateway *SettlementgatewaySession) CounterpartyFee() (*big.Int, error) {
-	return _Settlementgateway.Contract.CounterpartyFee(&_Settlementgateway.CallOpts)
+// Solidity: function counterpartyFinalizationFee() view returns(uint256)
+func (_Settlementgateway *SettlementgatewaySession) CounterpartyFinalizationFee() (*big.Int, error) {
+	return _Settlementgateway.Contract.CounterpartyFinalizationFee(&_Settlementgateway.CallOpts)
 }
 
-// CounterpartyFee is a free data retrieval call binding the contract method 0x97599011.
+// CounterpartyFinalizationFee is a free data retrieval call binding the contract method 0xce4ab0ad.
 //
-// Solidity: function counterpartyFee() view returns(uint256)
-func (_Settlementgateway *SettlementgatewayCallerSession) CounterpartyFee() (*big.Int, error) {
-	return _Settlementgateway.Contract.CounterpartyFee(&_Settlementgateway.CallOpts)
-}
-
-// FinalizationFee is a free data retrieval call binding the contract method 0x78d3d576.
-//
-// Solidity: function finalizationFee() view returns(uint256)
-func (_Settlementgateway *SettlementgatewayCaller) FinalizationFee(opts *bind.CallOpts) (*big.Int, error) {
-	var out []interface{}
-	err := _Settlementgateway.contract.Call(opts, &out, "finalizationFee")
-
-	if err != nil {
-		return *new(*big.Int), err
-	}
-
-	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
-
-	return out0, err
-
-}
-
-// FinalizationFee is a free data retrieval call binding the contract method 0x78d3d576.
-//
-// Solidity: function finalizationFee() view returns(uint256)
-func (_Settlementgateway *SettlementgatewaySession) FinalizationFee() (*big.Int, error) {
-	return _Settlementgateway.Contract.FinalizationFee(&_Settlementgateway.CallOpts)
-}
-
-// FinalizationFee is a free data retrieval call binding the contract method 0x78d3d576.
-//
-// Solidity: function finalizationFee() view returns(uint256)
-func (_Settlementgateway *SettlementgatewayCallerSession) FinalizationFee() (*big.Int, error) {
-	return _Settlementgateway.Contract.FinalizationFee(&_Settlementgateway.CallOpts)
+// Solidity: function counterpartyFinalizationFee() view returns(uint256)
+func (_Settlementgateway *SettlementgatewayCallerSession) CounterpartyFinalizationFee() (*big.Int, error) {
+	return _Settlementgateway.Contract.CounterpartyFinalizationFee(&_Settlementgateway.CallOpts)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
@@ -542,46 +511,46 @@ func (_Settlementgateway *SettlementgatewayTransactorSession) AcceptOwnership() 
 	return _Settlementgateway.Contract.AcceptOwnership(&_Settlementgateway.TransactOpts)
 }
 
-// FinalizeTransfer is a paid mutator transaction binding the contract method 0xc40a7c82.
+// FinalizeTransfer is a paid mutator transaction binding the contract method 0x169235ed.
 //
-// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx) returns()
-func (_Settlementgateway *SettlementgatewayTransactor) FinalizeTransfer(opts *bind.TransactOpts, _recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.contract.Transact(opts, "finalizeTransfer", _recipient, _amount, _counterpartyIdx)
+// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx, uint256 _finalizationFee) returns()
+func (_Settlementgateway *SettlementgatewayTransactor) FinalizeTransfer(opts *bind.TransactOpts, _recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int, _finalizationFee *big.Int) (*types.Transaction, error) {
+	return _Settlementgateway.contract.Transact(opts, "finalizeTransfer", _recipient, _amount, _counterpartyIdx, _finalizationFee)
 }
 
-// FinalizeTransfer is a paid mutator transaction binding the contract method 0xc40a7c82.
+// FinalizeTransfer is a paid mutator transaction binding the contract method 0x169235ed.
 //
-// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx) returns()
-func (_Settlementgateway *SettlementgatewaySession) FinalizeTransfer(_recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.Contract.FinalizeTransfer(&_Settlementgateway.TransactOpts, _recipient, _amount, _counterpartyIdx)
+// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx, uint256 _finalizationFee) returns()
+func (_Settlementgateway *SettlementgatewaySession) FinalizeTransfer(_recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int, _finalizationFee *big.Int) (*types.Transaction, error) {
+	return _Settlementgateway.Contract.FinalizeTransfer(&_Settlementgateway.TransactOpts, _recipient, _amount, _counterpartyIdx, _finalizationFee)
 }
 
-// FinalizeTransfer is a paid mutator transaction binding the contract method 0xc40a7c82.
+// FinalizeTransfer is a paid mutator transaction binding the contract method 0x169235ed.
 //
-// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx) returns()
-func (_Settlementgateway *SettlementgatewayTransactorSession) FinalizeTransfer(_recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.Contract.FinalizeTransfer(&_Settlementgateway.TransactOpts, _recipient, _amount, _counterpartyIdx)
+// Solidity: function finalizeTransfer(address _recipient, uint256 _amount, uint256 _counterpartyIdx, uint256 _finalizationFee) returns()
+func (_Settlementgateway *SettlementgatewayTransactorSession) FinalizeTransfer(_recipient common.Address, _amount *big.Int, _counterpartyIdx *big.Int, _finalizationFee *big.Int) (*types.Transaction, error) {
+	return _Settlementgateway.Contract.FinalizeTransfer(&_Settlementgateway.TransactOpts, _recipient, _amount, _counterpartyIdx, _finalizationFee)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xa6b63eb8.
+// Initialize is a paid mutator transaction binding the contract method 0xcf756fdf.
 //
-// Solidity: function initialize(address _allocatorAddr, address _owner, address _relayer, uint256 _finalizationFee, uint256 _counterpartyFee) returns()
-func (_Settlementgateway *SettlementgatewayTransactor) Initialize(opts *bind.TransactOpts, _allocatorAddr common.Address, _owner common.Address, _relayer common.Address, _finalizationFee *big.Int, _counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.contract.Transact(opts, "initialize", _allocatorAddr, _owner, _relayer, _finalizationFee, _counterpartyFee)
+// Solidity: function initialize(address _allocatorAddr, address _owner, address _relayer, uint256 _counterpartyFinalizationFee) returns()
+func (_Settlementgateway *SettlementgatewayTransactor) Initialize(opts *bind.TransactOpts, _allocatorAddr common.Address, _owner common.Address, _relayer common.Address, _counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _Settlementgateway.contract.Transact(opts, "initialize", _allocatorAddr, _owner, _relayer, _counterpartyFinalizationFee)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xa6b63eb8.
+// Initialize is a paid mutator transaction binding the contract method 0xcf756fdf.
 //
-// Solidity: function initialize(address _allocatorAddr, address _owner, address _relayer, uint256 _finalizationFee, uint256 _counterpartyFee) returns()
-func (_Settlementgateway *SettlementgatewaySession) Initialize(_allocatorAddr common.Address, _owner common.Address, _relayer common.Address, _finalizationFee *big.Int, _counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.Contract.Initialize(&_Settlementgateway.TransactOpts, _allocatorAddr, _owner, _relayer, _finalizationFee, _counterpartyFee)
+// Solidity: function initialize(address _allocatorAddr, address _owner, address _relayer, uint256 _counterpartyFinalizationFee) returns()
+func (_Settlementgateway *SettlementgatewaySession) Initialize(_allocatorAddr common.Address, _owner common.Address, _relayer common.Address, _counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _Settlementgateway.Contract.Initialize(&_Settlementgateway.TransactOpts, _allocatorAddr, _owner, _relayer, _counterpartyFinalizationFee)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xa6b63eb8.
+// Initialize is a paid mutator transaction binding the contract method 0xcf756fdf.
 //
-// Solidity: function initialize(address _allocatorAddr, address _owner, address _relayer, uint256 _finalizationFee, uint256 _counterpartyFee) returns()
-func (_Settlementgateway *SettlementgatewayTransactorSession) Initialize(_allocatorAddr common.Address, _owner common.Address, _relayer common.Address, _finalizationFee *big.Int, _counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.Contract.Initialize(&_Settlementgateway.TransactOpts, _allocatorAddr, _owner, _relayer, _finalizationFee, _counterpartyFee)
+// Solidity: function initialize(address _allocatorAddr, address _owner, address _relayer, uint256 _counterpartyFinalizationFee) returns()
+func (_Settlementgateway *SettlementgatewayTransactorSession) Initialize(_allocatorAddr common.Address, _owner common.Address, _relayer common.Address, _counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _Settlementgateway.Contract.Initialize(&_Settlementgateway.TransactOpts, _allocatorAddr, _owner, _relayer, _counterpartyFinalizationFee)
 }
 
 // InitiateTransfer is a paid mutator transaction binding the contract method 0xb504cd1e.
@@ -647,46 +616,25 @@ func (_Settlementgateway *SettlementgatewayTransactorSession) RenounceOwnership(
 	return _Settlementgateway.Contract.RenounceOwnership(&_Settlementgateway.TransactOpts)
 }
 
-// SetCounterpartyFee is a paid mutator transaction binding the contract method 0x30ef0586.
+// SetCounterpartyFinalizationFee is a paid mutator transaction binding the contract method 0x55f4bdfc.
 //
-// Solidity: function setCounterpartyFee(uint256 _counterpartyFee) returns()
-func (_Settlementgateway *SettlementgatewayTransactor) SetCounterpartyFee(opts *bind.TransactOpts, _counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.contract.Transact(opts, "setCounterpartyFee", _counterpartyFee)
+// Solidity: function setCounterpartyFinalizationFee(uint256 _counterpartyFinalizationFee) returns()
+func (_Settlementgateway *SettlementgatewayTransactor) SetCounterpartyFinalizationFee(opts *bind.TransactOpts, _counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _Settlementgateway.contract.Transact(opts, "setCounterpartyFinalizationFee", _counterpartyFinalizationFee)
 }
 
-// SetCounterpartyFee is a paid mutator transaction binding the contract method 0x30ef0586.
+// SetCounterpartyFinalizationFee is a paid mutator transaction binding the contract method 0x55f4bdfc.
 //
-// Solidity: function setCounterpartyFee(uint256 _counterpartyFee) returns()
-func (_Settlementgateway *SettlementgatewaySession) SetCounterpartyFee(_counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.Contract.SetCounterpartyFee(&_Settlementgateway.TransactOpts, _counterpartyFee)
+// Solidity: function setCounterpartyFinalizationFee(uint256 _counterpartyFinalizationFee) returns()
+func (_Settlementgateway *SettlementgatewaySession) SetCounterpartyFinalizationFee(_counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _Settlementgateway.Contract.SetCounterpartyFinalizationFee(&_Settlementgateway.TransactOpts, _counterpartyFinalizationFee)
 }
 
-// SetCounterpartyFee is a paid mutator transaction binding the contract method 0x30ef0586.
+// SetCounterpartyFinalizationFee is a paid mutator transaction binding the contract method 0x55f4bdfc.
 //
-// Solidity: function setCounterpartyFee(uint256 _counterpartyFee) returns()
-func (_Settlementgateway *SettlementgatewayTransactorSession) SetCounterpartyFee(_counterpartyFee *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.Contract.SetCounterpartyFee(&_Settlementgateway.TransactOpts, _counterpartyFee)
-}
-
-// SetFinalizationFee is a paid mutator transaction binding the contract method 0x21d411a1.
-//
-// Solidity: function setFinalizationFee(uint256 _finalizationFee) returns()
-func (_Settlementgateway *SettlementgatewayTransactor) SetFinalizationFee(opts *bind.TransactOpts, _finalizationFee *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.contract.Transact(opts, "setFinalizationFee", _finalizationFee)
-}
-
-// SetFinalizationFee is a paid mutator transaction binding the contract method 0x21d411a1.
-//
-// Solidity: function setFinalizationFee(uint256 _finalizationFee) returns()
-func (_Settlementgateway *SettlementgatewaySession) SetFinalizationFee(_finalizationFee *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.Contract.SetFinalizationFee(&_Settlementgateway.TransactOpts, _finalizationFee)
-}
-
-// SetFinalizationFee is a paid mutator transaction binding the contract method 0x21d411a1.
-//
-// Solidity: function setFinalizationFee(uint256 _finalizationFee) returns()
-func (_Settlementgateway *SettlementgatewayTransactorSession) SetFinalizationFee(_finalizationFee *big.Int) (*types.Transaction, error) {
-	return _Settlementgateway.Contract.SetFinalizationFee(&_Settlementgateway.TransactOpts, _finalizationFee)
+// Solidity: function setCounterpartyFinalizationFee(uint256 _counterpartyFinalizationFee) returns()
+func (_Settlementgateway *SettlementgatewayTransactorSession) SetCounterpartyFinalizationFee(_counterpartyFinalizationFee *big.Int) (*types.Transaction, error) {
+	return _Settlementgateway.Contract.SetCounterpartyFinalizationFee(&_Settlementgateway.TransactOpts, _counterpartyFinalizationFee)
 }
 
 // SetRelayer is a paid mutator transaction binding the contract method 0x6548e9bc.
@@ -815,9 +763,9 @@ func (_Settlementgateway *SettlementgatewayTransactorSession) Receive() (*types.
 	return _Settlementgateway.Contract.Receive(&_Settlementgateway.TransactOpts)
 }
 
-// SettlementgatewayCounterpartyFeeSetIterator is returned from FilterCounterpartyFeeSet and is used to iterate over the raw logs and unpacked data for CounterpartyFeeSet events raised by the Settlementgateway contract.
-type SettlementgatewayCounterpartyFeeSetIterator struct {
-	Event *SettlementgatewayCounterpartyFeeSet // Event containing the contract specifics and raw log
+// SettlementgatewayCounterpartyFinalizationFeeSetIterator is returned from FilterCounterpartyFinalizationFeeSet and is used to iterate over the raw logs and unpacked data for CounterpartyFinalizationFeeSet events raised by the Settlementgateway contract.
+type SettlementgatewayCounterpartyFinalizationFeeSetIterator struct {
+	Event *SettlementgatewayCounterpartyFinalizationFeeSet // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -831,7 +779,7 @@ type SettlementgatewayCounterpartyFeeSetIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *SettlementgatewayCounterpartyFeeSetIterator) Next() bool {
+func (it *SettlementgatewayCounterpartyFinalizationFeeSetIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -840,7 +788,7 @@ func (it *SettlementgatewayCounterpartyFeeSetIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(SettlementgatewayCounterpartyFeeSet)
+			it.Event = new(SettlementgatewayCounterpartyFinalizationFeeSet)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -855,7 +803,7 @@ func (it *SettlementgatewayCounterpartyFeeSetIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(SettlementgatewayCounterpartyFeeSet)
+		it.Event = new(SettlementgatewayCounterpartyFinalizationFeeSet)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -871,41 +819,41 @@ func (it *SettlementgatewayCounterpartyFeeSetIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *SettlementgatewayCounterpartyFeeSetIterator) Error() error {
+func (it *SettlementgatewayCounterpartyFinalizationFeeSetIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *SettlementgatewayCounterpartyFeeSetIterator) Close() error {
+func (it *SettlementgatewayCounterpartyFinalizationFeeSetIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// SettlementgatewayCounterpartyFeeSet represents a CounterpartyFeeSet event raised by the Settlementgateway contract.
-type SettlementgatewayCounterpartyFeeSet struct {
-	CounterpartyFee *big.Int
-	Raw             types.Log // Blockchain specific contextual infos
+// SettlementgatewayCounterpartyFinalizationFeeSet represents a CounterpartyFinalizationFeeSet event raised by the Settlementgateway contract.
+type SettlementgatewayCounterpartyFinalizationFeeSet struct {
+	CounterpartyFinalizationFee *big.Int
+	Raw                         types.Log // Blockchain specific contextual infos
 }
 
-// FilterCounterpartyFeeSet is a free log retrieval operation binding the contract event 0x05c0c89ce202456ae9a28898a2ea3b1b0bc57c7a775275f31fa6bcd6b5c0effa.
+// FilterCounterpartyFinalizationFeeSet is a free log retrieval operation binding the contract event 0xfd0467d48910fb6e6de1f4e0b9eedc9e04a7c227bad40d827a84a2b650ec0b7f.
 //
-// Solidity: event CounterpartyFeeSet(uint256 counterpartyFee)
-func (_Settlementgateway *SettlementgatewayFilterer) FilterCounterpartyFeeSet(opts *bind.FilterOpts) (*SettlementgatewayCounterpartyFeeSetIterator, error) {
+// Solidity: event CounterpartyFinalizationFeeSet(uint256 counterpartyFinalizationFee)
+func (_Settlementgateway *SettlementgatewayFilterer) FilterCounterpartyFinalizationFeeSet(opts *bind.FilterOpts) (*SettlementgatewayCounterpartyFinalizationFeeSetIterator, error) {
 
-	logs, sub, err := _Settlementgateway.contract.FilterLogs(opts, "CounterpartyFeeSet")
+	logs, sub, err := _Settlementgateway.contract.FilterLogs(opts, "CounterpartyFinalizationFeeSet")
 	if err != nil {
 		return nil, err
 	}
-	return &SettlementgatewayCounterpartyFeeSetIterator{contract: _Settlementgateway.contract, event: "CounterpartyFeeSet", logs: logs, sub: sub}, nil
+	return &SettlementgatewayCounterpartyFinalizationFeeSetIterator{contract: _Settlementgateway.contract, event: "CounterpartyFinalizationFeeSet", logs: logs, sub: sub}, nil
 }
 
-// WatchCounterpartyFeeSet is a free log subscription operation binding the contract event 0x05c0c89ce202456ae9a28898a2ea3b1b0bc57c7a775275f31fa6bcd6b5c0effa.
+// WatchCounterpartyFinalizationFeeSet is a free log subscription operation binding the contract event 0xfd0467d48910fb6e6de1f4e0b9eedc9e04a7c227bad40d827a84a2b650ec0b7f.
 //
-// Solidity: event CounterpartyFeeSet(uint256 counterpartyFee)
-func (_Settlementgateway *SettlementgatewayFilterer) WatchCounterpartyFeeSet(opts *bind.WatchOpts, sink chan<- *SettlementgatewayCounterpartyFeeSet) (event.Subscription, error) {
+// Solidity: event CounterpartyFinalizationFeeSet(uint256 counterpartyFinalizationFee)
+func (_Settlementgateway *SettlementgatewayFilterer) WatchCounterpartyFinalizationFeeSet(opts *bind.WatchOpts, sink chan<- *SettlementgatewayCounterpartyFinalizationFeeSet) (event.Subscription, error) {
 
-	logs, sub, err := _Settlementgateway.contract.WatchLogs(opts, "CounterpartyFeeSet")
+	logs, sub, err := _Settlementgateway.contract.WatchLogs(opts, "CounterpartyFinalizationFeeSet")
 	if err != nil {
 		return nil, err
 	}
@@ -915,8 +863,8 @@ func (_Settlementgateway *SettlementgatewayFilterer) WatchCounterpartyFeeSet(opt
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(SettlementgatewayCounterpartyFeeSet)
-				if err := _Settlementgateway.contract.UnpackLog(event, "CounterpartyFeeSet", log); err != nil {
+				event := new(SettlementgatewayCounterpartyFinalizationFeeSet)
+				if err := _Settlementgateway.contract.UnpackLog(event, "CounterpartyFinalizationFeeSet", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -937,146 +885,12 @@ func (_Settlementgateway *SettlementgatewayFilterer) WatchCounterpartyFeeSet(opt
 	}), nil
 }
 
-// ParseCounterpartyFeeSet is a log parse operation binding the contract event 0x05c0c89ce202456ae9a28898a2ea3b1b0bc57c7a775275f31fa6bcd6b5c0effa.
+// ParseCounterpartyFinalizationFeeSet is a log parse operation binding the contract event 0xfd0467d48910fb6e6de1f4e0b9eedc9e04a7c227bad40d827a84a2b650ec0b7f.
 //
-// Solidity: event CounterpartyFeeSet(uint256 counterpartyFee)
-func (_Settlementgateway *SettlementgatewayFilterer) ParseCounterpartyFeeSet(log types.Log) (*SettlementgatewayCounterpartyFeeSet, error) {
-	event := new(SettlementgatewayCounterpartyFeeSet)
-	if err := _Settlementgateway.contract.UnpackLog(event, "CounterpartyFeeSet", log); err != nil {
-		return nil, err
-	}
-	event.Raw = log
-	return event, nil
-}
-
-// SettlementgatewayFinalizationFeeSetIterator is returned from FilterFinalizationFeeSet and is used to iterate over the raw logs and unpacked data for FinalizationFeeSet events raised by the Settlementgateway contract.
-type SettlementgatewayFinalizationFeeSetIterator struct {
-	Event *SettlementgatewayFinalizationFeeSet // Event containing the contract specifics and raw log
-
-	contract *bind.BoundContract // Generic contract to use for unpacking event data
-	event    string              // Event name to use for unpacking event data
-
-	logs chan types.Log        // Log channel receiving the found contract events
-	sub  ethereum.Subscription // Subscription for errors, completion and termination
-	done bool                  // Whether the subscription completed delivering logs
-	fail error                 // Occurred error to stop iteration
-}
-
-// Next advances the iterator to the subsequent event, returning whether there
-// are any more events found. In case of a retrieval or parsing error, false is
-// returned and Error() can be queried for the exact failure.
-func (it *SettlementgatewayFinalizationFeeSetIterator) Next() bool {
-	// If the iterator failed, stop iterating
-	if it.fail != nil {
-		return false
-	}
-	// If the iterator completed, deliver directly whatever's available
-	if it.done {
-		select {
-		case log := <-it.logs:
-			it.Event = new(SettlementgatewayFinalizationFeeSet)
-			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-				it.fail = err
-				return false
-			}
-			it.Event.Raw = log
-			return true
-
-		default:
-			return false
-		}
-	}
-	// Iterator still in progress, wait for either a data or an error event
-	select {
-	case log := <-it.logs:
-		it.Event = new(SettlementgatewayFinalizationFeeSet)
-		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
-			it.fail = err
-			return false
-		}
-		it.Event.Raw = log
-		return true
-
-	case err := <-it.sub.Err():
-		it.done = true
-		it.fail = err
-		return it.Next()
-	}
-}
-
-// Error returns any retrieval or parsing error occurred during filtering.
-func (it *SettlementgatewayFinalizationFeeSetIterator) Error() error {
-	return it.fail
-}
-
-// Close terminates the iteration process, releasing any pending underlying
-// resources.
-func (it *SettlementgatewayFinalizationFeeSetIterator) Close() error {
-	it.sub.Unsubscribe()
-	return nil
-}
-
-// SettlementgatewayFinalizationFeeSet represents a FinalizationFeeSet event raised by the Settlementgateway contract.
-type SettlementgatewayFinalizationFeeSet struct {
-	FinalizationFee *big.Int
-	Raw             types.Log // Blockchain specific contextual infos
-}
-
-// FilterFinalizationFeeSet is a free log retrieval operation binding the contract event 0xd636108a5ebf9fe91b4bf69bc6776a0ef5c6a54e4d945c2aeeaa08a2bf6b0bc5.
-//
-// Solidity: event FinalizationFeeSet(uint256 finalizationFee)
-func (_Settlementgateway *SettlementgatewayFilterer) FilterFinalizationFeeSet(opts *bind.FilterOpts) (*SettlementgatewayFinalizationFeeSetIterator, error) {
-
-	logs, sub, err := _Settlementgateway.contract.FilterLogs(opts, "FinalizationFeeSet")
-	if err != nil {
-		return nil, err
-	}
-	return &SettlementgatewayFinalizationFeeSetIterator{contract: _Settlementgateway.contract, event: "FinalizationFeeSet", logs: logs, sub: sub}, nil
-}
-
-// WatchFinalizationFeeSet is a free log subscription operation binding the contract event 0xd636108a5ebf9fe91b4bf69bc6776a0ef5c6a54e4d945c2aeeaa08a2bf6b0bc5.
-//
-// Solidity: event FinalizationFeeSet(uint256 finalizationFee)
-func (_Settlementgateway *SettlementgatewayFilterer) WatchFinalizationFeeSet(opts *bind.WatchOpts, sink chan<- *SettlementgatewayFinalizationFeeSet) (event.Subscription, error) {
-
-	logs, sub, err := _Settlementgateway.contract.WatchLogs(opts, "FinalizationFeeSet")
-	if err != nil {
-		return nil, err
-	}
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case log := <-logs:
-				// New log arrived, parse the event and forward to the user
-				event := new(SettlementgatewayFinalizationFeeSet)
-				if err := _Settlementgateway.contract.UnpackLog(event, "FinalizationFeeSet", log); err != nil {
-					return err
-				}
-				event.Raw = log
-
-				select {
-				case sink <- event:
-				case err := <-sub.Err():
-					return err
-				case <-quit:
-					return nil
-				}
-			case err := <-sub.Err():
-				return err
-			case <-quit:
-				return nil
-			}
-		}
-	}), nil
-}
-
-// ParseFinalizationFeeSet is a log parse operation binding the contract event 0xd636108a5ebf9fe91b4bf69bc6776a0ef5c6a54e4d945c2aeeaa08a2bf6b0bc5.
-//
-// Solidity: event FinalizationFeeSet(uint256 finalizationFee)
-func (_Settlementgateway *SettlementgatewayFilterer) ParseFinalizationFeeSet(log types.Log) (*SettlementgatewayFinalizationFeeSet, error) {
-	event := new(SettlementgatewayFinalizationFeeSet)
-	if err := _Settlementgateway.contract.UnpackLog(event, "FinalizationFeeSet", log); err != nil {
+// Solidity: event CounterpartyFinalizationFeeSet(uint256 counterpartyFinalizationFee)
+func (_Settlementgateway *SettlementgatewayFilterer) ParseCounterpartyFinalizationFeeSet(log types.Log) (*SettlementgatewayCounterpartyFinalizationFeeSet, error) {
+	event := new(SettlementgatewayCounterpartyFinalizationFeeSet)
+	if err := _Settlementgateway.contract.UnpackLog(event, "CounterpartyFinalizationFeeSet", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
@@ -2026,16 +1840,17 @@ func (it *SettlementgatewayTransferInitiatedIterator) Close() error {
 
 // SettlementgatewayTransferInitiated represents a TransferInitiated event raised by the Settlementgateway contract.
 type SettlementgatewayTransferInitiated struct {
-	Sender      common.Address
-	Recipient   common.Address
-	Amount      *big.Int
-	TransferIdx *big.Int
-	Raw         types.Log // Blockchain specific contextual infos
+	Sender                      common.Address
+	Recipient                   common.Address
+	Amount                      *big.Int
+	TransferIdx                 *big.Int
+	CounterpartyFinalizationFee *big.Int
+	Raw                         types.Log // Blockchain specific contextual infos
 }
 
-// FilterTransferInitiated is a free log retrieval operation binding the contract event 0x6abe792a4e9e702afbc17fdac3c94f6ed1d8c9a8e4917c99672474b3f775ab43.
+// FilterTransferInitiated is a free log retrieval operation binding the contract event 0xb6167f4688b09f3299421570723fc91f0bd78d6f55e8d51fbfca3bfbda7a2664.
 //
-// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx)
+// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx, uint256 counterpartyFinalizationFee)
 func (_Settlementgateway *SettlementgatewayFilterer) FilterTransferInitiated(opts *bind.FilterOpts, sender []common.Address, recipient []common.Address, transferIdx []*big.Int) (*SettlementgatewayTransferInitiatedIterator, error) {
 
 	var senderRule []interface{}
@@ -2059,9 +1874,9 @@ func (_Settlementgateway *SettlementgatewayFilterer) FilterTransferInitiated(opt
 	return &SettlementgatewayTransferInitiatedIterator{contract: _Settlementgateway.contract, event: "TransferInitiated", logs: logs, sub: sub}, nil
 }
 
-// WatchTransferInitiated is a free log subscription operation binding the contract event 0x6abe792a4e9e702afbc17fdac3c94f6ed1d8c9a8e4917c99672474b3f775ab43.
+// WatchTransferInitiated is a free log subscription operation binding the contract event 0xb6167f4688b09f3299421570723fc91f0bd78d6f55e8d51fbfca3bfbda7a2664.
 //
-// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx)
+// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx, uint256 counterpartyFinalizationFee)
 func (_Settlementgateway *SettlementgatewayFilterer) WatchTransferInitiated(opts *bind.WatchOpts, sink chan<- *SettlementgatewayTransferInitiated, sender []common.Address, recipient []common.Address, transferIdx []*big.Int) (event.Subscription, error) {
 
 	var senderRule []interface{}
@@ -2110,9 +1925,9 @@ func (_Settlementgateway *SettlementgatewayFilterer) WatchTransferInitiated(opts
 	}), nil
 }
 
-// ParseTransferInitiated is a log parse operation binding the contract event 0x6abe792a4e9e702afbc17fdac3c94f6ed1d8c9a8e4917c99672474b3f775ab43.
+// ParseTransferInitiated is a log parse operation binding the contract event 0xb6167f4688b09f3299421570723fc91f0bd78d6f55e8d51fbfca3bfbda7a2664.
 //
-// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx)
+// Solidity: event TransferInitiated(address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx, uint256 counterpartyFinalizationFee)
 func (_Settlementgateway *SettlementgatewayFilterer) ParseTransferInitiated(log types.Log) (*SettlementgatewayTransferInitiated, error) {
 	event := new(SettlementgatewayTransferInitiated)
 	if err := _Settlementgateway.contract.UnpackLog(event, "TransferInitiated", log); err != nil {

--- a/contracts/contracts/interfaces/IGateway.sol
+++ b/contracts/contracts/interfaces/IGateway.sol
@@ -12,12 +12,14 @@ interface IGateway {
      * @param recipient Address receiving the tokens.
      * @param amount Ether being transferred in wei.
      * @param transferIdx Current index of this gateway.
+     * @param counterpartyFinalizationFee The finalization fee (wei) paid to the relayer by the counterparty contract.
      */
     event TransferInitiated(
         address indexed sender,
         address indexed recipient,
         uint256 amount,
-        uint256 indexed transferIdx
+        uint256 indexed transferIdx,
+        uint256 counterpartyFinalizationFee
     );
 
     /**
@@ -32,15 +34,13 @@ interface IGateway {
         uint256 indexed counterpartyIdx
     );
 
-    event FinalizationFeeSet(uint256 finalizationFee);
-    event CounterpartyFeeSet(uint256 counterpartyFee);
+    event CounterpartyFinalizationFeeSet(uint256 counterpartyFinalizationFee);
     event RelayerSet(address indexed relayer);
 
     error SenderNotRelayer(address sender, address relayer);
-    error AmountTooSmall(uint256 amount, uint256 counterpartyFee);
+    error AmountTooSmall(uint256 amount, uint256 counterpartyFinalizationFee);
     error InvalidCounterpartyIndex(uint256 counterpartyIdx, uint256 transferFinalizedIdx);
-    error FinalizationFeeTooSmall(uint256 _finalizationFee);
-    error CounterpartyFeeTooSmall(uint256 _counterpartyFee);
+    error CounterpartyFinalizationFeeTooSmall(uint256 _counterpartyFinalizationFee);
     error RelayerCannotBeZeroAddress();
 
     /**
@@ -59,11 +59,13 @@ interface IGateway {
      * @param _recipient Address to receive the tokens.
      * @param _amount Amount of Ether to transfer in wei.
      * @param _counterpartyIdx Index of the counterparty transfer.
+     * @param _finalizationFee The finalization fee (wei) paid to the relayer by the this contract.
      */
     function finalizeTransfer(
         address _recipient,
         uint256 _amount,
-        uint256 _counterpartyIdx
+        uint256 _counterpartyIdx,
+        uint256 _finalizationFee
     ) external;
 
     /**

--- a/contracts/contracts/standard-bridge/Gateway.sol
+++ b/contracts/contracts/standard-bridge/Gateway.sol
@@ -68,7 +68,7 @@ abstract contract Gateway is IGateway, GatewayStorage,
 
     /// @dev Allows owner to set a new counterparty finalization fee.
     function setCounterpartyFinalizationFee(uint256 _counterpartyFinalizationFee) external onlyOwner {
-        require(_counterpartyFinalizationFee > 0, CounterpartyFinalizationFeeTooSmall(_counterpartyFinalizationFee));
+        require(_counterpartyFinalizationFee != 0, CounterpartyFinalizationFeeTooSmall(_counterpartyFinalizationFee));
         counterpartyFinalizationFee = _counterpartyFinalizationFee;
         emit CounterpartyFinalizationFeeSet(_counterpartyFinalizationFee);
     }

--- a/contracts/contracts/standard-bridge/GatewayStorage.sol
+++ b/contracts/contracts/standard-bridge/GatewayStorage.sol
@@ -13,14 +13,11 @@ contract GatewayStorage {
     /// @dev Address of relayer account. 
     address public relayer;
 
-    /// @dev The finalization fee (wei) paid to the relayer by this contract upon transfer finalization.
-    /// This must be greater on average, over time, than what the relayer will pay per finalizeTransfer tx.
-    /// @notice When setting this value, ensure the same value is set as the `counterpartyFee` in the counterparty contract.
-    uint256 public finalizationFee;
-
-    /// @dev The finalization fee (wei) of the counterparty gateway contract, included for UX purposes.
-    /// @notice When setting this value, ensure the same value is set as the `finalizationFee` in the counterparty contract.
-    uint256 public counterpartyFee;
+    /// @dev The finalization fee (wei) of the counterparty gateway contract,
+    /// paid to the relayer by the counterparty contract upon transfer finalization.
+    /// @notice This value must on average, over time, be greater than what the relayer will pay per finalizeTransfer tx on the counterparty chain.
+    /// @notice Consequently, the value may be mutated by the contract owner.
+    uint256 public counterpartyFinalizationFee;
 
     /// @dev See https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
     uint256[48] private __gap;

--- a/contracts/contracts/standard-bridge/L1Gateway.sol
+++ b/contracts/contracts/standard-bridge/L1Gateway.sol
@@ -24,12 +24,10 @@ contract L1Gateway is L1GatewayStorage, Gateway {
     function initialize(
         address _owner, 
         address _relayer, 
-        uint256 _finalizationFee,
-        uint256 _counterpartyFee
+        uint256 _counterpartyFinalizationFee
     ) external initializer {
         relayer = _relayer;
-        finalizationFee = _finalizationFee;
-        counterpartyFee = _counterpartyFee;
+        counterpartyFinalizationFee = _counterpartyFinalizationFee;
         transferInitiatedIdx = 0;
         transferFinalizedIdx = 1; // First expected transfer index is 1
         __Ownable_init(_owner);

--- a/contracts/contracts/standard-bridge/SettlementGateway.sol
+++ b/contracts/contracts/standard-bridge/SettlementGateway.sol
@@ -18,13 +18,11 @@ contract SettlementGateway is Gateway {
         address _allocatorAddr,
         address _owner,
         address _relayer,
-        uint256 _finalizationFee,
-        uint256 _counterpartyFee
+        uint256 _counterpartyFinalizationFee
     ) external initializer {
         allocatorAddr = _allocatorAddr;
         relayer = _relayer;
-        finalizationFee = _finalizationFee;
-        counterpartyFee = _counterpartyFee;
+        counterpartyFinalizationFee = _counterpartyFinalizationFee;
         transferInitiatedIdx = 0;
         transferFinalizedIdx = 1; // First expected transfer index is 1
         __Ownable_init(_owner);

--- a/contracts/scripts/standard-bridge/DeployStandardBridge.s.sol
+++ b/contracts/scripts/standard-bridge/DeployStandardBridge.s.sol
@@ -62,7 +62,6 @@ contract DeploySettlementGateway is BridgeBase {
 
         address relayerAddr = _getRelayerAddress();
         uint256 l1FinalizationFee = _getL1FinalizationFee();
-        uint256 settlementFinalizationFee = _getSettlementFinalizationFee();
 
         require(address(msg.sender).balance >= DEPLOYER_GENESIS_ALLOCATION,
             DeployerMustHaveGenesisAllocation(address(msg.sender).balance, DEPLOYER_GENESIS_ALLOCATION));
@@ -84,8 +83,7 @@ contract DeploySettlementGateway is BridgeBase {
                 (allocatorProxy,
                     msg.sender, // Owner
                     relayerAddr,
-                    settlementFinalizationFee, // SettlementGateway._finalizationFee
-                    l1FinalizationFee)) // SettlementGateway._counterpartyFee
+                    l1FinalizationFee)) // SettlementGateway._counterpartyFinalizationFee
         );
         SettlementGateway settlementGateway = SettlementGateway(payable(sgProxy));
         console.log("SettlementGateway:", address(settlementGateway));
@@ -110,7 +108,6 @@ contract DeployL1Gateway is BridgeBase {
 
         address owner = _getL1OwnerAddress(); // On mainnet, this must be the primev multisig.
         address relayerAddr = _getRelayerAddress();
-        uint256 l1FinalizationFee = _getL1FinalizationFee();
         uint256 settlementFinalizationFee = _getSettlementFinalizationFee();
 
         // Caller needs funds to lock ETH w.r.t mev-commit chain setup cost, and ETH for L1 setup cost.
@@ -122,8 +119,7 @@ contract DeployL1Gateway is BridgeBase {
             abi.encodeCall(L1Gateway.initialize,
                 (owner, // Owner
                     relayerAddr,
-                    l1FinalizationFee, // L1Gateway._finalizationFee
-                    settlementFinalizationFee)) // L1Gateway._counterpartyFee
+                    settlementFinalizationFee)) // L1Gateway._counterpartyFinalizationFee
         );
         L1Gateway l1Gateway = L1Gateway(payable(l1gProxy));
         console.log("L1Gateway:", address(l1Gateway));

--- a/contracts/test/standard-bridge/L1GatewayTest.sol
+++ b/contracts/test/standard-bridge/L1GatewayTest.sol
@@ -14,61 +14,42 @@ contract L1GatewayTest is Test {
     address owner;
     address relayer;
     address bridgeUser;
-    uint256 finalizationFee;
-    uint256 counterpartyFee;
+    uint256 counterpartyFinalizationFee;
 
     function setUp() public {
         owner = address(this); // Original contract deployer as owner
         relayer = address(0x78);
         bridgeUser = address(0x101);
-        finalizationFee = 0.1 ether;
-        counterpartyFee = 0.05 ether;
+        counterpartyFinalizationFee = 0.05 ether;
 
         address l1GatewayProxy = Upgrades.deployUUPSProxy(
             "L1Gateway.sol",
             abi.encodeCall(L1Gateway.initialize,
             (owner, 
             relayer, 
-            finalizationFee, 
-            counterpartyFee))); 
+            counterpartyFinalizationFee))); 
         l1Gateway = L1Gateway(payable(l1GatewayProxy));
     }
 
     function test_ConstructorSetsVariablesCorrectly() public view {
         assertEq(l1Gateway.owner(), owner);
         assertEq(l1Gateway.relayer(), relayer);
-        assertEq(l1Gateway.finalizationFee(), finalizationFee);
-        assertEq(l1Gateway.counterpartyFee(), counterpartyFee);
+        assertEq(l1Gateway.counterpartyFinalizationFee(), counterpartyFinalizationFee);
     }
-    event FinalizationFeeSet(uint256 finalizationFee);
-    event CounterpartyFeeSet(uint256 counterpartyFee);
+    event CounterpartyFinalizationFeeSet(uint256 counterpartyFinalizationFee);
 
-    function test_SetFinalizationFee() public {
+    function test_SetCounterpartyFinalizationFee() public {
         vm.expectRevert(
             abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, vm.addr(888))
         );
         vm.prank(vm.addr(888));
-        l1Gateway.setFinalizationFee(0.0015 ether);
+        l1Gateway.setCounterpartyFinalizationFee(0.0005 ether);
 
-        assertEq(l1Gateway.finalizationFee(), 0.1 ether);
+        assertEq(l1Gateway.counterpartyFinalizationFee(), 0.05 ether);
         vm.expectEmit(true, true, true, true);
-        emit FinalizationFeeSet(0.0015 ether);
-        l1Gateway.setFinalizationFee(0.0015 ether);
-        assertEq(l1Gateway.finalizationFee(), 0.0015 ether);
-    }
-
-    function test_SetCounterpartyFee() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, vm.addr(888))
-        );
-        vm.prank(vm.addr(888));
-        l1Gateway.setCounterpartyFee(0.0005 ether);
-
-        assertEq(l1Gateway.counterpartyFee(), 0.05 ether);
-        vm.expectEmit(true, true, true, true);
-        emit CounterpartyFeeSet(0.0005 ether);
-        l1Gateway.setCounterpartyFee(0.0005 ether);
-        assertEq(l1Gateway.counterpartyFee(), 0.0005 ether);
+        emit CounterpartyFinalizationFeeSet(0.0005 ether);
+        l1Gateway.setCounterpartyFinalizationFee(0.0005 ether);
+        assertEq(l1Gateway.counterpartyFinalizationFee(), 0.0005 ether);
     }
 
     event RelayerSet(address indexed relayer);
@@ -91,7 +72,7 @@ contract L1GatewayTest is Test {
 
     // Expected event signature emitted in initiateTransfer()
     event TransferInitiated(
-        address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx);
+        address indexed sender, address indexed recipient, uint256 amount, uint256 indexed transferIdx, uint256 counterpartyFinalizationFee);
 
     event TransferNeedsWithdrawal(address indexed recipient, uint256 amount);
     event TransferSuccess(address indexed recipient, uint256 amount);
@@ -107,7 +88,7 @@ contract L1GatewayTest is Test {
 
         // Set up expectation for event
         vm.expectEmit(true, true, true, true);
-        emit TransferInitiated(bridgeUser, bridgeUser, amount, 1);
+        emit TransferInitiated(bridgeUser, bridgeUser, amount, 1, counterpartyFinalizationFee);
 
         // Call function as bridgeUser
         vm.prank(bridgeUser);
@@ -177,6 +158,7 @@ contract L1GatewayTest is Test {
     function test_FinalizeTransferSuccess() public {
         uint256 amount = 4 ether;
         uint256 counterpartyIdx = 1;
+        uint256 finalizationFee = 0.1 ether;
 
         // Fund gateway and relayer
         vm.deal(address(l1Gateway), 5 ether);
@@ -199,7 +181,7 @@ contract L1GatewayTest is Test {
 
         // Call function as relayer
         vm.prank(relayer);
-        l1Gateway.finalizeTransfer(bridgeUser, amount, counterpartyIdx);
+        l1Gateway.finalizeTransfer(bridgeUser, amount, counterpartyIdx, finalizationFee);
 
         // Finalization fee is 0.1 ether
         assertEq(address(l1Gateway).balance, 1 ether);
@@ -219,7 +201,7 @@ contract L1GatewayTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IGateway.SenderNotRelayer.selector, bridgeUser, relayer));
         vm.prank(bridgeUser);
-        l1Gateway.finalizeTransfer(address(0x101), amount, 1);
+        l1Gateway.finalizeTransfer(address(0x101), amount, 1, 0.05 ether);
 
         assertEq(address(l1Gateway).balance, 1 ether);
         assertEq(l1Gateway.transferInitiatedIdx(), 0);
@@ -229,6 +211,7 @@ contract L1GatewayTest is Test {
     // This scenario shouldn't be possible since initiateTransfer() should have prevented it.
     function test_FinalizeTranferAmountTooSmallForFinalizationFee() public {
         uint256 amount = 0.09 ether;
+        uint256 finalizationFee = 0.1 ether;
         vm.deal(address(l1Gateway), 1 ether);
 
         assertEq(address(l1Gateway).balance, 1 ether);
@@ -237,7 +220,7 @@ contract L1GatewayTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IGateway.AmountTooSmall.selector, 0.09 ether, 0.1 ether));
         vm.prank(relayer);
-        l1Gateway.finalizeTransfer(address(0x101), amount, 1);
+        l1Gateway.finalizeTransfer(address(0x101), amount, 1, finalizationFee);
 
         assertEq(address(l1Gateway).balance, 1 ether);
         assertEq(l1Gateway.transferInitiatedIdx(), 0);
@@ -246,6 +229,7 @@ contract L1GatewayTest is Test {
 
     function test_FinalizeTransferInvalidCounterpartyIdx() public {
         uint256 amount = 0.1 ether;
+        uint256 finalizationFee = 0.1 ether;
         vm.deal(address(l1Gateway), 1 ether);
         vm.deal(relayer, 1 ether);
 
@@ -256,7 +240,7 @@ contract L1GatewayTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IGateway.InvalidCounterpartyIndex.selector, 2, 1));
         vm.prank(relayer);
-        l1Gateway.finalizeTransfer(address(0x101), amount, 2);
+        l1Gateway.finalizeTransfer(address(0x101), amount, 2, finalizationFee);
 
         assertEq(address(l1Gateway).balance, 1 ether);
         assertEq(relayer.balance, 1 ether);
@@ -267,6 +251,7 @@ contract L1GatewayTest is Test {
     function test_FinalizeTransferWithInsufficientContractBalance() public {
         uint256 amount = 4 ether;
         uint256 counterpartyIdx = 1; // First transfer idx
+        uint256 finalizationFee = 0.1 ether;
         vm.deal(address(l1Gateway), 0.09 ether);
         assertEq(address(l1Gateway).balance, 0.09 ether);
 
@@ -275,7 +260,7 @@ contract L1GatewayTest is Test {
         
         vm.expectRevert(abi.encodeWithSelector(L1Gateway.InsufficientContractBalance.selector, 0.09 ether, 4 ether - finalizationFee));
         vm.prank(relayer);
-        l1Gateway.finalizeTransfer(bridgeUser, amount, counterpartyIdx);
+        l1Gateway.finalizeTransfer(bridgeUser, amount, counterpartyIdx, finalizationFee);
 
         assertEq(l1Gateway.transferInitiatedIdx(), 0);
         assertEq(l1Gateway.transferFinalizedIdx(), 1);
@@ -284,6 +269,7 @@ contract L1GatewayTest is Test {
     function test_FinalizeTransferRevertingReceiver() public {
         uint256 amount = 4 ether;
         uint256 counterpartyIdx = 1;
+        uint256 finalizationFee = 0.1 ether;
 
         vm.deal(address(l1Gateway), 5 ether);
         vm.deal(relayer, 5 ether);
@@ -307,7 +293,7 @@ contract L1GatewayTest is Test {
         emit TransferFinalized(receiver, amount, counterpartyIdx);
 
         vm.prank(relayer);
-        l1Gateway.finalizeTransfer(receiver, amount, counterpartyIdx);
+        l1Gateway.finalizeTransfer(receiver, amount, counterpartyIdx, finalizationFee);
 
         assertEq(address(l1Gateway).balance, 5 ether - finalizationFee);
         assertEq(relayer.balance, 5 ether + finalizationFee);
@@ -338,6 +324,7 @@ contract L1GatewayTest is Test {
     function test_finalizeTransferEventReceiver() public {
         uint256 amount = 4 ether;
         uint256 counterpartyIdx = 1;
+        uint256 finalizationFee = 0.1 ether;
 
         vm.deal(address(l1Gateway), 5 ether);
         vm.deal(relayer, 5 ether);
@@ -361,7 +348,7 @@ contract L1GatewayTest is Test {
         emit TransferFinalized(receiver, amount, counterpartyIdx);
 
         vm.prank(relayer);
-        l1Gateway.finalizeTransfer(receiver, amount, counterpartyIdx);
+        l1Gateway.finalizeTransfer(receiver, amount, counterpartyIdx, finalizationFee);
 
         assertEq(address(l1Gateway).balance, 5 ether - finalizationFee);
         assertEq(relayer.balance, 5 ether + finalizationFee);


### PR DESCRIPTION
## Describe your changes

Fixes https://cantina.xyz/code/d35ebc75-9107-4e58-a923-f81725912138/findings/10

* Removes `GatewayStorage.finalizationFee` from the storage of the gateway contracts. Each gateway still stores what's currently defined as `GatewayStorage.counterpartyFee` (now renamed to `counterpartyFinalizationFee`). 
* `TransferInitiated` event is augmented to emit this `counterpartyFinalizationFee`. 
* `finalizeTransfer` is augmented to accept a finalization fee as a part of the transfer being finalized. The relayer would be responsible for ensuring that the` _finalizationFee` value in `finalizeTransfer` is the same as what was specified as `counterpartyFinalizationFee` in the corresponding `TransferInitiated` event.

By making these changes, we remove the need for one gateway's counterpartyFee to match the other gateway's finalizationFee. The finalization fee is now (only) be set and stored on the origin chain as `counterpartyFinalizationFee`, while still being mutable. 

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
