### PR TITLE
fix: deploy l1 gateway directly from contracts dir

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
@@ -237,7 +237,17 @@ job "{{ job.name }}" {
             {{ end }}
           {% endraw %}
           export L1_OWNER_ADDRESS=${SENDER} #TODO: this should be a multisig address on mainnet.
-          LOGS="$(${CONTRACT_REPO_ROOT_PATH}/entrypoint.sh)"
+
+          # --verify flag in entrypoint.sh only works when running forge script from the contracts directory.
+          # Here we setup the environment variables to function when cd'ing into the contracts directory.
+          export FORGE_BIN_PATH="../../${XDG_CONFIG_HOME}/.foundry/bin/forge"
+          export SCRIPT_PATH_PREFIX="scripts"
+          export CONTRACT_REPO_ROOT_PATH="./"
+          LOGS="$(cd ${CONTRACT_REPO_ROOT_PATH} && ./entrypoint.sh)"
+
+          # Now cd back to previous directory.
+          cd ../../
+
           if [ $? -ne 0 ]; then
             echo "Failed to deploy contracts!"
             echo "${LOGS}"

--- a/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
@@ -240,10 +240,11 @@ job "{{ job.name }}" {
 
           # --verify flag in entrypoint.sh only works when running forge script from the contracts directory.
           # Here we setup the environment variables to function when cd'ing into the contracts directory.
+          cd ${CONTRACT_REPO_ROOT_PATH}
           export FORGE_BIN_PATH="../../${XDG_CONFIG_HOME}/.foundry/bin/forge"
           export SCRIPT_PATH_PREFIX="scripts"
           export CONTRACT_REPO_ROOT_PATH="./"
-          LOGS="$(cd ${CONTRACT_REPO_ROOT_PATH} && ./entrypoint.sh)"
+          LOGS="$(./entrypoint.sh)"
 
           # Now cd back to previous directory.
           cd ../../


### PR DESCRIPTION
## Describe your changes

Allows L1Gateway etherscan verification to work

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
