### PR TITLE
fix: foundryup renamed -v flag to -i

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
@@ -149,7 +149,7 @@ job "{{ job.name }}" {
             --strip-components=1
 
           chmod +x local/foundry.sh && local/foundry.sh
-          chmod +x ${XDG_CONFIG_HOME}/.foundry/bin/foundryup && ${XDG_CONFIG_HOME}/.foundry/bin/foundryup -v nightly-e649e62f125244a3ef116be25dfdc81a2afbaf2a
+          chmod +x ${XDG_CONFIG_HOME}/.foundry/bin/foundryup && ${XDG_CONFIG_HOME}/.foundry/bin/foundryup -i nightly-e649e62f125244a3ef116be25dfdc81a2afbaf2a
           export PATH="${XDG_CONFIG_HOME}/.foundry/bin:$PATH"
           chmod +x ${CONTRACT_REPO_ROOT_PATH}/entrypoint.sh
           echo ""


### PR DESCRIPTION
## Describe your changes

See https://github.com/foundry-rs/foundry/pull/9551. The previous `-v` flag is now `-i`

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
