### PR TITLE
fix: use primev multisig as l1 gateway owner addr

### DIFF
--- a/contracts/scripts/standard-bridge/DeployStandardBridge.s.sol
+++ b/contracts/scripts/standard-bridge/DeployStandardBridge.s.sol
@@ -11,6 +11,7 @@ import {L1Gateway} from "../../contracts/standard-bridge/L1Gateway.sol";
 import {Allocator} from "../../contracts/standard-bridge/Allocator.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 import {console} from "forge-std/console.sol";
+import {MainnetConstants} from "../MainnetConstants.sol";
 
 contract BridgeBase is Script {
     // Amount of ETH to initially fund the relayer account on the mev-commit chain.
@@ -145,7 +146,10 @@ contract DeployL1Gateway is BridgeBase {
     }
 
     function _getL1OwnerAddress() internal view returns (address ownerAddr) {
-        ownerAddr = vm.envAddress("L1_OWNER_ADDRESS");
-        require(ownerAddr != address(0), L1OwnerAddressNotSet(ownerAddr));
+        if (block.chainid == 1) {
+            ownerAddr = MainnetConstants.PRIMEV_TEAM_MULTISIG;
+        } else {
+            ownerAddr = msg.sender;
+        }
     }
 }

--- a/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
@@ -242,7 +242,6 @@ job "{{ job.name }}" {
           echo '{{ .Data.data.bridge_relayer_keystore }}' > local/bridge_relayer_keystore
             {{ end }}
           {% endraw %}
-          export L1_OWNER_ADDRESS=${SENDER} #TODO: this should be a multisig address on mainnet.
 
           # --verify flag in entrypoint.sh only works when running forge script from the contracts directory.
           # Here we setup the environment variables to function when cd'ing into the contracts directory.

--- a/infrastructure/nomad/playbooks/variables/environments.yml
+++ b/infrastructure/nomad/playbooks/variables/environments.yml
@@ -17,5 +17,5 @@ environments:
     profile: "{{ profile }}"
     version: "{{ version }}"
     secrets: fetch
-    genesis_timestamp: "0x676d7ae2"
+    genesis_timestamp: "0x676b1b58"
     domain: mev-commit.xyz

--- a/infrastructure/nomad/playbooks/variables/environments.yml
+++ b/infrastructure/nomad/playbooks/variables/environments.yml
@@ -17,5 +17,5 @@ environments:
     profile: "{{ profile }}"
     version: "{{ version }}"
     secrets: fetch
-    genesis_timestamp: "0x676b1b58"
+    genesis_timestamp: "0x676d7ae2"
     domain: mev-commit.xyz


### PR DESCRIPTION
## Describe your changes
The changes from https://github.com/primev/mev-commit/pull/545 into https://github.com/primev/mev-commit/pull/544 were seemingly lost during a rebase. This PR reintroduces the necessary changes to main 

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
