### PR TITLE
chore: mainnet config fixes

### DIFF
--- a/bridge/standard/cmd/user_cli/main.go
+++ b/bridge/standard/cmd/user_cli/main.go
@@ -49,13 +49,13 @@ var (
 		Name:    "l1-rpc-url",
 		Usage:   "URL for L1 RPC",
 		EnvVars: []string{"L1_RPC_URL"},
-		Value:   "https://ethereum-holesky-rpc.publicnode.com",
+		Value:   "https://eth.llamarpc.com",
 	}
 	optionSettlementRPCUrl = &cli.StringFlag{
 		Name:    "settlement-rpc-url",
 		Usage:   "URL for settlement RPC",
 		EnvVars: []string{"SETTLEMENT_RPC_URL"},
-		Value:   "https://chainrpc.testnet.mev-commit.xyz",
+		Value:   "https://chainrpc.mev-commit.xyz",
 	}
 	optionL1ContractAddr = &cli.StringFlag{
 		Name:    "l1-contract-addr",
@@ -67,7 +67,7 @@ var (
 		Name:    "settlement-contract-addr",
 		Usage:   "address of the settlement gateway contract",
 		EnvVars: []string{"SETTLEMENT_CONTRACT_ADDR"},
-		Value:   config.MainnetContracts.SettlementGateway,
+		Value:   config.MevCommitChainContracts.SettlementGateway,
 	}
 	optionSilent = &cli.BoolFlag{
 		Name:    "silent",

--- a/contracts-abi/config/mainnet.go
+++ b/contracts-abi/config/mainnet.go
@@ -1,6 +1,6 @@
 package config
 
-var MainnetContracts = Contracts{
+var MevCommitChainContracts = Contracts{
 	BidderRegistry:    "0xC973D09e51A20C9Ab0214c439e4B34Dbac52AD67",
 	ProviderRegistry:  "0xb772Add4718E5BD6Fe57Fb486A6f7f008E52167E",
 	PreconfManager:    "0x9fF03b7Ca0767f069e7AA811E383752267cc47Ec",

--- a/oracle/cmd/main.go
+++ b/oracle/cmd/main.go
@@ -124,35 +124,35 @@ var (
 		Name:    "oracle-contract-addr",
 		Usage:   "address of the oracle contract",
 		EnvVars: []string{"MEV_ORACLE_ORACLE_CONTRACT_ADDR"},
-		Value:   contracts.MainnetContracts.Oracle,
+		Value:   contracts.MevCommitChainContracts.Oracle,
 	})
 
 	optionPreconfContractAddr = altsrc.NewStringFlag(&cli.StringFlag{
 		Name:    "preconf-contract-addr",
 		Usage:   "address of the preconf contract",
 		EnvVars: []string{"MEV_ORACLE_PRECONF_CONTRACT_ADDR"},
-		Value:   contracts.MainnetContracts.PreconfManager,
+		Value:   contracts.MevCommitChainContracts.PreconfManager,
 	})
 
 	optionBlockTrackerContractAddr = altsrc.NewStringFlag(&cli.StringFlag{
 		Name:    "blocktracker-contract-addr",
 		Usage:   "address of the block tracker contract",
 		EnvVars: []string{"MEV_ORACLE_BLOCKTRACKER_CONTRACT_ADDR"},
-		Value:   contracts.MainnetContracts.BlockTracker,
+		Value:   contracts.MevCommitChainContracts.BlockTracker,
 	})
 
 	optionBidderRegistryContractAddr = altsrc.NewStringFlag(&cli.StringFlag{
 		Name:    "bidder-registry-contract-addr",
 		Usage:   "address of the bidder registry contract",
 		EnvVars: []string{"MEV_ORACLE_BIDDERREGISTRY_CONTRACT_ADDR"},
-		Value:   contracts.MainnetContracts.BidderRegistry,
+		Value:   contracts.MevCommitChainContracts.BidderRegistry,
 	})
 
 	optionProviderRegistryContractAddr = altsrc.NewStringFlag(&cli.StringFlag{
 		Name:    "provider-registry-contract-addr",
 		Usage:   "address of the provider registry contract",
 		EnvVars: []string{"MEV_ORACLE_PROVIDERREGISTRY_CONTRACT_ADDR"},
-		Value:   contracts.MainnetContracts.ProviderRegistry,
+		Value:   contracts.MevCommitChainContracts.ProviderRegistry,
 	})
 
 	optionPgHost = altsrc.NewStringFlag(&cli.StringFlag{

--- a/p2p/cmd/main.go
+++ b/p2p/cmd/main.go
@@ -224,7 +224,7 @@ var (
 		Name:    "bidder-registry-contract",
 		Usage:   "Address of the bidder registry contract",
 		EnvVars: []string{"MEV_COMMIT_BIDDER_REGISTRY_ADDR"},
-		Value:   contracts.MainnetContracts.BidderRegistry,
+		Value:   contracts.MevCommitChainContracts.BidderRegistry,
 		Action: func(ctx *cli.Context, s string) error {
 			if !common.IsHexAddress(s) {
 				return fmt.Errorf("invalid bidder registry address: %s", s)
@@ -238,7 +238,7 @@ var (
 		Name:    "provider-registry-contract",
 		Usage:   "Address of the provider registry contract",
 		EnvVars: []string{"MEV_COMMIT_PROVIDER_REGISTRY_ADDR"},
-		Value:   contracts.MainnetContracts.ProviderRegistry,
+		Value:   contracts.MevCommitChainContracts.ProviderRegistry,
 		Action: func(ctx *cli.Context, s string) error {
 			if !common.IsHexAddress(s) {
 				return fmt.Errorf("invalid provider registry address: %s", s)
@@ -252,7 +252,7 @@ var (
 		Name:    "preconf-contract",
 		Usage:   "Address of the preconfirmation commitment store contract",
 		EnvVars: []string{"MEV_COMMIT_PRECONF_ADDR"},
-		Value:   contracts.MainnetContracts.PreconfManager,
+		Value:   contracts.MevCommitChainContracts.PreconfManager,
 		Action: func(ctx *cli.Context, s string) error {
 			if !common.IsHexAddress(s) {
 				return fmt.Errorf("invalid preconfirmation commitment store address: %s", s)
@@ -266,7 +266,7 @@ var (
 		Name:    "block-tracker-contract",
 		Usage:   "Address of the block tracker contract",
 		EnvVars: []string{"MEV_COMMIT_BLOCK_TRACKER_ADDR"},
-		Value:   contracts.MainnetContracts.BlockTracker,
+		Value:   contracts.MevCommitChainContracts.BlockTracker,
 		Action: func(ctx *cli.Context, s string) error {
 			if !common.IsHexAddress(s) {
 				return fmt.Errorf("invalid block tracker address: %s", s)

--- a/tools/dashboard/main.go
+++ b/tools/dashboard/main.go
@@ -97,35 +97,35 @@ var (
 		Name:    "oracle-contract-addr",
 		Usage:   "address of the oracle contract",
 		EnvVars: []string{"DASHBOARD_ORACLE_CONTRACT_ADDR"},
-		Value:   contracts.MainnetContracts.Oracle,
+		Value:   contracts.MevCommitChainContracts.Oracle,
 	}
 
 	optionPreconfContractAddr = &cli.StringFlag{
 		Name:    "preconf-contract-addr",
 		Usage:   "address of the preconf contract",
 		EnvVars: []string{"DASHBOARD_PRECONF_CONTRACT_ADDR"},
-		Value:   contracts.MainnetContracts.PreconfManager,
+		Value:   contracts.MevCommitChainContracts.PreconfManager,
 	}
 
 	optionBlockTrackerContractAddr = &cli.StringFlag{
 		Name:    "blocktracker-contract-addr",
 		Usage:   "address of the block tracker contract",
 		EnvVars: []string{"DASHBOARD_BLOCKTRACKER_CONTRACT_ADDR"},
-		Value:   contracts.MainnetContracts.BlockTracker,
+		Value:   contracts.MevCommitChainContracts.BlockTracker,
 	}
 
 	optionBidderRegistryContractAddr = &cli.StringFlag{
 		Name:    "bidder-registry-contract-addr",
 		Usage:   "address of the bidder registry contract",
 		EnvVars: []string{"DASHBOARD_BIDDERREGISTRY_CONTRACT_ADDR"},
-		Value:   contracts.MainnetContracts.BidderRegistry,
+		Value:   contracts.MevCommitChainContracts.BidderRegistry,
 	}
 
 	optionProviderRegistryContractAddr = &cli.StringFlag{
 		Name:    "provider-registry-contract-addr",
 		Usage:   "address of the provider registry contract",
 		EnvVars: []string{"DASHBOARD_PROVIDERREGISTRY_CONTRACT_ADDR"},
-		Value:   contracts.MainnetContracts.ProviderRegistry,
+		Value:   contracts.MevCommitChainContracts.ProviderRegistry,
 	}
 )
 


### PR DESCRIPTION
## Describe your changes

Builds off https://github.com/primev/mev-commit/pull/551:

* `MainnetContracts` changed to `MevCommitChainContracts` since "mainnet" has its own meaning as mainnet L1 ethereum. 
* RPC addresses for bridge user cli were not updated to mainnet

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
