### PR TITLE
fix: use chain ID from RPC

### DIFF
--- a/tools/bidder-cli/main.go
+++ b/tools/bidder-cli/main.go
@@ -333,8 +333,10 @@ func main() {
 
 				tx := types.NewTx(txData)
 
-				// Chain ID for Holesky (17000)
-				chainID := big.NewInt(17000)
+				chainID, err := client.ChainID(c.Context)
+				if err != nil {
+					return fmt.Errorf("failed to get chain ID: %w", err)
+				}
 
 				// Sign the transaction
 				signedTx, err := types.SignTx(tx, types.NewLondonSigner(chainID), privateKey)

--- a/tools/bidder-cli/main.go
+++ b/tools/bidder-cli/main.go
@@ -248,6 +248,7 @@ func main() {
 				optionBlockNumber,
 				optionDecayDuration,
 				optionBidAmount,
+				optionTipBoost,
 			},
 			Action: func(c *cli.Context) error {
 				privateKey, err := crypto.HexToECDSA(c.String(optionFrom.Name))


### PR DESCRIPTION
## Describe your changes
Bidder CLI hardcodes chain ID. Use it from RPC.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
