### PR TITLE
chore: introduce commitment holdings address

### DIFF
--- a/contracts/scripts/MainnetConstants.sol
+++ b/contracts/scripts/MainnetConstants.sol
@@ -5,4 +5,7 @@ pragma solidity 0.8.26;
 library MainnetConstants {
     /// @notice DO NOT assume this address is valid on any chain other than mainnet.
     address constant public PRIMEV_TEAM_MULTISIG = 0x9101eda106A443A0fA82375936D0D1680D5a64F5;
+
+    /// @notice DO NOT assume this address is valid on any chain other than mainnet.
+    address constant public COMMITMENT_HOLDINGS_MULTISIG = 0xD5881f91270550B8850127f05BD6C8C203B3D33f;
 }

--- a/contracts/scripts/validator-registry/DeployVanillaRegistry.s.sol
+++ b/contracts/scripts/validator-registry/DeployVanillaRegistry.s.sol
@@ -39,7 +39,7 @@ contract DeployMainnet is BaseDeploy {
     address constant public OWNER = MainnetConstants.PRIMEV_TEAM_MULTISIG;
     uint256 constant public MIN_STAKE = 1 ether;
     address constant public SLASH_ORACLE = MainnetConstants.PRIMEV_TEAM_MULTISIG;
-    address constant public SLASH_RECEIVER = MainnetConstants.PRIMEV_TEAM_MULTISIG;
+    address constant public SLASH_RECEIVER = MainnetConstants.COMMITMENT_HOLDINGS_MULTISIG;
     uint256 constant public UNSTAKE_PERIOD_BLOCKS = 50000; // 50k * 12s ~= 1 week, which suffices for short-term manual slashing.
     uint256 constant public PAYOUT_PERIOD_BLOCKS = 12000; // ~ 1 day
 

--- a/contracts/scripts/validator-registry/avs/DeployAVS.s.sol
+++ b/contracts/scripts/validator-registry/avs/DeployAVS.s.sol
@@ -72,7 +72,7 @@ contract DeployMainnet is BaseDeploy {
     IAVSDirectory constant public AVS_DIRECTORY = IAVSDirectory(EigenMainnetReleaseConsts.AVS_DIRECTORY);
     address constant public FREEZE_ORACLE = MainnetConstants.PRIMEV_TEAM_MULTISIG;
     uint256 constant public UNFREEZE_FEE = 1 ether;
-    address constant public UNFREEZE_RECEIVER = MainnetConstants.PRIMEV_TEAM_MULTISIG;
+    address constant public UNFREEZE_RECEIVER = MainnetConstants.COMMITMENT_HOLDINGS_MULTISIG;
     uint256 constant public UNFREEZE_PERIOD_BLOCKS = 12000; // ~ 1 day
     uint256 constant public OPERATOR_DEREG_PERIOD_BLOCKS = 50000; // 50k * 12s ~= 1 week, which suffices for short-term manual slashing.
     uint256 constant public VALIDATOR_DEREG_PERIOD_BLOCKS = 50000; // 50k * 12s ~= 1 week, which suffices for short-term manual slashing.


### PR DESCRIPTION
## Describe your changes

Adds a constant for the "commitment holdings address" which will be used on L1 to received slashed funds from any of the validator registries

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
