### PR TITLE
feat: changes decayPercentage to residualAfterDecayPercentage

### DIFF
--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -404,12 +404,14 @@ func (u *Updater) settle(
 	decayPercentage int64,
 	window int64,
 ) error {
+	residualDecay := big.NewInt(0).Sub(big.NewInt(ONE_HUNDRED_PERCENT), big.NewInt(decayPercentage))
+
 	commitmentPostingTxn, err := u.oracle.ProcessBuilderCommitmentForBlockNumber(
 		update.CommitmentIndex,
 		big.NewInt(0).SetUint64(update.BlockNumber),
 		update.Committer,
 		settlementType == SettlementTypeSlash,
-		big.NewInt(decayPercentage),
+		residualDecay,
 	)
 	if err != nil {
 		u.logger.Error(

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -404,14 +404,14 @@ func (u *Updater) settle(
 	decayPercentage int64,
 	window int64,
 ) error {
-	residualDecay := big.NewInt(0).Sub(big.NewInt(ONE_HUNDRED_PERCENT), big.NewInt(decayPercentage))
+	residualBidPercentageAfterDecay := big.NewInt(0).Sub(big.NewInt(ONE_HUNDRED_PERCENT), big.NewInt(decayPercentage))
 
 	commitmentPostingTxn, err := u.oracle.ProcessBuilderCommitmentForBlockNumber(
 		update.CommitmentIndex,
 		big.NewInt(0).SetUint64(update.BlockNumber),
 		update.Committer,
 		settlementType == SettlementTypeSlash,
-		residualDecay,
+		residualBidPercentageAfterDecay,
 	)
 	if err != nil {
 		u.logger.Error(

--- a/oracle/pkg/updater/updater_test.go
+++ b/oracle/pkg/updater/updater_test.go
@@ -1087,7 +1087,7 @@ func TestUpdaterIgnoreCommitments(t *testing.T) {
 
 	// timestamp of the First block commitment is X
 	startTimestamp := time.UnixMilli(1615195200000)
-	midTimestamp := startTimestamp.Add(time.Duration(2.5 * float64(time.Second)))
+	midTimestamp := startTimestamp.Add(time.Duration(1 * float64(time.Second)))
 	endTimestamp := startTimestamp.Add(5 * time.Second)
 
 	key, err := crypto.GenerateKey()
@@ -1255,7 +1255,7 @@ func TestUpdaterIgnoreCommitments(t *testing.T) {
 			if commitment.isSlash {
 				t.Fatal("wrong isSlash")
 			}
-			if commitment.residualDecay.Cmp(big.NewInt(50*updater.PRECISION)) != 0 {
+			if commitment.residualDecay.Cmp(big.NewInt(80*updater.PRECISION)) != 0 {
 				t.Fatal("wrong residual decay")
 			}
 		}
@@ -1282,7 +1282,7 @@ func TestUpdaterIgnoreCommitments(t *testing.T) {
 			if settlement.settlementType != updater.SettlementTypeReward {
 				t.Fatal("wrong settlement type")
 			}
-			if settlement.decayPercentage != 50*updater.PRECISION {
+			if settlement.decayPercentage != 20*updater.PRECISION {
 				t.Fatal("wrong decay percentage")
 			}
 			if settlement.window != 5 {


### PR DESCRIPTION
* Resolves inverted calculation of decay in the Oracle.
* Ensures value sent is the residual bid **after** decay, rather than decay.