### PR TITLE
refactor: avoid contract redeployment on restart

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/contracts-deployer.nomad.j2
@@ -48,6 +48,12 @@ job "{{ job.name }}" {
       {% endfor %}
     }
 
+    volume "data-volume" {
+      type = "host"
+      source = "data-volume"
+      read_only = false
+    }
+
     task "contracts" {
       driver = "exec"
 
@@ -62,6 +68,12 @@ job "{{ job.name }}" {
         memory = 1024
       }
       {% endif %}
+
+      volume_mount {
+        volume = "data-volume"
+        destination = "/local/data"
+        read_only = false
+      }
 
       {% for port_name in job.ports[0] %}
       service {
@@ -132,7 +144,12 @@ job "{{ job.name }}" {
           {{- end }}
           {% endraw %}
 
-          {%- if job.artifacts | selectattr('keystores', 'defined') | list | length > 0 %}
+          if [ -f /local/data/www/contracts.json ]; then
+            exec python3 -m http.server {{ job.ports[0]['http']['static'] }} --directory /local/data/www
+            exit $?
+          fi
+
+          {% if job.artifacts | selectattr('keystores', 'defined') | list | length > 0 %}
           mkdir -p "${KEYSTORE_DIR}" > /dev/null 2>&1
           {%- raw %}
             {{- with secret "secret/data/mev-commit" }}
@@ -269,10 +286,10 @@ job "{{ job.name }}" {
 
           {%- endif %}
 
-          mkdir -p /local/www > /dev/null 2>&1
-          jq -s 'add' local/*_addresses.json > local/www/contracts.json
+          mkdir -p /local/data/www > /dev/null 2>&1
+          jq -s 'add' local/*_addresses.json > local/data/www/contracts.json
 
-          exec python3 -m http.server {{ job.ports[0]['http']['static'] }} --directory /local/www
+          exec python3 -m http.server {{ job.ports[0]['http']['static'] }} --directory /local/data/www
           # endtodo
         EOH
         destination = "local/run.sh"


### PR DESCRIPTION
## Describe your changes

Prevents smart contracts from being redeployed if the Contract Deployer job is restarted and the contracts have already been deployed.

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
