### PR TITLE
chore: remove stand-in middleware contract for mainnet

### DIFF
--- a/contracts/contracts/utils/AlwaysFalseMiddleware.sol
+++ b/contracts/contracts/utils/AlwaysFalseMiddleware.sol
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: BSL 1.1
-pragma solidity 0.8.26;
-
-/// Temporary stand-in until the mev-commit middleware and symbiotic core, are ready for mainnet.
-contract AlwaysFalseMevCommitMiddleware {
-    function isValidatorOptedIn(bytes calldata) external pure returns (bool) {
-        return false;
-    }
-}

--- a/contracts/scripts/validator-registry/DeployValidatorOptInRouter.s.sol
+++ b/contracts/scripts/validator-registry/DeployValidatorOptInRouter.s.sol
@@ -10,7 +10,6 @@ import {console} from "forge-std/console.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 import {ValidatorOptInRouter} from "../../contracts/validator-registry/ValidatorOptInRouter.sol";
 import {MainnetConstants} from "../MainnetConstants.sol";
-import {AlwaysFalseMevCommitMiddleware} from "../../contracts/utils/AlwaysFalseMiddleware.sol";
 
 contract BaseDeploy is Script {
     function deployValidatorOptInRouter(
@@ -37,18 +36,17 @@ contract BaseDeploy is Script {
 contract DeployMainnet is BaseDeploy {
     address constant public VANILLA_REGISTRY = 0x47afdcB2B089C16CEe354811EA1Bbe0DB7c335E9;
     address constant public MEV_COMMIT_AVS = 0xBc77233855e3274E1903771675Eb71E602D9DC2e;
+    address constant public MEV_COMMIT_MIDDLEWARE = 0x21fD239311B050bbeE7F32850d99ADc224761382;
     address constant public OWNER = MainnetConstants.PRIMEV_TEAM_MULTISIG;
 
     function run() external {
         require(block.chainid == 1, "must deploy on mainnet");
         vm.startBroadcast();
 
-        AlwaysFalseMevCommitMiddleware alwaysFalseMevCommitMiddleware = new AlwaysFalseMevCommitMiddleware();
-
         deployValidatorOptInRouter(
             VANILLA_REGISTRY,
             MEV_COMMIT_AVS,
-            address(alwaysFalseMevCommitMiddleware),
+            MEV_COMMIT_MIDDLEWARE,
             OWNER
         );
         vm.stopBroadcast();


### PR DESCRIPTION
## Describe your changes

Removes the stand-in "always false" middleware contract that was temporarily used on mainnet. We've deployed the actual  middleware contract on mainnet now https://docs.primev.xyz/v1.0.0/developers/mainnet#l1-validator-registries

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
