### PR TITLE
chore: use mainnet contract values in symbiotic example

### DIFF
--- a/contracts/scripts/validator-registry/middleware/ExampleSetup.s.sol
+++ b/contracts/scripts/validator-registry/middleware/ExampleSetup.s.sol
@@ -131,18 +131,18 @@ contract PrimevTeamActions is Script {
     function run() external {
         vm.startBroadcast();
 
-        IMevCommitMiddleware existingMevCommitMiddleware = IMevCommitMiddleware(payable(0x79FeCD427e5A3e5f1a40895A0AC20A6a50C95393));
+        IMevCommitMiddleware existingMevCommitMiddleware = IMevCommitMiddleware(payable(0x21fD239311B050bbeE7F32850d99ADc224761382));
 
         address[] memory vaults = new address[](1);
         vaults[0] = 0x5DF518571733d5F4f496D76C9087110FAe98a946;
 
         uint160[] memory slashAmounts = new uint160[](1);
-        slashAmounts[0] = 0.01 ether;
+        slashAmounts[0] = 1 ether;
 
         existingMevCommitMiddleware.registerVaults(vaults, slashAmounts);
 
         IBaseDelegator delegator = IBaseDelegator(IVault(vaults[0]).delegator());
-        delegator.setMaxNetworkLimit(1, 1000000 ether);
+        delegator.setMaxNetworkLimit(1, 1000 ether);
 
         address[] memory operators = new address[](1);
         operators[0] = 0xb4F13624966E874967d7C9231F2F740F03F1A832;

--- a/contracts/scripts/validator-registry/middleware/ExampleSetup.s.sol
+++ b/contracts/scripts/validator-registry/middleware/ExampleSetup.s.sol
@@ -7,7 +7,6 @@ pragma solidity 0.8.26;
 
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";
-import {SymbioticHoleskyDevnetConsts} from "./ReleaseAddrConsts.s.sol";
 import {IBaseDelegator} from "symbiotic-core/interfaces/delegator/IBaseDelegator.sol";
 import {IBurnerRouter} from "symbiotic-burners/interfaces/router/IBurnerRouter.sol";
 import {IBurnerRouterFactory} from "symbiotic-burners/interfaces/router/IBurnerRouterFactory.sol";
@@ -26,16 +25,16 @@ contract SetupVault is Script {
         vm.startBroadcast();
 
         // Deploy burner router
-        address burnerRouterFactory = 0x32e2AfbdAffB1e675898ABA75868d92eE1E68f3b; // From https://docs.symbiotic.fi/deployments/current
+        address burnerRouterFactory = 0x42dD40dC2130c658AB32d9989FF8aBe6c36463c0;
         IBurnerRouter.NetworkReceiver[] memory networkReceivers = new IBurnerRouter.NetworkReceiver[](1);
         networkReceivers[0] = IBurnerRouter.NetworkReceiver({
-            network: 0x4535bd6fF24860b5fd2889857651a85fb3d3C6b1, // MevCommitMiddleware.network()
-            receiver: 0x4535bd6fF24860b5fd2889857651a85fb3d3C6b1 // MevCommitMiddleware.slashReceiver()
+            network: 0x9101eda106A443A0fA82375936D0D1680D5a64F5,
+            receiver: 0xD5881f91270550B8850127f05BD6C8C203B3D33f
         });
         address burnerRouter = IBurnerRouterFactory(burnerRouterFactory).create(
             IBurnerRouter.InitParams({
                owner: msg.sender,                       
-               collateral: 0x3F1c547b21f65e10480dE3ad8E19fAAC46C95034, // stETH                  
+               collateral: 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84, // stETH                  
                delay: 3 days, // > 2 days
                globalReceiver: msg.sender,             
                networkReceivers: networkReceivers,
@@ -45,7 +44,7 @@ contract SetupVault is Script {
         console.log("Burner router deployed to:", address(burnerRouter));
 
         // Deploy vault with delegator and slasher
-        IVaultConfigurator vaultConfigurator = IVaultConfigurator(0xD2191FE92987171691d552C219b8caEf186eb9cA); // From https://docs.symbiotic.fi/deployments/current
+        IVaultConfigurator vaultConfigurator = IVaultConfigurator(0x29300b1d3150B4E2b12fE80BE72f365E200441EC);
 
         address[] memory networkLimitSetRoleHolders = new address[](1);
         networkLimitSetRoleHolders[0] = msg.sender;
@@ -55,7 +54,7 @@ contract SetupVault is Script {
             version: 1,                                                                   
             owner: msg.sender,                            
             vaultParams: abi.encode(IVault.InitParams({
-                collateral: 0x3F1c547b21f65e10480dE3ad8E19fAAC46C95034, // stETH
+                collateral: 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84, // stETH
                 burner: address(burnerRouter),                                                   
                 epochDuration: 1 weeks,
                 depositWhitelist: false, 
@@ -101,7 +100,7 @@ contract DepositToVault is Script {
         vm.startBroadcast();
 
         address stEthVault = 0x5DF518571733d5F4f496D76C9087110FAe98a946;
-        address stEthToken = 0x3F1c547b21f65e10480dE3ad8E19fAAC46C95034;
+        address stEthToken = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
         
         IERC20(stEthToken).approve(stEthVault, 0.1 ether);
         
@@ -115,15 +114,15 @@ contract DepositToVault is Script {
 contract OperatorActions is Script {
     function run() external {
         vm.startBroadcast();
-        IOperatorRegistry operatorRegistry = IOperatorRegistry(SymbioticHoleskyDevnetConsts.OPERATOR_REGISTRY);
+        IOperatorRegistry operatorRegistry = IOperatorRegistry(0xAd817a6Bc954F678451A71363f04150FDD81Af9F);
         operatorRegistry.registerOperator();
 
-        IOptInService vaultOptInService = IOptInService(SymbioticHoleskyDevnetConsts.VAULT_OPT_IN_SERVICE);
+        IOptInService vaultOptInService = IOptInService(0xb361894bC06cbBA7Ea8098BF0e32EB1906A5F891);
         address stEthVault = 0x5DF518571733d5F4f496D76C9087110FAe98a946;
         vaultOptInService.optIn(stEthVault);
 
-        IOptInService networkOptInService = IOptInService(SymbioticHoleskyDevnetConsts.NETWORK_OPT_IN_SERVICE);
-        networkOptInService.optIn(0x4535bd6fF24860b5fd2889857651a85fb3d3C6b1); // mev-commit network addr
+        IOptInService networkOptInService = IOptInService(0x7133415b33B438843D581013f98A08704316633c);
+        networkOptInService.optIn(0x9101eda106A443A0fA82375936D0D1680D5a64F5);
         vm.stopBroadcast();
     }
 }
@@ -158,9 +157,9 @@ contract VaultActions is Script {
         vm.startBroadcast();
 
         IOperatorSpecificDelegator delegator = IOperatorSpecificDelegator(0x75b131De299A5D343b9408081DD6A8D6a9891b8c);
-        delegator.setNetworkLimit(0x4535bd6ff24860b5fd2889857651a85fb3d3c6b1000000000000000000000001, 1000000 ether);
+        delegator.setNetworkLimit(0x9101eda106a443a0fa82375936d0d1680d5a64f5000000000000000000000001, 1000000 ether);
 
-        uint256 stake = delegator.stake(0x4535bd6ff24860b5fd2889857651a85fb3d3c6b1000000000000000000000001, msg.sender);
+        uint256 stake = delegator.stake(0x9101eda106a443a0fa82375936d0d1680d5a64f5000000000000000000000001, msg.sender);
         console.log("Stake toward operator:", stake);
 
         vm.stopBroadcast();


### PR DESCRIPTION
## Describe your changes

Symbiotic example scripts now use mainnet contract values. This matches examples from https://docs.primev.xyz/v1.0.0/get-started/validators/symbiotic

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
