### PR TITLE
fix: autodeposit during node init

### DIFF
--- a/p2p/pkg/node/node.go
+++ b/p2p/pkg/node/node.go
@@ -588,6 +588,7 @@ func NewNode(opts *Options) (*Node, error) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	nd.cancelFunc = cancel
 	healthChecker := health.New()
 
 	for _, s := range startables {
@@ -603,8 +604,6 @@ func NewNode(opts *Options) (*Node, error) {
 			return nil, errors.Join(err, nd.Close())
 		}
 	}
-
-	nd.cancelFunc = cancel
 
 	started := make(chan struct{})
 	go func() {


### PR DESCRIPTION
## Describe your changes
The txmonitor should be started before we start making transactions. This component rate-limits txns based on account nonces. So if it is not started a higher nonce could be considered invalid.

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
