### PR TITLE
fix: use separate chain id for mock l1

### DIFF
--- a/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
+++ b/infrastructure/nomad/playbooks/templates/jobs/mock-l1.nomad.j2
@@ -85,11 +85,11 @@ job "{{ job.name }}" {
         data = <<-EOH
           #!/usr/bin/env bash
 
-          # Mutate genesis file to only have a single alloc to contract deployer
+          # Mutate genesis file to only have a single alloc to contract deployer, and chainID of holesky (17000)
           ${GETH_BIN} --dev dumpgenesis > local/default_genesis.json
           jq -s '
             .[0].alloc = .[1].alloc
-            | .[0].config.chainId = .[1].config.chainId
+            | .[0].config.chainId = 17000
             | .[0]
           ' local/default_genesis.json local/genesis_{{ env }}-{{ version }}.json > local/genesis.json
           ${GETH_BIN} --datadir local/data init local/genesis.json


### PR DESCRIPTION
## Describe your changes

Currently the mock l1 used for integration tests has the same chain id as mev-commit testnet (17864). This PR changes the mock l1 to have a more realistic chain ID which is that of holesky (17000). 

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
