### PR TITLE
fix: removed static port from bidder emulator

### DIFF
--- a/infrastructure/nomad/playbooks/variables/profiles.yml
+++ b/infrastructure/nomad/playbooks/variables/profiles.yml
@@ -566,7 +566,6 @@ jobs:
     ports:
       - metrics:
           to: 8080
-          static: 8181
     env:
       l1_rpc_url: "{{ resolved_l1_rpc_urls.split(',')[0] }}"
 


### PR DESCRIPTION
## Describe your changes
Without that fix I'm not able to run a stressnet, facing that issue:

```
Placement Failures
mev-commit-bidder-emulator-nodes-group 
4 unplaced
Resources exhausted on 1 node
Dimension network: reserved port collision metrics=8181 exhausted on 1 node
```

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
