### PR TITLE
fix: closing autodepositor

### DIFF
--- a/p2p/pkg/node/node.go
+++ b/p2p/pkg/node/node.go
@@ -604,6 +604,9 @@ func NewNode(opts *Options) (*Node, error) {
 				nd.closers,
 				ioCloserFunc(func() error {
 					_, err := autoDeposit.Stop()
+					if errors.Is(err, autodepositor.ErrNotRunning) {
+						return nil
+					}
 					return err
 				}),
 			)
@@ -845,8 +848,8 @@ func (n *Node) Close() error {
 	}
 
 	var err error
-	for _, c := range n.closers {
-		err = errors.Join(err, c.Close())
+	for i := len(n.closers) - 1; i >= 0; i-- {
+		err = errors.Join(err, n.closers[i].Close())
 	}
 
 	return err


### PR DESCRIPTION
## Describe your changes
Seeing the following panic after changes to autodeposit closer flow. Better way is to close the DB in the end.
```
panic: pebble: closed

goroutine 126481 [running]:
github.com/cockroachdb/pebble.(*DB).newIter(0x459c00?, {0x1e18040?, 0x2bc51e0?}, 0x4?, {0x4?, 0x0?}, 0xc00099ba40?)
	/home/aloknerurkar/go/pkg/mod/github.com/cockroachdb/pebble@v1.1.2/db.go:1011 +0x585
github.com/cockroachdb/pebble.(*DB).NewIterWithContext(...)
	/home/aloknerurkar/go/pkg/mod/github.com/cockroachdb/pebble@v1.1.2/db.go:1503
github.com/cockroachdb/pebble.(*DB).NewIter(0xc001373f80?, 0x19328d7?)
	/home/aloknerurkar/go/pkg/mod/github.com/cockroachdb/pebble@v1.1.2/db.go:1497 +0x2b
github.com/primev/mev-commit/p2p/pkg/storage/pebble.(*pebbleStorage).WalkPrefix(0xc000134548, {0x19328d7, 0x4}, 0xc0013725e8)
	/home/aloknerurkar/dev/mev-commit/p2p/pkg/storage/pebble/pebble.go:46 +0x17b
github.com/primev/mev-commit/p2p/pkg/autodepositor/store.(*Store).ListDeposits(0xc000f0b440, {0xc000638380?, 0x4?}, 0x0)
	/home/aloknerurkar/dev/mev-commit/p2p/pkg/autodepositor/store/store.go:53 +0x123
github.com/primev/mev-commit/p2p/pkg/autodepositor.(*AutoDepositTracker).Stop(0xc0006c42d0)
	/home/aloknerurkar/dev/mev-commit/p2p/pkg/autodepositor/autodepositor.go:272 +0xdd
github.com/primev/mev-commit/p2p/pkg/node.NewNode.func5()
	/home/aloknerurkar/dev/mev-commit/p2p/pkg/node/node.go:606 +0x17
github.com/primev/mev-commit/p2p/pkg/node.ioCloserFunc.Close(0xc0005dc000?)
	/home/aloknerurkar/dev/mev-commit/p2p/pkg/node/node.go:893 +0x12
github.com/primev/mev-commit/p2p/pkg/node.(*Node).Close(0xc00012ccc0?)
	/home/aloknerurkar/dev/mev-commit/p2p/pkg/node/node.go:849 +0x8f
main.launchNodeWithConfig.func2()
	/home/aloknerurkar/dev/mev-commit/p2p/cmd/main.go:686 +0x65
created by main.launchNodeWithConfig in goroutine 1
	/home/aloknerurkar/dev/mev-commit/p2p/cmd/main.go:683 +0x1b79

```

DB should be closed at the end.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
