### PR TITLE
chore: configurable proposer notification offset

### DIFF
--- a/p2p/cmd/main.go
+++ b/p2p/cmd/main.go
@@ -53,6 +53,7 @@ const (
 	categoryBidder    = "Bidder options"
 	categoryProvider  = "Provider options"
 	categoryEthRPC    = "Ethereum RPC options"
+	categoryValidator = "Validator options"
 )
 
 var (
@@ -446,6 +447,14 @@ var (
 		Value:    100,
 		Category: categoryGlobal,
 	})
+
+	optionProposerNotifyOffset = altsrc.NewDurationFlag(&cli.DurationFlag{
+		Name:     "proposer-notify-offset",
+		Usage:    "Time offset that a notification is sent, prior to the start of a slot where the proposer is opted-in to mev-commit",
+		EnvVars:  []string{"MEV_COMMIT_PROPOSER_NOTIFY_OFFSET"},
+		Value:    1 * time.Second,
+		Category: categoryValidator,
+	})
 )
 
 func main() {
@@ -491,6 +500,7 @@ func main() {
 		optionProviderDecisionTimeout,
 		optionNotificationsBuffer,
 		optionLaggardMode,
+		optionProposerNotifyOffset,
 	}
 
 	app := &cli.App{
@@ -671,6 +681,7 @@ func launchNodeWithConfig(c *cli.Context) (err error) {
 		BidderBidTimeout:         c.Duration(optionBidderBidTimeout.Name),
 		ProviderDecisionTimeout:  c.Duration(optionProviderDecisionTimeout.Name),
 		NotificationsBufferCap:   c.Int(optionNotificationsBuffer.Name),
+		ProposerNotifyOffset:     c.Duration(optionProposerNotifyOffset.Name),
 	})
 	if err != nil {
 		return fmt.Errorf("failed starting node: %w", err)

--- a/p2p/pkg/node/node.go
+++ b/p2p/pkg/node/node.go
@@ -110,6 +110,7 @@ type Options struct {
 	BidderBidTimeout         time.Duration
 	ProviderDecisionTimeout  time.Duration
 	NotificationsBufferCap   int
+	ProposerNotifyOffset     time.Duration
 }
 
 type Node struct {
@@ -480,6 +481,7 @@ func NewNode(opts *Options) (*Node, error) {
 			opts.Logger.With("component", "validatorapi"),
 			callOptsGetter,
 			notificationsSvc,
+			opts.ProposerNotifyOffset,
 		)
 		if err != nil {
 			opts.Logger.Error("failed to create validator api", "error", err)

--- a/p2p/pkg/rpc/validator/export_test.go
+++ b/p2p/pkg/rpc/validator/export_test.go
@@ -8,6 +8,10 @@ import (
 	validatorapiv1 "github.com/primev/mev-commit/p2p/gen/go/validatorapi/v1"
 )
 
+var (
+	NotifyOffset = 1 * time.Second
+)
+
 // SetTestTimings sets the global timing variables for testing and returns a cleanup function
 // that restores the previous values.
 func SetTestTimings(slotDuration time.Duration, epochSlots int, notifyOffset, fetchOffset time.Duration) func() {

--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -91,7 +91,8 @@ func TestGetValidators(t *testing.T) {
 	optsGetter := func() (*bind.CallOpts, error) { return &bind.CallOpts{}, nil }
 	notifier := NewMockNotifier()
 	logger := util.NewTestLogger(os.Stdout)
-	service := validatorapi.NewService(mockServer.URL, mockValidatorRouter, logger, optsGetter, notifier)
+	notifyOffset := 1 * time.Second
+	service := validatorapi.NewService(mockServer.URL, mockValidatorRouter, logger, optsGetter, notifier, notifyOffset)
 	ctx := context.Background()
 	req := &validatorapiv1.GetValidatorsRequest{Epoch: 123}
 	resp, err := service.GetValidators(ctx, req)
@@ -124,7 +125,8 @@ func TestGetValidators_HTTPError(t *testing.T) {
 	mockValidatorRouter := &MockValidatorRouterContract{}
 	notifier := NewMockNotifier()
 	logger := util.NewTestLogger(os.Stdout)
-	service := validatorapi.NewService(mockServer.URL, mockValidatorRouter, logger, optsGetter, notifier)
+	notifyOffset := 1 * time.Second
+	service := validatorapi.NewService(mockServer.URL, mockValidatorRouter, logger, optsGetter, notifier, notifyOffset)
 
 	ctx := context.Background()
 	req := &validatorapiv1.GetValidatorsRequest{Epoch: 123}
@@ -166,7 +168,8 @@ func TestGetValidators_EpochZero(t *testing.T) {
 	notifier := NewMockNotifier()
 	logger := util.NewTestLogger(os.Stdout)
 	ctx := context.Background()
-	service := validatorapi.NewService(mockServer.URL, mockValidatorRouter, logger, optsGetter, notifier)
+	notifyOffset := 1 * time.Second
+	service := validatorapi.NewService(mockServer.URL, mockValidatorRouter, logger, optsGetter, notifier, notifyOffset)
 
 	req := &validatorapiv1.GetValidatorsRequest{Epoch: 0}
 	resp, err := service.GetValidators(ctx, req)
@@ -200,8 +203,8 @@ func TestNewService_FetchGenesisTime(t *testing.T) {
 	mockValidatorRouter := &MockValidatorRouterContract{ExpectedCalls: map[string]interface{}{}}
 	notifier := NewMockNotifier()
 	logger := util.NewTestLogger(os.Stdout)
-
-	svc := validatorapi.NewService(mockServer.URL, mockValidatorRouter, logger, optsGetter, notifier)
+	notifyOffset := 1 * time.Second
+	svc := validatorapi.NewService(mockServer.URL, mockValidatorRouter, logger, optsGetter, notifier, notifyOffset)
 	svc.Start(context.Background())
 
 	val := svc.GenesisTime()
@@ -215,7 +218,8 @@ func TestScheduleNotificationForSlot(t *testing.T) {
 	mockNotifier := NewMockNotifier()
 	now := time.Now()
 	genesisTime := now.Add(100*time.Millisecond + validatorapi.NotifyOffset - validatorapi.SlotDuration)
-	svc := validatorapi.NewService("http://dummy", nil, util.NewTestLogger(os.Stdout), func() (*bind.CallOpts, error) { return &bind.CallOpts{}, nil }, mockNotifier)
+	notifyOffset := 1 * time.Second
+	svc := validatorapi.NewService("http://dummy", nil, util.NewTestLogger(os.Stdout), func() (*bind.CallOpts, error) { return &bind.CallOpts{}, nil }, mockNotifier, notifyOffset)
 	svc.SetGenesisTime(genesisTime)
 
 	slotInfo := &validatorapiv1.SlotInfo{
@@ -278,7 +282,8 @@ func TestProcessEpoch(t *testing.T) {
 	logger := util.NewTestLogger(os.Stdout)
 	ctx := context.Background()
 
-	svc := validatorapi.NewService(ts.URL, mockValidatorRouter, logger, optsGetter, mockNotifier)
+	notifyOffset := 1 * time.Second
+	svc := validatorapi.NewService(ts.URL, mockValidatorRouter, logger, optsGetter, mockNotifier, notifyOffset)
 
 	now := time.Now()
 	svc.SetGenesisTime(now.Add(100*time.Millisecond + validatorapi.NotifyOffset - validatorapi.SlotDuration))
@@ -355,8 +360,8 @@ func TestStart(t *testing.T) {
 	optsGetter := func() (*bind.CallOpts, error) { return &bind.CallOpts{}, nil }
 	notifier := NewMockNotifier()
 	logger := util.NewTestLogger(os.Stdout)
-
-	svc := validatorapi.NewService(ts.URL, mockValidatorRouter, logger, optsGetter, notifier)
+	notifyOffset := 1 * time.Second
+	svc := validatorapi.NewService(ts.URL, mockValidatorRouter, logger, optsGetter, notifier, notifyOffset)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Describe your changes

Makes the notification offset for an opted-in proposer configurable upon p2p node init. 

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
