### PR TITLE
feat: adds nominal bidding to bot

### DIFF
--- a/tools/bidder-bot/README.md
+++ b/tools/bidder-bot/README.md
@@ -27,9 +27,9 @@ flowchart TB
         BalanceChecker -- "Check Settlement Balance" --> SettlementRPC["MEV-Commit Settlement"]
     end
 
-    classDef primary fill:#d0e8ff,stroke:#0066cc,stroke-width:2px
-    classDef secondary fill:#e6f2ff,stroke:#0066cc,stroke-width:1px
-    classDef external fill:#f5f5f5,stroke:#666666,stroke-width:1px
+    classDef primary fill:#c6e6ff,stroke:#1a75ff,stroke-width:2px
+    classDef secondary fill:#e1f0ff,stroke:#1a75ff,stroke-width:1px
+    classDef external fill:#f0f0f0,stroke:#555555,stroke-width:1px
     
     class BidderBot primary
     class Bidder,Notifier,BeaconClient,Service,Main secondary
@@ -89,6 +89,7 @@ sequenceDiagram
     else Timeout or error
         Bidder->>Bidder: Log warning/error
     end
+    
 ```
 
 ## Component Details
@@ -151,12 +152,12 @@ flowchart LR
     BidderAPI --> BidderRPC
     TopologyAPI --> BidderRPC
     
-    classDef config fill:#f9d79b,stroke:#d35400,stroke-width:1px
-    classDef service fill:#aed6f1,stroke:#2874a6,stroke-width:1px
-    classDef core fill:#d4efdf,stroke:#27ae60,stroke-width:1px
-    classDef api fill:#d2b4de,stroke:#8e44ad,stroke-width:1px
-    classDef external fill:#f5f5f5,stroke:#7f8c8d,stroke-width:1px
-    classDef channel fill:#f7dc6f,stroke:#f39c12,stroke-width:1px
+    classDef config fill:#ffe0b2,stroke:#e67e22,stroke-width:1px
+    classDef service fill:#bbdefb,stroke:#1976d2,stroke-width:1px
+    classDef core fill:#c8e6c9,stroke:#2e7d32,stroke-width:1px
+    classDef api fill:#e1bee7,stroke:#7b1fa2,stroke-width:1px
+    classDef external fill:#f5f5f5,stroke:#616161,stroke-width:1px
+    classDef channel fill:#fff9c4,stroke:#f57f17,stroke-width:1px
     
     class Config config
     class Service,GRPCConn,HealthChecker,L1Client,SettlementClient service
@@ -214,10 +215,10 @@ flowchart TD
     Components -->|"Periodic checks"| BalanceCheck
     BalanceCheck -->|"If low balance"| AutoDeposit
     
-    classDef input fill:#f9d79b,stroke:#d35400,stroke-width:1px
-    classDef process fill:#aed6f1,stroke:#2874a6,stroke-width:1px
-    classDef component fill:#d4efdf,stroke:#27ae60,stroke-width:1px
-    classDef output fill:#d2b4de,stroke:#8e44ad,stroke-width:1px
+    classDef input fill:#ffecb3,stroke:#ff8f00,stroke-width:1px
+    classDef process fill:#b3e0ff,stroke:#0277bd,stroke-width:1px
+    classDef component fill:#c8e6c9,stroke:#2e7d32,stroke-width:1px
+    classDef output fill:#e1bee7,stroke:#6a1b9a,stroke-width:1px
     
     class Inputs,BeaconSlots,ProposerNotifications,ConfigParams input
     class Processing,SlotProcessing,BidCreation,TxCreation,CommitmentTracking process
@@ -319,12 +320,12 @@ graph TD
     classDef start fill:#d4efdf,stroke:#27ae60,stroke-width:2px
     classDef process fill:#aed6f1,stroke:#2874a6,stroke-width:1px
     classDef decision fill:#f9d79b,stroke:#d35400,stroke-width:1px
-    classDef end fill:#f5b7b1,stroke:#c0392b,stroke-width:1px
+    classDef terminal fill:#f5b7b1,stroke:#c0392b,stroke-width:1px
     
     class Start start
     class CheckBalances,EnableAutoDeposit,StartServices,SubscribeNotifications,ValidateSlot,GetPreviousSlotBlock,CalculateTargetBlock,PrepareTransaction,SignTransaction,CreateBid,SendBid,GetTopology,TrackCommitment process
     class WaitForNotification,CheckAllReceived,WaitForCommitments decision
-    class LogSuccess,LogError end
+    class LogSuccess,LogError terminal
 ```
 
 1. **Service Initialization**:
@@ -345,7 +346,3 @@ graph TD
    - The bid is submitted to the MEV-Commit Bidder Node with the transaction data
    - The Bidder tracks commitments from providers in response to the bid
    - Success or failures are logged appropriately
-
-## License
-
-This project is licensed under the [MIT License](LICENSE).

--- a/tools/bidder-bot/README.md
+++ b/tools/bidder-bot/README.md
@@ -1,0 +1,100 @@
+# MEV-Commit Bidder Bot
+
+A Go service that automatically places bids for block space on the MEV-Commit network. This bot monitors for upcoming Ethereum block proposers, creates bids, and sends them to the MEV-Commit bidder node.
+
+## Architecture Overview
+
+The bidder bot consists of several key components that work together to monitor the Ethereum network and place bids at the appropriate time.
+
+## Bidding Process Flow
+
+The following diagram illustrates the complete flow of how the bidder bot monitors for upcoming block proposers and places bids.
+
+
+
+## Component Details
+
+The bidder bot is composed of several key components, each with distinct responsibilities.
+
+### Key Components
+
+1. **Service** - The main orchestrator that initializes and coordinates all other components
+2. **Notifier** - Subscribes to and processes notifications about upcoming block proposers
+3. **Bidder** - Handles the creation and submission of bids to the MEV-Commit network
+4. **BeaconClient** - Interfaces with the Ethereum Beacon chain to retrieve slot and block information
+5. **KeySigner** - Manages cryptographic signing of transactions using a keystore file
+
+## Configuration
+
+The bidder bot accepts the following configuration parameters:
+
+```
+--keystore-dir         Directory where keystore file is stored [required]
+--keystore-password    Password to access keystore [required]
+--l1-rpc-urls          URLs for L1 RPC endpoints [required]
+--beacon-api-urls      URLs for Beacon API endpoints [required]
+--settlement-rpc-url   URL for settlement RPC [required]
+--bidder-node-rpc-url  URL for mev-commit bidder node RPC [required]
+--auto-deposit-amount  Amount to auto-deposit (default: 0.1 ETH)
+--bid-amount           Amount to use for each bid (default: 0.005 ETH)
+--gas-tip-cap          Gas tip cap (default: 0.015 gwei)
+--gas-fee-cap          Gas fee cap (default: 1 gwei)
+--log-fmt              Log format: 'text' or 'json' (default: text)
+--log-level            Log level: 'debug', 'info', 'warn', 'error' (default: info)
+```
+
+## Getting Started
+
+### Prerequisites
+
+- Go 1.20 or higher
+- Ethereum keystore file with sufficient ETH on both L1 and MEV-Commit settlement layer
+- Access to Ethereum L1 and Beacon chain endpoints
+- Access to MEV-Commit bidder node and settlement layer endpoints
+
+### Building
+
+```bash
+go build -o bidder-bot ./tools/bidder-bot
+```
+
+### Running
+
+```bash
+./bidder-bot \
+  --keystore-dir=/path/to/keystore \
+  --keystore-password=your_password \
+  --l1-rpc-urls=https://ethereum-rpc.example.com \
+  --beacon-api-urls=https://ethereum-beacon.example.com \
+  --settlement-rpc-url=https://settlement-rpc.example.com \
+  --bidder-node-rpc-url=https://bidder-node.example.com \
+  --log-level=info
+```
+
+## How It Works
+
+
+
+
+1. **Service Initialization**:
+   - Check balances on L1 and settlement layer
+   - Set up auto-deposit if needed
+   - Initialize and start the Notifier and Bidder components
+
+2. **Notification Subscription**:
+   - The Notifier subscribes to upcoming proposer notifications from the MEV-Commit network
+   - When a notification arrives, it's validated and passed to the Bidder
+
+3. **Bid Preparation**:
+   - The Bidder uses the BeaconClient to get the corresponding block number for the target slot
+   - A self-transfer Ethereum transaction is created and signed with the configured keystore
+   - This transaction is included in the bid to demonstrate user intent
+
+4. **Bid Submission**:
+   - The bid is submitted to the MEV-Commit Bidder Node with the transaction data
+   - The Bidder tracks commitments from providers in response to the bid
+   - Success or failures are logged appropriately
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/tools/bidder-bot/service/service.go
+++ b/tools/bidder-bot/service/service.go
@@ -25,16 +25,18 @@ import (
 )
 
 type Config struct {
-	Logger            *slog.Logger
-	Signer            keysigner.KeySigner
-	BidderNodeRPC     string
-	AutoDepositAmount *big.Int
-	L1RPCUrls         []string
-	BeaconApiUrls     []string
-	SettlementRPCUrl  string
-	GasTipCap         *big.Int
-	GasFeeCap         *big.Int
-	BidAmount         *big.Int
+	Logger                *slog.Logger
+	Signer                keysigner.KeySigner
+	BidderNodeRPC         string
+	AutoDepositAmount     *big.Int
+	L1RPCUrls             []string
+	BeaconApiUrls         []string
+	SettlementRPCUrl      string
+	GasTipCap             *big.Int
+	GasFeeCap             *big.Int
+	BidAmount             *big.Int
+	BidAllBlocks          bool
+	RegularBlockBidAmount *big.Int
 }
 
 type Service struct {
@@ -54,7 +56,7 @@ func New(config *Config) (*Service, error) {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
-	conn, err := grpc.NewClient(config.BidderNodeRPC, opts...)
+	conn, err := grpc.Dial(config.BidderNodeRPC, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
@@ -132,6 +134,8 @@ func New(config *Config) (*Service, error) {
 		config.GasFeeCap,
 		config.BidAmount,
 		proposerChan, // receive-only
+		config.BidAllBlocks,
+		config.RegularBlockBidAmount,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
# Add support for bidding on all blocks

This PR enhances the bidder bot to support bidding on all Ethereum blocks, not just those with opted-in proposers.

## Changes

- Add `--bid-all-blocks` flag to enable bidding on all blocks
- Add `--regular-block-bid-amount` to set lower bid amounts for non-opted-in blocks
- Maintain separate bid amounts for opted-in vs regular blocks
- Prevent double-bidding by tracking opted-in slots
- Include automatic cleanup of tracked slots to prevent memory leaks

## Usage

The existing behavior remains unchanged by default. To enable bidding on all blocks:

```
bidder-bot --bid-all-blocks --regular-block-bid-amount=4000000000
```

This will bid 4 gwei for regular blocks while still using the configured `--bid-amount` for opted-in blocks.