### PR TITLE
feat: bidder bot monitor worker

### DIFF
--- a/tools/bidder-bot/bidder/beacon.go
+++ b/tools/bidder-bot/bidder/beacon.go
@@ -87,7 +87,7 @@ func (bc *beaconClient) getLatestSlot(ctx context.Context) (uint64, error) {
 }
 
 func (bc *beaconClient) getBlockNumForSlot(ctx context.Context, slot uint64) (uint64, error) {
-	url := fmt.Sprintf("%s/eth/v1/beacon/blocks/%d", bc.apiURL, slot)
+	url := fmt.Sprintf("%s/eth/v2/beacon/blocks/%d", bc.apiURL, slot)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/tools/bidder-bot/bidder/bidder.go
+++ b/tools/bidder-bot/bidder/bidder.go
@@ -119,7 +119,6 @@ func (b *Bidder) handle(ctx context.Context, upcomingProposer *notifier.Upcoming
 	err = b.watchPendingBid(bidCtx, bidStream)
 	if err != nil {
 		b.logger.Error("failed to watch pending bid", "error", err)
-		return
 	}
 }
 

--- a/tools/bidder-bot/bidder/bidder.go
+++ b/tools/bidder-bot/bidder/bidder.go
@@ -112,6 +112,7 @@ func (b *Bidder) handle(ctx context.Context, upcomingProposer *notifier.Upcoming
 
 	bidStream, err := b.bid(bidCtx, b.bidAmount, targetBlockNum)
 	if err != nil {
+		b.logger.Error("bid failed", "error", err)
 		return
 	}
 

--- a/tools/bidder-bot/bidder/bidder.go
+++ b/tools/bidder-bot/bidder/bidder.go
@@ -3,8 +3,6 @@ package bidder
 import (
 	"context"
 	"encoding/hex"
-	"errors"
-	"io"
 	"log/slog"
 	"math/big"
 	"time"
@@ -13,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	bidderapiv1 "github.com/primev/mev-commit/p2p/gen/go/bidderapi/v1"
 	debugapiv1 "github.com/primev/mev-commit/p2p/gen/go/debugapi/v1"
+	"github.com/primev/mev-commit/tools/bidder-bot/monitor"
 	"github.com/primev/mev-commit/tools/bidder-bot/notifier"
 	"github.com/primev/mev-commit/x/keysigner"
 )
@@ -36,6 +35,7 @@ type Bidder struct {
 	gasFeeCap      *big.Int
 	bidAmount      *big.Int
 	proposerChan   <-chan *notifier.UpcomingProposer
+	sentBidChan    chan<- *monitor.SentBid
 }
 
 func NewBidder(
@@ -49,6 +49,7 @@ func NewBidder(
 	gasFeeCap *big.Int,
 	bidAmount *big.Int,
 	proposerChan <-chan *notifier.UpcomingProposer,
+	sentBidChan chan<- *monitor.SentBid,
 ) *Bidder {
 	beaconClient := newBeaconClient(beaconRPCUrl, logger.With("component", "beacon_client"))
 
@@ -63,6 +64,7 @@ func NewBidder(
 		gasFeeCap:      gasFeeCap,
 		bidAmount:      bidAmount,
 		proposerChan:   proposerChan,
+		sentBidChan:    sentBidChan,
 	}
 }
 
@@ -106,15 +108,10 @@ func (b *Bidder) handle(ctx context.Context, upcomingProposer *notifier.Upcoming
 
 	b.logger.Info("preparing to bid", "upcomingProposer slot", upcomingProposer.Slot, "targetBlockNumber", targetBlockNum)
 
-	pc, err := b.bid(bidCtx, b.bidAmount, targetBlockNum)
+	err = b.bid(bidCtx, b.bidAmount, targetBlockNum)
 	if err != nil {
 		b.logger.Error("bid failed", "error", err)
 		return
-	}
-
-	err = b.watchPendingBid(bidCtx, pc)
-	if err != nil {
-		b.logger.Error("bid failed", "error", err)
 	}
 }
 
@@ -122,22 +119,22 @@ func (b *Bidder) bid(
 	ctx context.Context,
 	bidAmount *big.Int,
 	targetBlockNum uint64,
-) (bidderapiv1.Bidder_SendBidClient, error) {
+) error {
 
 	tx, err := b.selfETHTransfer()
 	if err != nil {
 		b.logger.Error("failed to create self ETH transfer transaction", "error", err)
-		return nil, err
+		return err
 	}
 
 	txBytes, err := tx.MarshalBinary()
 	if err != nil {
 		b.logger.Error("failed to marshal transaction", "error", err)
-		return nil, err
+		return err
 	}
 	txString := hex.EncodeToString(txBytes)
 
-	pc, err := b.bidderClient.SendBid(ctx, &bidderapiv1.Bid{
+	bidStream, err := b.bidderClient.SendBid(ctx, &bidderapiv1.Bid{
 		TxHashes:            []string{},
 		Amount:              bidAmount.String(),
 		BlockNumber:         int64(targetBlockNum),
@@ -149,11 +146,20 @@ func (b *Bidder) bid(
 	})
 	if err != nil {
 		b.logger.Error("failed to send bid", "error", err)
-		return nil, err
+		return err
 	}
 	b.logger.Info("bid sent", "tx_hash", tx.Hash().Hex(), "amount", bidAmount.String(), "target_block_number", targetBlockNum)
 
-	return pc, nil
+	select {
+	case b.sentBidChan <- &monitor.SentBid{
+		TxHash:            tx.Hash(),
+		TargetBlockNumber: targetBlockNum,
+		BidStream:         bidStream,
+	}:
+	default:
+		b.logger.Warn("failed to signal bid monitor: channel full")
+	}
+	return nil
 }
 
 func (b *Bidder) selfETHTransfer() (*types.Transaction, error) {
@@ -194,53 +200,6 @@ func (b *Bidder) selfETHTransfer() (*types.Transaction, error) {
 	b.logger.Info("Self ETH transfer transaction created and signed", "tx_hash", signedTx.Hash().Hex())
 
 	return signedTx, nil
-}
-
-func (b *Bidder) watchPendingBid(ctx context.Context, pc bidderapiv1.Bidder_SendBidClient) error {
-	topo, err := b.topologyClient.GetTopology(ctx, &debugapiv1.EmptyMessage{})
-	if err != nil {
-		b.logger.Error("failed to get topology", "error", err)
-		return err
-	}
-
-	providers := topo.Topology.Fields["connected_providers"].GetListValue()
-	if providers == nil || len(providers.Values) == 0 {
-		return errors.New("no connected providers")
-	}
-
-	commitments := make([]*bidderapiv1.Commitment, 0)
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		msg, err := pc.Recv()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			b.logger.Error("failed to receive commitment", "error", err)
-			return err
-		}
-
-		commitments = append(commitments, msg)
-		b.logger.Debug("received commitment", "commitment", msg)
-
-		if len(commitments) == len(providers.Values) {
-			b.logger.Info("all commitments received")
-			return nil
-		} else {
-			b.logger.Warn(
-				"not all commitments received",
-				"received", len(commitments),
-				"expected", len(providers.Values),
-			)
-		}
-	}
-	return errors.New("bid timeout, not all commitments received")
 }
 
 func (b *Bidder) logDebugInfo(ctx context.Context) {

--- a/tools/bidder-bot/monitor/monitor.go
+++ b/tools/bidder-bot/monitor/monitor.go
@@ -7,16 +7,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	bidderapiv1 "github.com/primev/mev-commit/p2p/gen/go/bidderapi/v1"
 )
 
 type AcceptedBid struct {
 	TxHash            common.Hash
 	TargetBlockNumber uint64
-}
-
-type BidStream interface {
-	Recv() (*bidderapiv1.Commitment, error)
 }
 
 type Monitor struct {

--- a/tools/bidder-bot/monitor/monitor.go
+++ b/tools/bidder-bot/monitor/monitor.go
@@ -1,0 +1,169 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	bidderapiv1 "github.com/primev/mev-commit/p2p/gen/go/bidderapi/v1"
+	debugapiv1 "github.com/primev/mev-commit/p2p/gen/go/debugapi/v1"
+)
+
+type SentBid struct {
+	TxHash            common.Hash
+	TargetBlockNumber uint64
+	BidStream         BidStream
+}
+
+type BidStream interface {
+	Recv() (*bidderapiv1.Commitment, error)
+}
+
+type Monitor struct {
+	logger                   *slog.Logger
+	topologyClient           debugapiv1.DebugServiceClient
+	l1Client                 L1Client
+	monitorTxLandingTimeout  time.Duration
+	monitorTxLandingInterval time.Duration
+	sentBidChan              <-chan *SentBid
+}
+
+type L1Client interface {
+	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+}
+
+func NewMonitor(
+	logger *slog.Logger,
+	topologyClient debugapiv1.DebugServiceClient,
+	l1Client L1Client,
+	sentBidChan <-chan *SentBid,
+	monitorTxLandingTimeout time.Duration,
+	monitorTxLandingInterval time.Duration,
+) *Monitor {
+	return &Monitor{
+		logger:                   logger.With("component", "bid_monitor"),
+		topologyClient:           topologyClient,
+		l1Client:                 l1Client,
+		sentBidChan:              sentBidChan,
+		monitorTxLandingTimeout:  monitorTxLandingTimeout,
+		monitorTxLandingInterval: monitorTxLandingInterval,
+	}
+}
+
+func (m *Monitor) Start(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-ctx.Done():
+				m.logger.Info("monitor context done")
+				return
+			case sentBid := <-m.sentBidChan:
+				m.logger.Info("monitoring sent bid", "tx_hash", sentBid.TxHash.Hex())
+				go m.monitorSentBid(ctx, sentBid)
+			}
+		}
+	}()
+	return done
+}
+
+func (m *Monitor) monitorSentBid(ctx context.Context, sentBid *SentBid) {
+	expectedCommitmentsReceived := m.monitorCommitments(ctx, sentBid)
+	landedInTargetBlock := m.monitorTxLanding(ctx, sentBid)
+
+	m.logger.Info("bid monitoring complete",
+		"tx_hash", sentBid.TxHash.Hex(),
+		"expected_commitments_received", expectedCommitmentsReceived,
+		"landed_in_target_block", landedInTargetBlock)
+}
+
+func (m *Monitor) monitorCommitments(ctx context.Context, sentBid *SentBid) bool {
+	topo, err := m.topologyClient.GetTopology(ctx, &debugapiv1.EmptyMessage{})
+	if err != nil {
+		m.logger.Error("failed to get topology", "tx_hash", sentBid.TxHash.Hex(), "error", err)
+		return false
+	}
+
+	providers := topo.Topology.Fields["connected_providers"].GetListValue()
+	if providers == nil || len(providers.Values) == 0 {
+		m.logger.Error("no connected providers", "tx_hash", sentBid.TxHash.Hex())
+		return false
+	}
+
+	expectedCommitments := len(providers.Values)
+	commitments := make([]*bidderapiv1.Commitment, 0)
+	for {
+		select {
+		case <-ctx.Done():
+			if len(commitments) == expectedCommitments {
+				m.logger.Info("all commitments received", "tx_hash", sentBid.TxHash.Hex())
+				return true
+			}
+			m.logger.Warn("commitment timeout",
+				"tx_hash", sentBid.TxHash.Hex(),
+				"received", commitments,
+				"expected", expectedCommitments)
+			return false
+		default:
+		}
+
+		// 12 second timeout is already set for bid stream in bidder.go
+		msg, err := sentBid.BidStream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			m.logger.Error("failed to receive commitment", "tx_hash", sentBid.TxHash.Hex(), "error", err)
+			return false
+		}
+
+		commitments = append(commitments, msg)
+		m.logger.Debug("received commitment",
+			"tx_hash", sentBid.TxHash.Hex(),
+			"count", len(commitments),
+			"expected", expectedCommitments)
+
+		if len(commitments) == expectedCommitments {
+			m.logger.Info("all commitments received", "tx_hash", sentBid.TxHash.Hex())
+			return true
+		}
+	}
+
+	return len(commitments) == expectedCommitments
+}
+
+func (m *Monitor) monitorTxLanding(ctx context.Context, sentBid *SentBid) bool {
+	txLandingCtx, cancel := context.WithTimeout(ctx, m.monitorTxLandingTimeout)
+	defer cancel()
+	ticker := time.NewTicker(m.monitorTxLandingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-txLandingCtx.Done():
+			m.logger.Warn("tx landing monitoring timeout", "tx_hash", sentBid.TxHash.Hex())
+			return false
+		case <-ticker.C:
+			receipt, err := m.l1Client.TransactionReceipt(txLandingCtx, sentBid.TxHash)
+			if err == nil && receipt != nil {
+				actualBlock := receipt.BlockNumber.Uint64()
+				if actualBlock == sentBid.TargetBlockNumber {
+					m.logger.Info("transaction landed in the target block",
+						"tx_hash", sentBid.TxHash.Hex(),
+						"block", actualBlock)
+					return true
+				}
+				m.logger.Error("transaction landed in non-target block",
+					"tx_hash", sentBid.TxHash.Hex(),
+					"actual_block", actualBlock,
+					"target_block", sentBid.TargetBlockNumber)
+				return false
+			}
+		}
+	}
+}

--- a/tools/bidder-bot/monitor/monitor_test.go
+++ b/tools/bidder-bot/monitor/monitor_test.go
@@ -3,8 +3,6 @@ package monitor
 import (
 	"context"
 	"errors"
-	"fmt"
-	"io"
 	"math/big"
 	"os"
 	"testing"
@@ -12,32 +10,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	bidderapiv1 "github.com/primev/mev-commit/p2p/gen/go/bidderapi/v1"
-	debugapiv1 "github.com/primev/mev-commit/p2p/gen/go/debugapi/v1"
 	"github.com/primev/mev-commit/x/util"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/structpb"
 )
-
-type mockBidStream struct {
-	commitments []*bidderapiv1.Commitment
-	current     int
-	delay       time.Duration
-}
-
-func (m *mockBidStream) Recv() (*bidderapiv1.Commitment, error) {
-	if m.delay > 0 {
-		time.Sleep(m.delay)
-	}
-
-	if m.current >= len(m.commitments) {
-		return nil, io.EOF
-	}
-
-	commitment := m.commitments[m.current]
-	m.current++
-	return commitment, nil
-}
 
 type mockL1Client struct {
 	receipts       map[common.Hash]*types.Receipt
@@ -68,158 +42,6 @@ func (m *mockL1Client) TransactionReceipt(ctx context.Context, txHash common.Has
 		return nil, errors.New("receipt not found")
 	}
 	return receipt, nil
-}
-
-type mockTopologyClient struct {
-	providerCount int
-	err           error
-	responseDelay time.Duration
-}
-
-func (m *mockTopologyClient) GetTopology(ctx context.Context, req *debugapiv1.EmptyMessage, opts ...grpc.CallOption) (*debugapiv1.TopologyResponse, error) {
-	if m.responseDelay > 0 {
-		time.Sleep(m.responseDelay)
-	}
-
-	if m.err != nil {
-		return nil, m.err
-	}
-
-	providersCount := m.providerCount
-	if providersCount < 0 {
-		providersCount = 0
-	}
-
-	providers := make([]*structpb.Value, providersCount)
-	for i := 0; i < providersCount; i++ {
-		providers[i] = structpb.NewStringValue(fmt.Sprintf("provider%d", i+1))
-	}
-
-	listValue := structpb.ListValue{
-		Values: providers,
-	}
-
-	fields := map[string]*structpb.Value{
-		"connected_providers": structpb.NewListValue(&listValue),
-	}
-
-	topologyStruct := &structpb.Struct{
-		Fields: fields,
-	}
-
-	return &debugapiv1.TopologyResponse{
-		Topology: topologyStruct,
-	}, nil
-}
-
-func (m *mockTopologyClient) CancelTransaction(ctx context.Context, req *debugapiv1.CancelTransactionReq, opts ...grpc.CallOption) (*debugapiv1.CancelTransactionResponse, error) {
-	return &debugapiv1.CancelTransactionResponse{}, nil
-}
-
-func (m *mockTopologyClient) GetPendingTransactions(ctx context.Context, req *debugapiv1.EmptyMessage, opts ...grpc.CallOption) (*debugapiv1.PendingTransactionsResponse, error) {
-	return &debugapiv1.PendingTransactionsResponse{}, nil
-}
-
-func TestMonitorCommitments(t *testing.T) {
-	t.Parallel()
-
-	logger := util.NewTestLogger(os.Stdout)
-
-	tests := []struct {
-		name              string
-		providerCount     int
-		commitments       []*bidderapiv1.Commitment
-		topologyErr       error
-		topologyDelay     time.Duration
-		commitmentDelay   time.Duration
-		expectAllReceived bool
-		description       string
-	}{
-		{
-			name:              "all commitments received quickly",
-			providerCount:     3,
-			commitments:       []*bidderapiv1.Commitment{{}, {}, {}},
-			expectAllReceived: true,
-			description:       "All commitments are received before timeout",
-		},
-		{
-			name:              "all commitments received with delay",
-			providerCount:     2,
-			commitments:       []*bidderapiv1.Commitment{{}, {}},
-			commitmentDelay:   10 * time.Millisecond,
-			expectAllReceived: true,
-			description:       "All commitments are received but with some network delay",
-		},
-		{
-			name:              "all commitments received with commitment delay",
-			providerCount:     3,
-			commitments:       []*bidderapiv1.Commitment{{}, {}, {}},
-			commitmentDelay:   30 * time.Millisecond,
-			expectAllReceived: true,
-			description:       "All commitments are received but with some network delay",
-		},
-		{
-			name:              "topology delay but all commitments received",
-			providerCount:     2,
-			commitments:       []*bidderapiv1.Commitment{{}, {}},
-			topologyDelay:     15 * time.Millisecond,
-			expectAllReceived: true,
-			description:       "There's a delay in getting topology but all commitments are received",
-		},
-		{
-			name:              "topology error",
-			topologyErr:       errors.New("failed to fetch topology"),
-			expectAllReceived: false,
-			description:       "Error when fetching topology information",
-		},
-		{
-			name:              "no commitments available",
-			providerCount:     2,
-			commitments:       []*bidderapiv1.Commitment{},
-			expectAllReceived: false,
-			description:       "No commitments are available from the stream",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			topologyClient := &mockTopologyClient{
-				providerCount: tc.providerCount,
-				err:           tc.topologyErr,
-				responseDelay: tc.topologyDelay,
-			}
-
-			bidStream := &mockBidStream{
-				commitments: tc.commitments,
-				delay:       tc.commitmentDelay,
-			}
-
-			m := &Monitor{
-				logger:         logger,
-				topologyClient: topologyClient,
-			}
-
-			ctx := context.Background()
-
-			txHash := common.HexToHash("0x123")
-
-			sentBid := &SentBid{
-				TxHash:            txHash,
-				TargetBlockNumber: 12345,
-				BidStream:         bidStream,
-			}
-
-			result := m.monitorCommitments(ctx, sentBid)
-
-			if result != tc.expectAllReceived {
-				t.Errorf("monitorCommitments() for '%s' = %v, want %v", tc.name, result, tc.expectAllReceived)
-				t.Logf("Description: %s", tc.description)
-				if tc.providerCount > 0 {
-					t.Logf("Expected commitments: %d, Available commitments: %d", tc.providerCount, len(tc.commitments))
-				}
-			}
-		})
-	}
 }
 
 func TestMonitorTxLanding(t *testing.T) {
@@ -340,10 +162,6 @@ func TestStartMonitor(t *testing.T) {
 
 	logger := util.NewTestLogger(os.Stdout)
 
-	topologyClient := &mockTopologyClient{
-		providerCount: 2,
-	}
-
 	l1Client := &mockL1Client{
 		receipts: make(map[common.Hash]*types.Receipt),
 	}
@@ -355,7 +173,6 @@ func TestStartMonitor(t *testing.T) {
 
 	m := NewMonitor(
 		logger,
-		topologyClient,
 		l1Client,
 		bidChan,
 		monitorTxLandingTimeout,
@@ -369,9 +186,6 @@ func TestStartMonitor(t *testing.T) {
 
 	txHash := common.HexToHash("0x123")
 	targetBlockNumber := uint64(12345)
-	bidStream := &mockBidStream{
-		commitments: []*bidderapiv1.Commitment{{}, {}},
-	}
 
 	l1Client.receipts[txHash] = &types.Receipt{
 		BlockNumber: new(big.Int).SetUint64(targetBlockNumber),
@@ -380,7 +194,6 @@ func TestStartMonitor(t *testing.T) {
 	sentBid := &SentBid{
 		TxHash:            txHash,
 		TargetBlockNumber: targetBlockNumber,
-		BidStream:         bidStream,
 	}
 
 	bidChan <- sentBid

--- a/tools/bidder-bot/monitor/monitor_test.go
+++ b/tools/bidder-bot/monitor/monitor_test.go
@@ -138,7 +138,7 @@ func TestMonitorTxLanding(t *testing.T) {
 				monitorTxLandingInterval: tc.checkInterval,
 			}
 
-			sentBid := &SentBid{
+			acceptedBid := &AcceptedBid{
 				TxHash:            txHash,
 				TargetBlockNumber: targetBlockNumber,
 			}
@@ -147,7 +147,7 @@ func TestMonitorTxLanding(t *testing.T) {
 			t.Logf("Context timeout: %v, Receipt delay: %v, Retries: %d",
 				tc.contextTimeout, tc.receiptDelay, tc.receiptRetries)
 
-			result := m.monitorTxLanding(context.Background(), sentBid)
+			result := m.monitorTxLanding(context.Background(), acceptedBid)
 
 			if result != tc.expectLandedInTargetBlock {
 				t.Errorf("monitorTxLanding() for %s = %v, want %v", tc.name, result, tc.expectLandedInTargetBlock)
@@ -166,7 +166,7 @@ func TestStartMonitor(t *testing.T) {
 		receipts: make(map[common.Hash]*types.Receipt),
 	}
 
-	bidChan := make(chan *SentBid, 5)
+	bidChan := make(chan *AcceptedBid, 5)
 
 	monitorTxLandingTimeout := 15 * time.Minute
 	monitorTxLandingInterval := 30 * time.Second
@@ -191,12 +191,12 @@ func TestStartMonitor(t *testing.T) {
 		BlockNumber: new(big.Int).SetUint64(targetBlockNumber),
 	}
 
-	sentBid := &SentBid{
+	acceptedBid := &AcceptedBid{
 		TxHash:            txHash,
 		TargetBlockNumber: targetBlockNumber,
 	}
 
-	bidChan <- sentBid
+	bidChan <- acceptedBid
 
 	time.Sleep(50 * time.Millisecond)
 

--- a/tools/bidder-bot/monitor/monitor_test.go
+++ b/tools/bidder-bot/monitor/monitor_test.go
@@ -1,0 +1,397 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	bidderapiv1 "github.com/primev/mev-commit/p2p/gen/go/bidderapi/v1"
+	debugapiv1 "github.com/primev/mev-commit/p2p/gen/go/debugapi/v1"
+	"github.com/primev/mev-commit/x/util"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type mockBidStream struct {
+	commitments []*bidderapiv1.Commitment
+	current     int
+	delay       time.Duration
+}
+
+func (m *mockBidStream) Recv() (*bidderapiv1.Commitment, error) {
+	if m.delay > 0 {
+		time.Sleep(m.delay)
+	}
+
+	if m.current >= len(m.commitments) {
+		return nil, io.EOF
+	}
+
+	commitment := m.commitments[m.current]
+	m.current++
+	return commitment, nil
+}
+
+type mockL1Client struct {
+	receipts       map[common.Hash]*types.Receipt
+	receiptDelay   time.Duration
+	receiptRetries int
+	callCount      int
+}
+
+func (m *mockL1Client) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	m.callCount++
+
+	if m.receiptDelay > 0 {
+		time.Sleep(m.receiptDelay)
+	}
+
+	if m.receiptRetries > 0 && m.callCount <= m.receiptRetries {
+		return nil, errors.New("transaction not yet mined")
+	}
+
+	receipt, exists := m.receipts[txHash]
+	if !exists {
+		return nil, errors.New("receipt not found")
+	}
+	return receipt, nil
+}
+
+type mockTopologyClient struct {
+	providerCount int
+	err           error
+	responseDelay time.Duration
+}
+
+func (m *mockTopologyClient) GetTopology(ctx context.Context, req *debugapiv1.EmptyMessage, opts ...grpc.CallOption) (*debugapiv1.TopologyResponse, error) {
+	if m.responseDelay > 0 {
+		time.Sleep(m.responseDelay)
+	}
+
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	providersCount := m.providerCount
+	if providersCount < 0 {
+		providersCount = 0
+	}
+
+	providers := make([]*structpb.Value, providersCount)
+	for i := 0; i < providersCount; i++ {
+		providers[i] = structpb.NewStringValue(fmt.Sprintf("provider%d", i+1))
+	}
+
+	listValue := structpb.ListValue{
+		Values: providers,
+	}
+
+	fields := map[string]*structpb.Value{
+		"connected_providers": structpb.NewListValue(&listValue),
+	}
+
+	topologyStruct := &structpb.Struct{
+		Fields: fields,
+	}
+
+	return &debugapiv1.TopologyResponse{
+		Topology: topologyStruct,
+	}, nil
+}
+
+func (m *mockTopologyClient) CancelTransaction(ctx context.Context, req *debugapiv1.CancelTransactionReq, opts ...grpc.CallOption) (*debugapiv1.CancelTransactionResponse, error) {
+	return &debugapiv1.CancelTransactionResponse{}, nil
+}
+
+func (m *mockTopologyClient) GetPendingTransactions(ctx context.Context, req *debugapiv1.EmptyMessage, opts ...grpc.CallOption) (*debugapiv1.PendingTransactionsResponse, error) {
+	return &debugapiv1.PendingTransactionsResponse{}, nil
+}
+
+func TestMonitorCommitments(t *testing.T) {
+	t.Parallel()
+
+	logger := util.NewTestLogger(os.Stdout)
+
+	tests := []struct {
+		name              string
+		providerCount     int
+		commitments       []*bidderapiv1.Commitment
+		topologyErr       error
+		topologyDelay     time.Duration
+		commitmentDelay   time.Duration
+		expectAllReceived bool
+		description       string
+	}{
+		{
+			name:              "all commitments received quickly",
+			providerCount:     3,
+			commitments:       []*bidderapiv1.Commitment{{}, {}, {}},
+			expectAllReceived: true,
+			description:       "All commitments are received before timeout",
+		},
+		{
+			name:              "all commitments received with delay",
+			providerCount:     2,
+			commitments:       []*bidderapiv1.Commitment{{}, {}},
+			commitmentDelay:   10 * time.Millisecond,
+			expectAllReceived: true,
+			description:       "All commitments are received but with some network delay",
+		},
+		{
+			name:              "all commitments received with commitment delay",
+			providerCount:     3,
+			commitments:       []*bidderapiv1.Commitment{{}, {}, {}},
+			commitmentDelay:   30 * time.Millisecond,
+			expectAllReceived: true,
+			description:       "All commitments are received but with some network delay",
+		},
+		{
+			name:              "topology delay but all commitments received",
+			providerCount:     2,
+			commitments:       []*bidderapiv1.Commitment{{}, {}},
+			topologyDelay:     15 * time.Millisecond,
+			expectAllReceived: true,
+			description:       "There's a delay in getting topology but all commitments are received",
+		},
+		{
+			name:              "topology error",
+			topologyErr:       errors.New("failed to fetch topology"),
+			expectAllReceived: false,
+			description:       "Error when fetching topology information",
+		},
+		{
+			name:              "no commitments available",
+			providerCount:     2,
+			commitments:       []*bidderapiv1.Commitment{},
+			expectAllReceived: false,
+			description:       "No commitments are available from the stream",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			topologyClient := &mockTopologyClient{
+				providerCount: tc.providerCount,
+				err:           tc.topologyErr,
+				responseDelay: tc.topologyDelay,
+			}
+
+			bidStream := &mockBidStream{
+				commitments: tc.commitments,
+				delay:       tc.commitmentDelay,
+			}
+
+			m := &Monitor{
+				logger:         logger,
+				topologyClient: topologyClient,
+			}
+
+			ctx := context.Background()
+
+			txHash := common.HexToHash("0x123")
+
+			sentBid := &SentBid{
+				TxHash:            txHash,
+				TargetBlockNumber: 12345,
+				BidStream:         bidStream,
+			}
+
+			result := m.monitorCommitments(ctx, sentBid)
+
+			if result != tc.expectAllReceived {
+				t.Errorf("monitorCommitments() for '%s' = %v, want %v", tc.name, result, tc.expectAllReceived)
+				t.Logf("Description: %s", tc.description)
+				if tc.providerCount > 0 {
+					t.Logf("Expected commitments: %d, Available commitments: %d", tc.providerCount, len(tc.commitments))
+				}
+			}
+		})
+	}
+}
+
+func TestMonitorTxLanding(t *testing.T) {
+	t.Parallel()
+
+	logger := util.NewTestLogger(os.Stdout)
+
+	targetBlockNumber := uint64(12345)
+	txHash := common.HexToHash("0x123")
+
+	tests := []struct {
+		name                      string
+		receipt                   *types.Receipt
+		receiptDelay              time.Duration
+		receiptRetries            int
+		contextTimeout            time.Duration
+		checkInterval             time.Duration
+		expectLandedInTargetBlock bool
+	}{
+		{
+			name: "transaction lands in target block",
+			receipt: &types.Receipt{
+				BlockNumber: new(big.Int).SetUint64(targetBlockNumber),
+			},
+			contextTimeout:            250 * time.Millisecond,
+			checkInterval:             10 * time.Millisecond,
+			expectLandedInTargetBlock: true,
+		},
+		{
+			name: "transaction lands in different block",
+			receipt: &types.Receipt{
+				BlockNumber: new(big.Int).SetUint64(targetBlockNumber + 1),
+			},
+			contextTimeout:            250 * time.Millisecond,
+			checkInterval:             10 * time.Millisecond,
+			expectLandedInTargetBlock: false,
+		},
+		{
+			name:                      "transaction does not land (no receipt)",
+			receipt:                   nil,
+			contextTimeout:            50 * time.Millisecond,
+			checkInterval:             10 * time.Millisecond,
+			expectLandedInTargetBlock: false,
+		},
+		{
+			name: "transaction does not land (delayed past timeout)",
+			receipt: &types.Receipt{
+				BlockNumber: new(big.Int).SetUint64(targetBlockNumber),
+			},
+			receiptRetries:            2,
+			receiptDelay:              100 * time.Millisecond,
+			contextTimeout:            50 * time.Millisecond,
+			checkInterval:             10 * time.Millisecond,
+			expectLandedInTargetBlock: false,
+		},
+		{
+			name: "transaction lands after retries",
+			receipt: &types.Receipt{
+				BlockNumber: new(big.Int).SetUint64(targetBlockNumber),
+			},
+			receiptRetries:            2,
+			contextTimeout:            250 * time.Millisecond,
+			checkInterval:             10 * time.Millisecond,
+			expectLandedInTargetBlock: true,
+		},
+		{
+			name: "transaction lands with delay",
+			receipt: &types.Receipt{
+				BlockNumber: new(big.Int).SetUint64(targetBlockNumber),
+			},
+			receiptDelay:              10 * time.Millisecond,
+			contextTimeout:            250 * time.Millisecond,
+			checkInterval:             10 * time.Millisecond,
+			expectLandedInTargetBlock: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l1Client := &mockL1Client{
+				receipts:       make(map[common.Hash]*types.Receipt),
+				receiptDelay:   tc.receiptDelay,
+				receiptRetries: tc.receiptRetries,
+				callCount:      0,
+			}
+			if tc.receipt != nil {
+				l1Client.receipts[txHash] = tc.receipt
+			}
+
+			m := &Monitor{
+				logger:                   logger,
+				l1Client:                 l1Client,
+				monitorTxLandingTimeout:  tc.contextTimeout,
+				monitorTxLandingInterval: tc.checkInterval,
+			}
+
+			sentBid := &SentBid{
+				TxHash:            txHash,
+				TargetBlockNumber: targetBlockNumber,
+			}
+
+			t.Logf("Test case: %s", tc.name)
+			t.Logf("Context timeout: %v, Receipt delay: %v, Retries: %d",
+				tc.contextTimeout, tc.receiptDelay, tc.receiptRetries)
+
+			result := m.monitorTxLanding(context.Background(), sentBid)
+
+			if result != tc.expectLandedInTargetBlock {
+				t.Errorf("monitorTxLanding() for %s = %v, want %v", tc.name, result, tc.expectLandedInTargetBlock)
+				t.Logf("Call count: %d", l1Client.callCount)
+			}
+		})
+	}
+}
+
+func TestStartMonitor(t *testing.T) {
+	t.Parallel()
+
+	logger := util.NewTestLogger(os.Stdout)
+
+	topologyClient := &mockTopologyClient{
+		providerCount: 2,
+	}
+
+	l1Client := &mockL1Client{
+		receipts: make(map[common.Hash]*types.Receipt),
+	}
+
+	bidChan := make(chan *SentBid, 5)
+
+	monitorTxLandingTimeout := 15 * time.Minute
+	monitorTxLandingInterval := 30 * time.Second
+
+	m := NewMonitor(
+		logger,
+		topologyClient,
+		l1Client,
+		bidChan,
+		monitorTxLandingTimeout,
+		monitorTxLandingInterval,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := m.Start(ctx)
+
+	txHash := common.HexToHash("0x123")
+	targetBlockNumber := uint64(12345)
+	bidStream := &mockBidStream{
+		commitments: []*bidderapiv1.Commitment{{}, {}},
+	}
+
+	l1Client.receipts[txHash] = &types.Receipt{
+		BlockNumber: new(big.Int).SetUint64(targetBlockNumber),
+	}
+
+	sentBid := &SentBid{
+		TxHash:            txHash,
+		TargetBlockNumber: targetBlockNumber,
+		BidStream:         bidStream,
+	}
+
+	bidChan <- sentBid
+
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Monitor failed to stop")
+	}
+}

--- a/tools/bidder-bot/service/balance.go
+++ b/tools/bidder-bot/service/balance.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"time"
+
+	"github.com/primev/mev-commit/x/contracts/ethwrapper"
+	"github.com/primev/mev-commit/x/keysigner"
+)
+
+type BalanceChecker struct {
+	logger              *slog.Logger
+	signer              keysigner.KeySigner
+	l1RPCClient         *ethwrapper.Client
+	settlementRPCClient *ethwrapper.Client
+}
+
+func NewBalanceChecker(
+	logger *slog.Logger,
+	signer keysigner.KeySigner,
+	l1RPCClient *ethwrapper.Client,
+	settlementRPCClient *ethwrapper.Client,
+) *BalanceChecker {
+	return &BalanceChecker{
+		logger:              logger,
+		signer:              signer,
+		l1RPCClient:         l1RPCClient,
+		settlementRPCClient: settlementRPCClient,
+	}
+}
+
+func (b *BalanceChecker) Start(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				err := b.CheckBalances(ctx)
+				if err != nil {
+					b.logger.Error("balance check failed", "error", err)
+				}
+			}
+		}
+	}()
+	return done
+}
+
+func (b *BalanceChecker) CheckBalances(ctx context.Context) error {
+	balanceCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	l1Balance, err := b.l1RPCClient.RawClient().BalanceAt(balanceCtx, b.signer.GetAddress(), nil)
+	if err != nil {
+		return err
+	}
+
+	settlementBalance, err := b.settlementRPCClient.RawClient().BalanceAt(balanceCtx, b.signer.GetAddress(), nil)
+	if err != nil {
+		return err
+	}
+
+	pointZeroFiveEth := big.NewInt(50000000000000000)
+	if l1Balance.Cmp(pointZeroFiveEth) < 0 {
+		return fmt.Errorf("keystore account has less than 0.05 eth on L1")
+	}
+
+	pointFiveEth := big.NewInt(500000000000000000)
+	if settlementBalance.Cmp(pointFiveEth) < 0 {
+		return fmt.Errorf("keystore account has less than 0.5 eth on mev-commit chain")
+	}
+
+	return nil
+}

--- a/tools/bidder-bot/service/service.go
+++ b/tools/bidder-bot/service/service.go
@@ -123,7 +123,6 @@ func New(config *Config) (*Service, error) {
 
 	monitor := monitor.NewMonitor(
 		config.Logger.With("module", "monitor"),
-		topologyCli,
 		l1RPCClient,
 		sentBidChan, // receive-only
 		monitorTxLandingTimeout,

--- a/tools/bidder-bot/service/service.go
+++ b/tools/bidder-bot/service/service.go
@@ -92,7 +92,7 @@ func New(config *Config) (*Service, error) {
 	// Only a single upcomingProposer can be buffered, the notifier overwrites if the buffer is full
 	proposerChan := make(chan *notifier.UpcomingProposer, 1)
 
-	sentBidChan := make(chan *monitor.SentBid, 5)
+	acceptedBidChan := make(chan *monitor.AcceptedBid, 5)
 
 	notifier := notifier.NewNotifier(
 		config.Logger.With("module", "notifier"),
@@ -114,8 +114,8 @@ func New(config *Config) (*Service, error) {
 		config.GasTipCap,
 		config.GasFeeCap,
 		config.BidAmount,
-		proposerChan, // receive-only
-		sentBidChan,  // send-only
+		proposerChan,    // receive-only
+		acceptedBidChan, // send-only
 	)
 
 	monitorTxLandingTimeout := 15 * time.Minute
@@ -124,7 +124,7 @@ func New(config *Config) (*Service, error) {
 	monitor := monitor.NewMonitor(
 		config.Logger.With("module", "monitor"),
 		l1RPCClient,
-		sentBidChan, // receive-only
+		acceptedBidChan, // receive-only
 		monitorTxLandingTimeout,
 		monitorTxLandingInterval,
 	)

--- a/x/contracts/ethwrapper/client.go
+++ b/x/contracts/ethwrapper/client.go
@@ -256,3 +256,11 @@ func (c *Client) ChainID(ctx context.Context) (*big.Int, error) {
 	}
 	return rawClient.ChainID(ctx)
 }
+
+func (c *Client) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	rawClient := c.RawClient()
+	if rawClient == nil {
+		return nil, fmt.Errorf("no raw client")
+	}
+	return rawClient.TransactionReceipt(ctx, txHash)
+}


### PR DESCRIPTION
## Describe your changes

For each sent bid, the bidder now monitors the following in a goroutine:
* Whether all commitments received
* Whether the tx landed on L1
For now, the output is just logs.

Additionally, the balance check for the bidder account now happens every hour instead of only on init.

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
