### PR TITLE
fix: oracle only marks settled on success

### DIFF
--- a/oracle/pkg/store/store.go
+++ b/oracle/pkg/store/store.go
@@ -371,14 +371,16 @@ func (s *Store) Update(ctx context.Context, txHash common.Hash, status string) e
 		return err
 	}
 
-	_, err = tx.ExecContext(
-		ctx,
-		"UPDATE settlements SET settled = true WHERE chainhash = $1",
-		txHashBase64,
-	)
-	if err != nil {
-		_ = tx.Rollback()
-		return err
+	if status == "success" {
+		_, err = tx.ExecContext(
+			ctx,
+			"UPDATE settlements SET settled = true WHERE chainhash = $1",
+			txHashBase64,
+		)
+		if err != nil {
+			_ = tx.Rollback()
+			return err
+		}
 	}
 
 	err = tx.Commit()


### PR DESCRIPTION
## Describe your changes
Oracle should not mark settlement as settled if the txn fails on chain. This would help identify the commitments that havent been settled and should be retried at some point.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
