### PR TITLE
feat: introduce full bidder bot type

### DIFF
--- a/tools/bidder-bot/bidder/bidder.go
+++ b/tools/bidder-bot/bidder/bidder.go
@@ -233,5 +233,9 @@ func (b *Bidder) watchPendingBid(ctx context.Context, pc bidderapiv1.Bidder_Send
 			)
 		}
 	}
-	return errors.New("bid timeout, not all commitments received")
+	if len(commitments) > 0 {
+		return nil
+	} else {
+		return errors.New("bid timeout, no commitments received")
+	}
 }

--- a/tools/bidder-bot/main.go
+++ b/tools/bidder-bot/main.go
@@ -38,6 +38,13 @@ var (
 		Required: true,
 	}
 
+	optionL1WsUrls = &cli.StringSliceFlag{
+		Name:     "l1-ws-urls",
+		Usage:    "URLs for L1 WebSocket",
+		EnvVars:  []string{"L1_WS_URLS"},
+		Required: true,
+	}
+
 	optionBeaconApiUrls = &cli.StringSliceFlag{
 		Name:     "beacon-api-urls",
 		Usage:    "URLs for Beacon API endpoints",
@@ -71,6 +78,13 @@ var (
 		Usage:   "amount to use for each bid",
 		EnvVars: []string{"BID_AMOUNT"},
 		Value:   "5000000000000000", // 0.005 ETH
+	}
+
+	optionUseFullNotifier = &cli.BoolFlag{
+		Name:    "use-full-notifier",
+		Usage:   "whether to use full notifier (false = selective opted-in notifier)",
+		EnvVars: []string{"USE_FULL_NOTIFIER"},
+		Value:   false,
 	}
 
 	optionGasTipCap = &cli.StringFlag{
@@ -139,6 +153,7 @@ func main() {
 			optionKeystorePath,
 			optionKeystorePassword,
 			optionL1RPCUrls,
+			optionL1WsUrls,
 			optionBeaconApiUrls,
 			optionSettlementRPCUrl,
 			optionBidderNodeRPCUrl,
@@ -146,6 +161,7 @@ func main() {
 			optionGasFeeCap,
 			optionAutoDepositAmount,
 			optionBidAmount,
+			optionUseFullNotifier,
 		},
 		Action: func(c *cli.Context) error {
 			logger, err := util.NewLogger(
@@ -198,7 +214,9 @@ func main() {
 				SettlementRPCUrl:  c.String(optionSettlementRPCUrl.Name),
 				BidderNodeRPC:     c.String(optionBidderNodeRPCUrl.Name),
 				L1RPCUrls:         c.StringSlice(optionL1RPCUrls.Name),
+				L1WsUrls:          c.StringSlice(optionL1WsUrls.Name),
 				BeaconApiUrls:     c.StringSlice(optionBeaconApiUrls.Name),
+				IsFullNotifier:    c.Bool(optionUseFullNotifier.Name),
 				Signer:            signer,
 			}
 

--- a/tools/bidder-bot/main.go
+++ b/tools/bidder-bot/main.go
@@ -87,6 +87,13 @@ var (
 		Value:   false,
 	}
 
+	optionCheckBalances = &cli.BoolFlag{
+		Name:    "check-balances",
+		Usage:   "whether to periodically check account balances",
+		EnvVars: []string{"CHECK_BALANCES"},
+		Value:   true,
+	}
+
 	optionGasTipCap = &cli.StringFlag{
 		Name:    "gas-tip-cap",
 		Usage:   "gas tip cap",
@@ -162,6 +169,7 @@ func main() {
 			optionAutoDepositAmount,
 			optionBidAmount,
 			optionUseFullNotifier,
+			optionCheckBalances,
 		},
 		Action: func(c *cli.Context) error {
 			logger, err := util.NewLogger(
@@ -218,6 +226,7 @@ func main() {
 				BeaconApiUrls:     c.StringSlice(optionBeaconApiUrls.Name),
 				IsFullNotifier:    c.Bool(optionUseFullNotifier.Name),
 				Signer:            signer,
+				CheckBalances:     c.Bool(optionCheckBalances.Name),
 			}
 
 			logger.Debug("service config", "config", config)

--- a/tools/bidder-bot/notifier/beacon.go
+++ b/tools/bidder-bot/notifier/beacon.go
@@ -32,46 +32,57 @@ type beaconBlockResponse struct {
 			Body struct {
 				ExecutionPayload struct {
 					BlockNumber string `json:"block_number"`
+					Timestamp   string `json:"timestamp"`
 				} `json:"execution_payload"`
 			} `json:"body"`
 		} `json:"message"`
 	} `json:"data"`
 }
 
-func (bc *beaconClient) getBlockNumForSlot(ctx context.Context, slot uint64) (uint64, error) {
+func (bc *beaconClient) getPayloadDataForSlot(ctx context.Context, slot uint64) (
+	blockNumber uint64,
+	timestamp uint64,
+	err error,
+) {
 	url := fmt.Sprintf("%s/eth/v2/beacon/blocks/%d", bc.apiURL, slot)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		bc.logger.Error("creating request for block number", "error", err)
-		return 0, fmt.Errorf("creating request: %w", err)
+		return 0, 0, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Add("Accept", "application/json")
 
 	resp, err := bc.client.Do(req)
 	if err != nil {
 		bc.logger.Error("failed to execute request for block number", "error", err)
-		return 0, fmt.Errorf("executing request: %w", err)
+		return 0, 0, fmt.Errorf("executing request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		bc.logger.Error("unexpected status code for block number", "status", resp.StatusCode, "slot", slot)
-		return 0, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return 0, 0, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	var blockResp beaconBlockResponse
 	if err := json.NewDecoder(resp.Body).Decode(&blockResp); err != nil {
 		bc.logger.Error("failed to decode response for block number", "error", err)
-		return 0, fmt.Errorf("decoding response: %w", err)
+		return 0, 0, fmt.Errorf("decoding response: %w", err)
 	}
 
-	blockNumber, err := strconv.ParseUint(blockResp.Data.Message.Body.ExecutionPayload.BlockNumber, 10, 64)
+	blockNumber, err = strconv.ParseUint(blockResp.Data.Message.Body.ExecutionPayload.BlockNumber, 10, 64)
 	if err != nil {
 		bc.logger.Error("failed to parse block number", "error", err)
-		return 0, fmt.Errorf("parsing block number: %w", err)
+		return 0, 0, fmt.Errorf("parsing block number: %w", err)
+	}
+
+	timestamp, err = strconv.ParseUint(blockResp.Data.Message.Body.ExecutionPayload.Timestamp, 10, 64)
+	if err != nil {
+		bc.logger.Error("failed to parse timestamp", "error", err)
+		return 0, 0, fmt.Errorf("parsing timestamp: %w", err)
 	}
 
 	bc.logger.Debug("retrieved block number for slot", "slot", slot, "blockNumber", blockNumber)
-	return blockNumber, nil
+	return blockNumber, timestamp, nil
 }

--- a/tools/bidder-bot/notifier/export_test.go
+++ b/tools/bidder-bot/notifier/export_test.go
@@ -1,11 +1,9 @@
 package notifier
 
 import (
-	"context"
-
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-func (s *FullNotifier) HandleHeader(ctx context.Context, header *types.Header) error {
-	return s.handleHeader(ctx, header)
+func (s *FullNotifier) HandleHeader(header *types.Header) error {
+	return s.handleHeader(header)
 }

--- a/tools/bidder-bot/notifier/export_test.go
+++ b/tools/bidder-bot/notifier/export_test.go
@@ -1,0 +1,11 @@
+package notifier
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func (s *FullNotifier) HandleHeader(ctx context.Context, header *types.Header) error {
+	return s.handleHeader(ctx, header)
+}

--- a/tools/bidder-bot/notifier/export_test.go
+++ b/tools/bidder-bot/notifier/export_test.go
@@ -1,9 +1,11 @@
 package notifier
 
 import (
+	"context"
+
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-func (s *FullNotifier) HandleHeader(header *types.Header) error {
-	return s.handleHeader(header)
+func (s *FullNotifier) HandleHeader(ctx context.Context, header *types.Header) error {
+	return s.handleHeader(ctx, header)
 }

--- a/tools/bidder-bot/notifier/full.go
+++ b/tools/bidder-bot/notifier/full.go
@@ -1,0 +1,143 @@
+package notifier
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const (
+	BlockDuration = 12 * time.Second
+)
+
+type FullNotifier struct {
+	logger               *slog.Logger
+	targetBlockNumChan   chan uint64
+	l1Client             L1Client
+	notifySecondsAhead   time.Duration
+	lastNotifiedBlockNum uint64
+	mu                   sync.Mutex
+}
+
+func NewFullNotifier(
+	logger *slog.Logger,
+	targetBlockNumChan chan uint64,
+	l1Client L1Client,
+	notifySecondsAhead time.Duration,
+) *FullNotifier {
+	return &FullNotifier{
+		logger:             logger,
+		targetBlockNumChan: targetBlockNumChan,
+		l1Client:           l1Client,
+		notifySecondsAhead: notifySecondsAhead,
+	}
+}
+
+type L1Client interface {
+	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
+}
+
+func (b *FullNotifier) Start(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		headers := make(chan *types.Header)
+		sub, err := b.l1Client.SubscribeNewHead(ctx, headers)
+		if err != nil {
+			b.logger.Error("failed to subscribe to new heads", "error", err)
+			return
+		}
+
+		b.logger.Info("subscribed to new block headers")
+
+		for {
+			select {
+			case <-ctx.Done():
+				b.logger.Info("context done")
+				return
+
+			case err := <-sub.Err():
+				b.logger.Error("subscription error", "error", err)
+				sub, err = b.l1Client.SubscribeNewHead(ctx, headers)
+				if err != nil {
+					b.logger.Error("failed to resubscribe to new heads", "error", err)
+					return
+				}
+
+			case header := <-headers:
+				if err := b.handleHeader(ctx, header); err != nil {
+					b.logger.Error("error handling header", "error", err)
+				}
+			}
+		}
+	}()
+	return done
+}
+
+func (b *FullNotifier) handleHeader(ctx context.Context, header *types.Header) error {
+	currentBlockNum := header.Number.Uint64()
+	nextBlockNum := currentBlockNum + 1
+
+	now := time.Now()
+	nextBlockTime := now.Add(BlockDuration)
+	notificationTime := nextBlockTime.Add(-b.notifySecondsAhead)
+
+	if notificationTime.Before(now) {
+		b.sendTargetBlockNotification(nextBlockNum)
+		return nil
+	}
+
+	delay := notificationTime.Sub(now)
+
+	b.logger.Debug("scheduling notification",
+		"target_block_number", nextBlockNum,
+		"delay_seconds", delay.Seconds(),
+		"expected_block_time", nextBlockTime)
+
+	b.scheduleNotification(ctx, nextBlockNum, delay)
+	return nil
+}
+
+func (b *FullNotifier) scheduleNotification(ctx context.Context, blockNum uint64, delay time.Duration) {
+	go func() {
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return
+		case <-timer.C:
+			b.sendTargetBlockNotification(blockNum)
+		}
+	}()
+}
+
+func (b *FullNotifier) sendTargetBlockNotification(targetBlockNum uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if targetBlockNum <= b.lastNotifiedBlockNum {
+		return
+	}
+
+	select {
+	case b.targetBlockNumChan <- targetBlockNum:
+		b.logger.Debug("sent target block number", "target_block_number", targetBlockNum)
+	default:
+		select {
+		case drainedTargetBlockNum := <-b.targetBlockNumChan:
+			b.logger.Warn("drained buffered target block number", "drained_target_block_number", drainedTargetBlockNum)
+		default:
+		}
+		b.targetBlockNumChan <- targetBlockNum
+		b.logger.Warn("sent target block number after draining buffer", "target_block_number", targetBlockNum)
+	}
+
+	b.lastNotifiedBlockNum = targetBlockNum
+}

--- a/tools/bidder-bot/notifier/full.go
+++ b/tools/bidder-bot/notifier/full.go
@@ -79,7 +79,7 @@ func (b *FullNotifier) Start(ctx context.Context) <-chan struct{} {
 
 func (b *FullNotifier) handleHeader(header *types.Header) error {
 	targetBlockNum := header.Number.Uint64() + 1
-	b.logger.Debug("scheduling notification from header", "target_block_number", targetBlockNum)
+	b.logger.Debug("handling header", "target_block_number", targetBlockNum)
 
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/tools/bidder-bot/notifier/full.go
+++ b/tools/bidder-bot/notifier/full.go
@@ -120,6 +120,7 @@ func (b *FullNotifier) sendTargetBlockNotification(targetBlockNum uint64) {
 	defer b.mu.Unlock()
 
 	if targetBlockNum <= b.lastNotifiedBlockNum {
+		b.logger.Error("skipping notification for duplicate target block number", "target_block_number", targetBlockNum)
 		return
 	}
 

--- a/tools/bidder-bot/notifier/full.go
+++ b/tools/bidder-bot/notifier/full.go
@@ -71,7 +71,7 @@ func (b *FullNotifier) Start(ctx context.Context) <-chan struct{} {
 				}
 
 			case header := <-headers:
-				if err := b.HandleHeader(ctx, header); err != nil {
+				if err := b.handleHeader(ctx, header); err != nil {
 					b.logger.Error("error handling header", "error", err)
 				}
 			}
@@ -80,7 +80,7 @@ func (b *FullNotifier) Start(ctx context.Context) <-chan struct{} {
 	return done
 }
 
-func (b *FullNotifier) HandleHeader(ctx context.Context, header *types.Header) error {
+func (b *FullNotifier) handleHeader(ctx context.Context, header *types.Header) error {
 	targetBlockNum := header.Number.Uint64() + 1
 	currentBlockTime := time.Unix(int64(header.Time), 0)
 	nextBlockTime := currentBlockTime.Add(BlockDuration)

--- a/tools/bidder-bot/notifier/full_test.go
+++ b/tools/bidder-bot/notifier/full_test.go
@@ -135,12 +135,18 @@ func TestDrain(t *testing.T) {
 		10*time.Second,
 		targetBlockNumChan,
 	)
-	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(5)})
+	err := notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(5)})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	targetBlockNum := <-targetBlockNumChan
 	if targetBlockNum != 6 {
 		t.Fatalf("expected target block number %d, got %d", 6, targetBlockNum)
 	}
-	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(15)})
+	err = notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(15)})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	targetBlockNum = <-targetBlockNumChan
 	if targetBlockNum != 16 {
 		t.Fatalf("expected target block number %d, got %d", 16, targetBlockNum)
@@ -148,10 +154,19 @@ func TestDrain(t *testing.T) {
 
 	pastTime := time.Now().Add(-100 * time.Second) // To ensure sendTargetBlockNotification is called immediately
 
-	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(25), Time: uint64(pastTime.Unix())})
+	err = notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(25), Time: uint64(pastTime.Unix())})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	// draining starts here
-	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(35), Time: uint64(pastTime.Unix())})
-	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(45), Time: uint64(pastTime.Unix())})
+	err = notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(35), Time: uint64(pastTime.Unix())})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	err = notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(45), Time: uint64(pastTime.Unix())})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	targetBlockNum = <-targetBlockNumChan
 	if targetBlockNum != 46 {
 		t.Fatalf("expected target block number %d, got %d", 46, targetBlockNum)

--- a/tools/bidder-bot/notifier/full_test.go
+++ b/tools/bidder-bot/notifier/full_test.go
@@ -135,7 +135,7 @@ func TestDrain(t *testing.T) {
 	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(5)})
 	targetBlockNum := <-targetBlockNumChan
 	if targetBlockNum != 6 {
-		t.Fatalf("expected target block number %d, got %d", 5, targetBlockNum)
+		t.Fatalf("expected target block number %d, got %d", 6, targetBlockNum)
 	}
 	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(15)})
 	targetBlockNum = <-targetBlockNumChan
@@ -143,9 +143,12 @@ func TestDrain(t *testing.T) {
 		t.Fatalf("expected target block number %d, got %d", 16, targetBlockNum)
 	}
 
-	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(25)})
-	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(35)}) // draining starts here
-	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(45)})
+	pastTime := time.Now().Add(-100 * time.Second) // To ensure sendTargetBlockNotification is called immediately
+
+	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(25), Time: uint64(pastTime.Unix())})
+	// draining starts here
+	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(35), Time: uint64(pastTime.Unix())})
+	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(45), Time: uint64(pastTime.Unix())})
 	targetBlockNum = <-targetBlockNumChan
 	if targetBlockNum != 46 {
 		t.Fatalf("expected target block number %d, got %d", 46, targetBlockNum)

--- a/tools/bidder-bot/notifier/full_test.go
+++ b/tools/bidder-bot/notifier/full_test.go
@@ -102,7 +102,10 @@ func TestHandleHeader(t *testing.T) {
 				Number: big.NewInt(int64(71)),
 				Time:   uint64(time.Now().Add(test.currentBlockTimeNowOffset).Unix()),
 			}
-			notifier.HandleHeader(context.Background(), header)
+			err := notifier.HandleHeader(context.Background(), header)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
 
 			select {
 			case <-time.After(test.receiveSignalWithin):

--- a/tools/bidder-bot/notifier/full_test.go
+++ b/tools/bidder-bot/notifier/full_test.go
@@ -114,7 +114,7 @@ func TestChannelTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "failed to send target block number 16") {
+	if !strings.Contains(err.Error(), "failed to send target block 16") {
 		t.Fatalf("unexpected error, got %v", err)
 	}
 

--- a/tools/bidder-bot/notifier/full_test.go
+++ b/tools/bidder-bot/notifier/full_test.go
@@ -1,0 +1,159 @@
+package notifier_test
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/primev/mev-commit/tools/bidder-bot/notifier"
+	"github.com/primev/mev-commit/x/util"
+)
+
+func TestHandleHeader(t *testing.T) {
+	t.Parallel()
+	logger := util.NewTestLogger(os.Stdout)
+
+	recvdBufferTime := 200 * time.Millisecond
+
+	tests := []struct {
+		name                      string
+		currentBlockTimeNowOffset time.Duration
+		notifySecondsAhead        time.Duration
+		receiveSignalWithin       time.Duration
+		expectToReceive           bool
+	}{
+		{
+			name:                      "block time in past, should receive immediately",
+			currentBlockTimeNowOffset: -15 * time.Second,
+			notifySecondsAhead:        10 * time.Second,
+			receiveSignalWithin:       recvdBufferTime,
+			expectToReceive:           true,
+		},
+		{
+			name:                      "block time in past, don't wait long enough",
+			currentBlockTimeNowOffset: -5 * time.Second,
+			notifySecondsAhead:        2 * time.Second,
+			receiveSignalWithin:       recvdBufferTime + 4*time.Second, // -5 + 12 - 2 = 5
+			expectToReceive:           false,
+		},
+		{
+			name:                      "block time in past, wait long enough",
+			currentBlockTimeNowOffset: -5 * time.Second,
+			notifySecondsAhead:        2 * time.Second,
+			receiveSignalWithin:       recvdBufferTime + 5*time.Second,
+			expectToReceive:           true,
+		},
+		{
+			name:                      "block time now, 12 sec notif ahead",
+			currentBlockTimeNowOffset: 0 * time.Second,
+			notifySecondsAhead:        12 * time.Second,
+			receiveSignalWithin:       recvdBufferTime,
+			expectToReceive:           true,
+		},
+		{
+			name:                      "block time now, 10 sec notif ahead",
+			currentBlockTimeNowOffset: 0 * time.Second,
+			notifySecondsAhead:        10 * time.Second,
+			receiveSignalWithin:       recvdBufferTime + 2*time.Second, // 12 second block time - 10 second = 2
+			expectToReceive:           true,
+		},
+		{
+			name:                      "block time now, 8 sec notif ahead, don't wait long enough",
+			currentBlockTimeNowOffset: 0 * time.Second,
+			notifySecondsAhead:        8 * time.Second,
+			receiveSignalWithin:       recvdBufferTime + 3*time.Second, // 12 - 8 = 4
+			expectToReceive:           false,
+		},
+		{
+			name:                      "block time now, 8 sec notif ahead, wait long enough",
+			currentBlockTimeNowOffset: 0 * time.Second,
+			notifySecondsAhead:        8 * time.Second,
+			receiveSignalWithin:       recvdBufferTime + 4*time.Second, // 12 - 8 = 4
+			expectToReceive:           true,
+		},
+		{
+			name:                      "block time in future, 11 sec notif ahead, don't wait long enough",
+			currentBlockTimeNowOffset: 2 * time.Second,
+			notifySecondsAhead:        11 * time.Second,
+			receiveSignalWithin:       recvdBufferTime + 2*time.Second, // 12 + 2 - 11 = 3
+			expectToReceive:           false,
+		},
+		{
+			name:                      "block time in future, 11 sec notif ahead, wait long enough",
+			currentBlockTimeNowOffset: 2 * time.Second,
+			notifySecondsAhead:        11 * time.Second,
+			receiveSignalWithin:       recvdBufferTime + 3*time.Second,
+			expectToReceive:           true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			targetBlockNumChan := make(chan uint64, 1)
+			notifier := notifier.NewFullNotifier(
+				logger,
+				nil,
+				test.notifySecondsAhead,
+				targetBlockNumChan,
+			)
+			header := &types.Header{
+				Number: big.NewInt(int64(71)),
+				Time:   uint64(time.Now().Add(test.currentBlockTimeNowOffset).Unix()),
+			}
+			notifier.HandleHeader(context.Background(), header)
+
+			select {
+			case <-time.After(test.receiveSignalWithin):
+				if test.expectToReceive {
+					t.Fatal("notification not sent in time")
+				}
+			case targetBlockNum := <-targetBlockNumChan:
+				if !test.expectToReceive {
+					t.Fatal("notification sent when not expected")
+				}
+				if targetBlockNum != 72 {
+					t.Fatalf("expected target block number %d, got %d", 72, targetBlockNum)
+				}
+			}
+		})
+	}
+}
+
+func TestDrain(t *testing.T) {
+	t.Parallel()
+	logger := util.NewTestLogger(os.Stdout)
+
+	targetBlockNumChan := make(chan uint64, 1)
+	notifier := notifier.NewFullNotifier(
+		logger,
+		nil,
+		10*time.Second,
+		targetBlockNumChan,
+	)
+	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(5)})
+	targetBlockNum := <-targetBlockNumChan
+	if targetBlockNum != 6 {
+		t.Fatalf("expected target block number %d, got %d", 5, targetBlockNum)
+	}
+	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(15)})
+	targetBlockNum = <-targetBlockNumChan
+	if targetBlockNum != 16 {
+		t.Fatalf("expected target block number %d, got %d", 16, targetBlockNum)
+	}
+
+	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(25)})
+	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(35)}) // draining starts here
+	notifier.HandleHeader(context.Background(), &types.Header{Number: big.NewInt(45)})
+	targetBlockNum = <-targetBlockNumChan
+	if targetBlockNum != 46 {
+		t.Fatalf("expected target block number %d, got %d", 46, targetBlockNum)
+	}
+
+	select {
+	case <-targetBlockNumChan:
+		t.Fatal("expected no more in channel")
+	default:
+	}
+}

--- a/tools/bidder-bot/notifier/selective.go
+++ b/tools/bidder-bot/notifier/selective.go
@@ -19,7 +19,7 @@ var (
 	ErrUnexpectedTopic = errors.New("unexpected msg topic")
 )
 
-type Notifier struct {
+type SelectiveNotifier struct {
 	logger               *slog.Logger
 	notificationsClient  notificationsapiv1.NotificationsClient
 	beaconClient         *beaconClient
@@ -27,13 +27,13 @@ type Notifier struct {
 	lastUpcomingProposer atomic.Pointer[UpcomingProposer]
 }
 
-func NewNotifier(
+func NewSelectiveNotifier(
 	logger *slog.Logger,
 	notificationsClient notificationsapiv1.NotificationsClient,
 	beaconRPCUrl string,
 	targetBlockNumChan chan uint64,
-) *Notifier {
-	return &Notifier{
+) *SelectiveNotifier {
+	return &SelectiveNotifier{
 		logger:              logger,
 		notificationsClient: notificationsClient,
 		beaconClient:        newBeaconClient(beaconRPCUrl, logger.With("component", "beacon_client")),
@@ -41,7 +41,7 @@ func NewNotifier(
 	}
 }
 
-func (b *Notifier) Start(ctx context.Context) <-chan struct{} {
+func (b *SelectiveNotifier) Start(ctx context.Context) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -76,7 +76,7 @@ func (b *Notifier) Start(ctx context.Context) <-chan struct{} {
 	return done
 }
 
-func (b *Notifier) handleMsg(ctx context.Context, msg *notificationsapiv1.Notification) error {
+func (b *SelectiveNotifier) handleMsg(ctx context.Context, msg *notificationsapiv1.Notification) error {
 	upcomingProposer, err := parseUpcomingProposer(msg)
 	if err != nil {
 		b.logger.Error("failed to parse upcoming proposer", "error", err)

--- a/tools/bidder-bot/service/service.go
+++ b/tools/bidder-bot/service/service.go
@@ -111,12 +111,9 @@ func New(config *Config) (*Service, error) {
 		}
 		config.Logger.Debug("created L1 WebSocket client", "url", config.L1WsUrls[0])
 
-		notifySecondsAhead := 7 * time.Second
-
 		notif = notifier.NewFullNotifier(
 			config.Logger.With("module", "full_notifier"),
 			l1WsClient,
-			notifySecondsAhead,
 			targetBlockNumChan, // send-and-receive for draining capability
 		)
 	} else {

--- a/tools/bidder-bot/service/service.go
+++ b/tools/bidder-bot/service/service.go
@@ -98,8 +98,8 @@ func New(config *Config) (*Service, error) {
 		return nil, fmt.Errorf("no beacon API URLs provided")
 	}
 
-	notifier := notifier.NewNotifier(
-		config.Logger.With("module", "notifier"),
+	notifier := notifier.NewSelectiveNotifier(
+		config.Logger.With("module", "selective_notifier"),
 		notificationsCli,
 		config.BeaconApiUrls[0],
 		targetBlockNumChan, // send-and-receive for draining capability


### PR DESCRIPTION
## Describe your changes

Introduces a new mode for the bidder bot where it uses a "full notifier", causing the bot to bid for every block. The old functionality uses a "selective notifier" where bids are only sent for opted-in proposers. 

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
