### PR TITLE
fix: properly handle first slot of epoch 

### DIFF
--- a/p2p/pkg/rpc/validator/export_test.go
+++ b/p2p/pkg/rpc/validator/export_test.go
@@ -27,6 +27,6 @@ func (s *Service) SetGenesisTime(genesisTime time.Time) {
 	s.genesisTime = genesisTime
 }
 
-func (s *Service) SetProcessEpoch(ctx context.Context, epoch uint64, epochTime int64) {
+func (s *Service) SetProcessEpoch(ctx context.Context, epoch uint64, epochTime time.Time) {
 	s.processEpoch(ctx, epoch, epochTime)
 }

--- a/p2p/pkg/rpc/validator/service.go
+++ b/p2p/pkg/rpc/validator/service.go
@@ -316,7 +316,7 @@ func (s *Service) processEpoch(ctx context.Context, epoch uint64, epochTime time
 				"opted_in": info.IsOptedIn,
 			})
 		}
-		if slot != firstSlot { // first slot already scheduled last iteration
+		if slot != firstSlot {
 			s.scheduleNotificationForSlot(epoch, slot, info)
 		}
 	}

--- a/p2p/pkg/rpc/validator/service.go
+++ b/p2p/pkg/rpc/validator/service.go
@@ -257,7 +257,7 @@ func (s *Service) scheduleNotificationForSlot(epoch uint64, slot uint64, info *v
 
 	delay := time.Until(notificationTime)
 	if delay <= 0 {
-		s.logger.Warn("notification time already passed for slot", "epoch", epoch, "slot", slot)
+		s.logger.Error("notification time already passed for slot", "epoch", epoch, "slot", slot)
 		return
 	}
 

--- a/p2p/pkg/rpc/validator/service.go
+++ b/p2p/pkg/rpc/validator/service.go
@@ -255,6 +255,14 @@ func (s *Service) scheduleNotificationForSlot(epoch uint64, slot uint64, info *v
 	slotStartTime := s.genesisTime.Add(time.Duration(slot) * s.slotDuration)
 	notificationTime := slotStartTime.Add(-s.proposerNotifyOffset)
 
+	s.logger.Debug("scheduling opted-in validator notification for slot",
+		"epoch", epoch,
+		"slot", slot,
+		"slot_start_time", slotStartTime,
+		"notification_time", notificationTime,
+		"delay", time.Until(notificationTime),
+	)
+
 	delay := time.Until(notificationTime)
 	if delay <= 0 {
 		s.logger.Error("notification time already passed for slot", "epoch", epoch, "slot", slot)
@@ -315,9 +323,9 @@ func (s *Service) processEpoch(ctx context.Context, epoch uint64, epochTime time
 				"bls_key":  info.BLSKey,
 				"opted_in": info.IsOptedIn,
 			})
-		}
-		if slot != firstSlot {
-			s.scheduleNotificationForSlot(epoch, slot, info)
+			if slot != firstSlot {
+				s.scheduleNotificationForSlot(epoch, slot, info)
+			}
 		}
 	}
 

--- a/p2p/pkg/rpc/validator/service.go
+++ b/p2p/pkg/rpc/validator/service.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -282,15 +283,25 @@ func (s *Service) scheduleNotificationForSlot(epoch uint64, slot uint64, info *v
 func (s *Service) processEpoch(ctx context.Context, epoch uint64, epochTime time.Time) {
 	s.logger.Info("processing epoch", "epoch", epoch)
 
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.processFirstSlotOfNextEpoch(ctx, epoch+1, epochTime.Add(s.epochDuration))
+		s.logger.Debug("processed first slot of next epoch", "epoch", epoch+1)
+	}()
+
 	dutiesResp, err := s.fetchProposerDuties(ctx, epoch)
 	if err != nil {
 		s.logger.Error("failed to fetch proposer duties", "epoch", epoch, "error", err)
+		wg.Wait()
 		return
 	}
 
 	validators, err := s.processValidators(dutiesResp)
 	if err != nil {
 		s.logger.Error("failed to process validators", "epoch", epoch, "error", err)
+		wg.Wait()
 		return
 	}
 
@@ -326,8 +337,7 @@ func (s *Service) processEpoch(ctx context.Context, epoch uint64, epochTime time
 		"first_slot_in_epoch", firstSlot,
 	)
 
-	s.processFirstSlotOfNextEpoch(ctx, epoch+1, epochTime.Add(s.epochDuration))
-	s.logger.Debug("processed first slot of next epoch", "epoch", epoch+1)
+	wg.Wait()
 }
 
 func (s *Service) processFirstSlotOfNextEpoch(ctx context.Context, nextEpoch uint64, nextEpochTime time.Time) {

--- a/p2p/pkg/rpc/validator/service.go
+++ b/p2p/pkg/rpc/validator/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -195,6 +196,10 @@ func (s *Service) fetchProposerDuties(ctx context.Context, epoch uint64) (*Propo
 		return nil, status.Errorf(codes.Internal, "decoding response: %v", err)
 	}
 
+	if len(dutiesResp.Data) == 0 {
+		return nil, status.Errorf(codes.Internal, "no proposer duties found for epoch %d", epoch)
+	}
+
 	return &dutiesResp, nil
 }
 
@@ -274,7 +279,7 @@ func (s *Service) scheduleNotificationForSlot(epoch uint64, slot uint64, info *v
 	})
 }
 
-func (s *Service) processEpoch(ctx context.Context, epoch uint64, epochTime int64) {
+func (s *Service) processEpoch(ctx context.Context, epoch uint64, epochTime time.Time) {
 	s.logger.Info("processing epoch", "epoch", epoch)
 
 	dutiesResp, err := s.fetchProposerDuties(ctx, epoch)
@@ -289,6 +294,8 @@ func (s *Service) processEpoch(ctx context.Context, epoch uint64, epochTime int6
 		return
 	}
 
+	firstSlot := s.getFirstSlot(validators)
+
 	optedInSlots := make([]any, 0)
 	for slot, info := range validators {
 		if info.IsOptedIn {
@@ -297,6 +304,8 @@ func (s *Service) processEpoch(ctx context.Context, epoch uint64, epochTime int6
 				"bls_key":  info.BLSKey,
 				"opted_in": info.IsOptedIn,
 			})
+		}
+		if slot != firstSlot { // first slot already scheduled last iteration
 			s.scheduleNotificationForSlot(epoch, slot, info)
 		}
 	}
@@ -306,15 +315,38 @@ func (s *Service) processEpoch(ctx context.Context, epoch uint64, epochTime int6
 		notifications.TopicEpochValidatorsOptedIn,
 		map[string]any{
 			"epoch":            epoch,
-			"epoch_start_time": epochTime,
+			"epoch_start_time": epochTime.Unix(),
 			"slots":            optedInSlots,
 		},
 	)
 	s.notifier.Notify(notif)
 	s.logger.Info("sent notification for epoch with opted in validators",
 		"epoch", epoch,
-		"slot_count", len(optedInSlots),
+		"opted_in_slot_count", len(optedInSlots),
+		"first_slot_in_epoch", firstSlot,
 	)
+
+	s.processFirstSlotOfNextEpoch(ctx, epoch+1, epochTime.Add(s.epochDuration))
+	s.logger.Debug("processed first slot of next epoch", "epoch", epoch+1)
+}
+
+func (s *Service) processFirstSlotOfNextEpoch(ctx context.Context, nextEpoch uint64, nextEpochTime time.Time) {
+	nextDutiesResp, err := s.fetchProposerDuties(ctx, nextEpoch)
+	if err != nil {
+		s.logger.Error("failed to fetch proposer duties", "epoch", nextEpoch, "error", err)
+		return
+	}
+	nextValidators, err := s.processValidators(nextDutiesResp)
+	if err != nil {
+		s.logger.Error("failed to process validators", "epoch", nextEpoch, "error", err)
+		return
+	}
+
+	firstSlot := s.getFirstSlot(nextValidators)
+	info := nextValidators[firstSlot]
+	if info.IsOptedIn {
+		s.scheduleNotificationForSlot(nextEpoch, firstSlot, info)
+	}
 }
 
 // Start starts a background job that fetches and processes an epoch every 384 seconds.
@@ -335,8 +367,8 @@ func (s *Service) Start(ctx context.Context) <-chan struct{} {
 
 	eg.Go(func() error {
 		currentEpoch := uint64(time.Since(s.genesisTime) / s.epochDuration)
-		s.processEpoch(egCtx, currentEpoch, s.genesisTime.Add(time.Duration(currentEpoch)*s.epochDuration).Unix())
 
+		s.processEpoch(egCtx, currentEpoch, s.genesisTime.Add(time.Duration(currentEpoch)*s.epochDuration))
 		for {
 			nextEpochStart := s.genesisTime.Add(time.Duration(currentEpoch+1) * s.epochDuration)
 			delay := max(time.Until(nextEpochStart), 0)
@@ -352,7 +384,7 @@ func (s *Service) Start(ctx context.Context) <-chan struct{} {
 			case <-timer.C:
 				currentEpoch++
 				s.logger.Info("processing new epoch", "epoch", currentEpoch)
-				s.processEpoch(egCtx, currentEpoch, nextEpochStart.Unix())
+				s.processEpoch(egCtx, currentEpoch, nextEpochStart)
 			}
 		}
 	})
@@ -402,4 +434,14 @@ func (s *Service) fetchGenesisTime(ctx context.Context) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return time.Unix(genesisTimeInt, 0), nil
+}
+
+func (s *Service) getFirstSlot(validators map[uint64]*validatorapiv1.SlotInfo) uint64 {
+	firstSlot := uint64(math.MaxUint64)
+	for slot := range validators {
+		if slot < firstSlot {
+			firstSlot = slot
+		}
+	}
+	return firstSlot
 }

--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -294,7 +294,7 @@ func TestProcessEpoch(t *testing.T) {
 	numValidatorOptedInNotifs := 0
 	numEpochValidatorsOptedInNotifs := 0
 
-	timeout := time.After(1*time.Second + slotDuration)
+	timeout := time.After(2*time.Second + slotDuration)
 
 	// expect 2 validator opted in and 1 epoch notif
 	for numValidatorOptedInNotifs < 2 || numEpochValidatorsOptedInNotifs < 1 {

--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -256,11 +256,6 @@ func TestProcessEpoch(t *testing.T) {
     ]}`
 
 	mux := http.NewServeMux()
-	// Handle genesis requests.
-	mux.HandleFunc("/eth/v1/beacon/genesis", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"data":{"genesis_time":"1672531200"}}`)
-	})
 	// Handle proposer duties.
 	mux.HandleFunc("/eth/v1/validator/duties/proposer/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -286,7 +286,7 @@ func TestProcessEpoch(t *testing.T) {
 	slotDuration := 12 * time.Second
 	svc := validatorapi.NewService(ts.URL, mockValidatorRouter, logger, optsGetter, mockNotifier, notifyOffset)
 
-	svc.SetGenesisTime(time.Now().Add(2*time.Second - slotDuration))
+	svc.SetGenesisTime(time.Now().Add(1*time.Second + 500*time.Millisecond - slotDuration))
 
 	svc.SetProcessEpoch(ctx, 10, time.Now().Unix())
 

--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -286,17 +286,17 @@ func TestProcessEpoch(t *testing.T) {
 	slotDuration := 12 * time.Second
 	svc := validatorapi.NewService(ts.URL, mockValidatorRouter, logger, optsGetter, mockNotifier, notifyOffset)
 
-	svc.SetGenesisTime(time.Now().Add(100*time.Millisecond - slotDuration))
+	svc.SetGenesisTime(time.Now().Add(2*time.Second - slotDuration))
 
 	svc.SetProcessEpoch(ctx, 10, time.Now().Unix())
 
 	numValidatorOptedInNotifs := 0
 	numEpochValidatorsOptedInNotifs := 0
 
-	timeout := time.After(12 * time.Second)
+	timeout := time.After(1 * time.Second)
 
-	// expect 2 validator opted in and 1 epoch notif
-	for numValidatorOptedInNotifs < 2 || numEpochValidatorsOptedInNotifs < 1 {
+	// expect 1 validator opted in and 1 epoch notif
+	for numValidatorOptedInNotifs < 1 || numEpochValidatorsOptedInNotifs < 1 {
 		select {
 		case n := <-mockNotifier.NotifyCh:
 			if n == nil {

--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -289,7 +289,7 @@ func TestProcessEpoch(t *testing.T) {
 
 	svc.SetGenesisTime(time.Now().Add(1*time.Second + 500*time.Millisecond - slotDuration))
 
-	svc.SetProcessEpoch(ctx, 10, time.Now().Unix())
+	svc.SetProcessEpoch(ctx, 10, time.Now())
 
 	numValidatorOptedInNotifs := 0
 	numEpochValidatorsOptedInNotifs := 0

--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -249,17 +251,38 @@ func TestScheduleNotificationForSlot(t *testing.T) {
 func TestProcessEpoch(t *testing.T) {
 	t.Parallel()
 
-	dutiesJSON := `{"data":[
+	dutiesJSONEpoch10 := `{"data":[
         {"pubkey":"0x1234567890abcdef","slot":"1"},
 		{"pubkey":"0x7777777777777777","slot":"2"},
         {"pubkey":"0xfedcba0987654321","slot":"3"}
     ]}`
+	dutiesJSONEpoch11 := `{"data":[
+		{"pubkey":"0x8888888888888888","slot":"4"},
+		{"pubkey":"0x9999999999999999","slot":"5"}
+    ]}`
+
+	currentEpoch := uint64(10)
 
 	mux := http.NewServeMux()
 	// Handle proposer duties.
 	mux.HandleFunc("/eth/v1/validator/duties/proposer/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, dutiesJSON)
+
+		path := r.URL.Path
+		epochStr := path[strings.LastIndex(path, "/")+1:]
+		epoch, err := strconv.Atoi(epochStr)
+		if err != nil {
+			http.Error(w, "Invalid epoch", http.StatusBadRequest)
+			return
+		}
+
+		if epoch == int(currentEpoch) {
+			fmt.Fprint(w, dutiesJSONEpoch10)
+		} else if epoch == int(currentEpoch+1) {
+			fmt.Fprint(w, dutiesJSONEpoch11)
+		} else {
+			t.Fatalf("unexpected epoch request: %d", epoch)
+		}
 	})
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
@@ -275,6 +298,12 @@ func TestProcessEpoch(t *testing.T) {
 			string(hexutil.MustDecode("0xfedcba0987654321")): validatoroptinrouter.IValidatorOptInRouterOptInStatus{
 				IsVanillaOptedIn: false,
 			},
+			string(hexutil.MustDecode("0x8888888888888888")): validatoroptinrouter.IValidatorOptInRouterOptInStatus{
+				IsVanillaOptedIn: true,
+			},
+			string(hexutil.MustDecode("0x9999999999999999")): validatoroptinrouter.IValidatorOptInRouterOptInStatus{
+				IsVanillaOptedIn: true,
+			},
 		},
 	}
 
@@ -284,20 +313,21 @@ func TestProcessEpoch(t *testing.T) {
 	ctx := context.Background()
 
 	notifyOffset := 1 * time.Second
-	slotDuration := 12 * time.Second
+	slotDuration := 2 * time.Second
 	svc := validatorapi.NewService(ts.URL, mockValidatorRouter, logger, optsGetter, mockNotifier, notifyOffset)
 
 	svc.SetGenesisTime(time.Now().Add(1*time.Second + 500*time.Millisecond - slotDuration))
-
-	svc.SetProcessEpoch(ctx, 10, time.Now())
+	svc.SetTestTimings(slotDuration, 32, notifyOffset)
+	svc.SetProcessEpoch(ctx, currentEpoch, time.Now())
 
 	numValidatorOptedInNotifs := 0
-	numEpochValidatorsOptedInNotifs := 0
+	numEpochNotifs := 0
 
-	timeout := time.After(2*time.Second + slotDuration)
+	timeout := time.After(2*time.Second + 4*slotDuration)
 
-	// expect 2 validator opted in and 1 epoch notif
-	for numValidatorOptedInNotifs < 2 || numEpochValidatorsOptedInNotifs < 1 {
+	// expect 2 validator opted in notifs (second slot in epoch 10 and first slot in epoch 11)
+	// also expect 1 epoch notif
+	for numValidatorOptedInNotifs < 2 || numEpochNotifs < 1 {
 		select {
 		case n := <-mockNotifier.NotifyCh:
 			if n == nil {
@@ -309,11 +339,11 @@ func TestProcessEpoch(t *testing.T) {
 				if !ok {
 					t.Fatal("expected slot in notification value")
 				}
-				if slotVal != uint64(1) && slotVal != uint64(2) {
-					t.Errorf("expected slot 1 or 2, got %v", slotVal)
+				if slotVal != uint64(2) && slotVal != uint64(4) {
+					t.Errorf("expected slot 2 or 4, got %v", slotVal)
 				}
 			} else if n.Topic() == notifications.TopicEpochValidatorsOptedIn {
-				numEpochValidatorsOptedInNotifs++
+				numEpochNotifs++
 				slotsVal, ok := n.Value()["slots"]
 				if !ok {
 					t.Fatal("expected slots in notification value")
@@ -325,19 +355,32 @@ func TestProcessEpoch(t *testing.T) {
 				if len(slotsSlice) != 2 {
 					t.Fatalf("expected 2 slots, got %d", len(slotsSlice))
 				}
-				if slotData, ok := slotsSlice[0].(map[string]interface{}); !ok {
-					t.Fatalf("expected slot data to be a map, got %T: %v", slotsSlice[0], slotsSlice[0])
-				} else {
-					if slotVal, ok := slotData["slot"]; !ok || slotVal != uint64(1) {
-						t.Fatalf("expected slot 1, got %v", slotVal)
+				slot1Found, slot2Found := false, false
+				for _, slot := range slotsSlice {
+					slotData, ok := slot.(map[string]interface{})
+					if !ok {
+						t.Fatalf("expected slot to be a map, got %T: %v", slot, slot)
 					}
+					slotVal, ok := slotData["slot"]
+					if !ok {
+						t.Fatal("expected slot in notification value")
+					}
+					if slotVal == uint64(1) {
+						slot1Found = true
+					}
+					if slotVal == uint64(2) {
+						slot2Found = true
+					}
+				}
+				if !slot1Found || !slot2Found {
+					t.Fatalf("expected slots 1 and 2 to be found in epoch notification value")
 				}
 			} else {
 				t.Fatalf("unexpected notification topic: %s", n.Topic())
 			}
 		case <-timeout:
-			t.Fatalf("timeout waiting for notifications: got %d validator opted in (expected 2) and %d epoch validators opted in (expected 1)",
-				numValidatorOptedInNotifs, numEpochValidatorsOptedInNotifs)
+			t.Fatalf("timeout waiting for notifications: got %d validator opted in (expected 3) and %d epoch validators opted in (expected 1)",
+				numValidatorOptedInNotifs, numEpochNotifs)
 		}
 	}
 }


### PR DESCRIPTION
## Describe your changes

Since mev-commit v1.1.1 release, missed slots have only ever happened for the first slot in an epoch. This fix is required so notifications for the first slot of an epoch are sent before the epoch starts.

We maintain the query that runs during the 'current epoch' for the 31 other slots, since validator duties are theoretically only stable within the current epoch. This means the notification for the first slot in an epoch is slightly less reliable than other notifs.

However I ran a [testing script](https://github.com/primev/validator-registry/blob/main/cmd/test-duties/main.go) for a few hours and didn't observe validator duties changing between epochs even once.

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
