### PR TITLE
fix: test for processEpoch func

### DIFF
--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -294,7 +294,7 @@ func TestProcessEpoch(t *testing.T) {
 	numValidatorOptedInNotifs := 0
 	numEpochValidatorsOptedInNotifs := 0
 
-	timeout := time.After(1*time.Second + slotDuration)
+	timeout := time.After(2*time.Second + slotDuration)
 
 	// expect 2 validator opted in and 1 epoch notif
 	for numValidatorOptedInNotifs < 2 || numEpochValidatorsOptedInNotifs < 1 {

--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -256,11 +256,6 @@ func TestProcessEpoch(t *testing.T) {
     ]}`
 
 	mux := http.NewServeMux()
-	// Handle genesis requests.
-	mux.HandleFunc("/eth/v1/beacon/genesis", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"data":{"genesis_time":"1672531200"}}`)
-	})
 	// Handle proposer duties.
 	mux.HandleFunc("/eth/v1/validator/duties/proposer/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -286,7 +286,7 @@ func TestProcessEpoch(t *testing.T) {
 	slotDuration := 12 * time.Second
 	svc := validatorapi.NewService(ts.URL, mockValidatorRouter, logger, optsGetter, mockNotifier, notifyOffset)
 
-	svc.SetGenesisTime(time.Now().Add(2*time.Second - slotDuration))
+	svc.SetGenesisTime(time.Now().Add(1*time.Second + 500*time.Millisecond - slotDuration))
 
 	svc.SetProcessEpoch(ctx, 10, time.Now().Unix())
 

--- a/p2p/pkg/rpc/validator/service_test.go
+++ b/p2p/pkg/rpc/validator/service_test.go
@@ -286,17 +286,17 @@ func TestProcessEpoch(t *testing.T) {
 	slotDuration := 12 * time.Second
 	svc := validatorapi.NewService(ts.URL, mockValidatorRouter, logger, optsGetter, mockNotifier, notifyOffset)
 
-	svc.SetGenesisTime(time.Now().Add(100*time.Millisecond - slotDuration))
+	svc.SetGenesisTime(time.Now().Add(2*time.Second - slotDuration))
 
 	svc.SetProcessEpoch(ctx, 10, time.Now().Unix())
 
 	numValidatorOptedInNotifs := 0
 	numEpochValidatorsOptedInNotifs := 0
 
-	timeout := time.After(12 * time.Second)
+	timeout := time.After(1 * time.Second)
 
-	// expect 2 validator opted in and 1 epoch notif
-	for numValidatorOptedInNotifs < 2 || numEpochValidatorsOptedInNotifs < 1 {
+	// expect 1 validator opted in and 1 epoch notif
+	for numValidatorOptedInNotifs < 1 || numEpochValidatorsOptedInNotifs < 1 {
 		select {
 		case n := <-mockNotifier.NotifyCh:
 			if n == nil {


### PR DESCRIPTION
## Describe your changes

* `TestProcessEpoch` now properly tests that expected notifications are firing, s.t. its a regression test for https://github.com/primev/mev-commit/pull/661
* It now tests for two opted in slot notifs, making it a better regression test for #661, which handles the first slot of an epoch in a special way

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
