### PR TITLE
fix: full bidder bot no longer monitors l1 txes

### DIFF
--- a/tools/bidder-bot/main.go
+++ b/tools/bidder-bot/main.go
@@ -94,6 +94,13 @@ var (
 		Value:   true,
 	}
 
+	optionMonitorTxes = &cli.BoolFlag{
+		Name:    "monitor-txes",
+		Usage:   "whether to monitor if bidded txes land on L1",
+		EnvVars: []string{"MONITOR_TXES"},
+		Value:   true,
+	}
+
 	optionGasTipCap = &cli.StringFlag{
 		Name:    "gas-tip-cap",
 		Usage:   "gas tip cap",
@@ -170,6 +177,7 @@ func main() {
 			optionBidAmount,
 			optionUseFullNotifier,
 			optionCheckBalances,
+			optionMonitorTxes,
 		},
 		Action: func(c *cli.Context) error {
 			logger, err := util.NewLogger(
@@ -227,6 +235,7 @@ func main() {
 				IsFullNotifier:    c.Bool(optionUseFullNotifier.Name),
 				Signer:            signer,
 				CheckBalances:     c.Bool(optionCheckBalances.Name),
+				MonitorTxLanding:  c.Bool(optionMonitorTxes.Name),
 			}
 
 			logger.Debug("service config", "config", config)

--- a/tools/bidder-bot/main.go
+++ b/tools/bidder-bot/main.go
@@ -94,13 +94,6 @@ var (
 		Value:   true,
 	}
 
-	optionMonitorTxes = &cli.BoolFlag{
-		Name:    "monitor-txes",
-		Usage:   "whether to monitor if bidded txes land on L1",
-		EnvVars: []string{"MONITOR_TXES"},
-		Value:   true,
-	}
-
 	optionGasTipCap = &cli.StringFlag{
 		Name:    "gas-tip-cap",
 		Usage:   "gas tip cap",
@@ -177,7 +170,6 @@ func main() {
 			optionBidAmount,
 			optionUseFullNotifier,
 			optionCheckBalances,
-			optionMonitorTxes,
 		},
 		Action: func(c *cli.Context) error {
 			logger, err := util.NewLogger(
@@ -235,7 +227,6 @@ func main() {
 				IsFullNotifier:    c.Bool(optionUseFullNotifier.Name),
 				Signer:            signer,
 				CheckBalances:     c.Bool(optionCheckBalances.Name),
-				MonitorTxLanding:  c.Bool(optionMonitorTxes.Name),
 			}
 
 			logger.Debug("service config", "config", config)

--- a/tools/bidder-bot/service/service.go
+++ b/tools/bidder-bot/service/service.go
@@ -40,7 +40,6 @@ type Config struct {
 	BidAmount         *big.Int
 	IsFullNotifier    bool
 	CheckBalances     bool
-	MonitorTxLanding  bool
 }
 
 type Service struct {
@@ -213,7 +212,7 @@ func New(config *Config) (*Service, error) {
 		s.closers = append(s.closers, channelCloser(balanceCheckerDone))
 	}
 
-	if config.MonitorTxLanding {
+	if !config.IsFullNotifier {
 		monitorDone := monitor.Start(ctx)
 		healthChecker.Register(health.CloseChannelHealthCheck("MonitorService", monitorDone))
 		s.closers = append(s.closers, channelCloser(monitorDone))


### PR DESCRIPTION
## Describe your changes

The "full" bidder bot sends bids for every L1 slot. Some providers accept all of these bids. But these bids will rarely result in a tx landing on L1. Meaning we should not monitor for l1 txes landing, specifically for the "full" configuration of the bidder bot

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
