### PR TITLE
fix: changed decay logic

### DIFF
--- a/oracle/pkg/updater/export_test.go
+++ b/oracle/pkg/updater/export_test.go
@@ -1,0 +1,7 @@
+package updater
+
+import "math/big"
+
+func (u *Updater) ComputeResidualAfterDecay(startTimestamp, endTimestamp, commitTimestamp uint64) *big.Int {
+	return u.computeResidualAfterDecay(startTimestamp, endTimestamp, commitTimestamp)
+}

--- a/oracle/pkg/updater/updater.go
+++ b/oracle/pkg/updater/updater.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"math/big"
 	"strings"
 	"sync"
@@ -39,8 +38,11 @@ const (
 )
 
 const (
-	PRECISION           = 1e16
-	ONE_HUNDRED_PERCENT = 100 * PRECISION
+	PRECISION = 1e16
+)
+
+var (
+	BigOneHundredPercent = big.NewInt(100 * PRECISION)
 )
 
 type Winner struct {
@@ -584,38 +586,59 @@ func (u *Updater) getL1Txns(ctx context.Context, blockNum uint64) (map[string]Tx
 // (e.g they could be unix or unixMili timestamps)
 func (u *Updater) computeResidualAfterDecay(startTimestamp, endTimestamp, commitTimestamp uint64) *big.Int {
 	if startTimestamp >= endTimestamp || endTimestamp <= commitTimestamp {
-		u.logger.Debug("timestamp out of range", "startTimestamp", startTimestamp, "endTimestamp", endTimestamp, "commitTimestamp", commitTimestamp)
+		u.logger.Debug(
+			"timestamp out of range",
+			"startTimestamp", startTimestamp,
+			"endTimestamp", endTimestamp,
+			"commitTimestamp", commitTimestamp,
+		)
 		return big.NewInt(0)
 	}
 
 	// providers may commit before the start of the decay period
 	// in this case, there is no decay
 	if startTimestamp > commitTimestamp {
-		u.logger.Debug("commitTimestamp is before startTimestamp", "startTimestamp", startTimestamp, "commitTimestamp", commitTimestamp)
-		return big.NewInt(int64(ONE_HUNDRED_PERCENT))
+		u.logger.Debug(
+			"commitTimestamp is before startTimestamp",
+			"startTimestamp", startTimestamp,
+			"commitTimestamp", commitTimestamp,
+		)
+		return BigOneHundredPercent
 	}
 
 	// Calculate the total time in seconds
-	totalTime := endTimestamp - startTimestamp
+	totalTime := new(big.Int).SetUint64(endTimestamp - startTimestamp)
 	// Calculate the time passed in seconds
-	timePassed := commitTimestamp - startTimestamp
-	// Calculate the decay percentage
-	decayPercentage := float64(timePassed) / float64(totalTime)
-	// Residual value
-	residual := 1 - decayPercentage
+	timePassed := new(big.Int).SetUint64(commitTimestamp - startTimestamp)
 
-	residualPercentageRound := math.Round(residual * ONE_HUNDRED_PERCENT)
-	if residualPercentageRound > ONE_HUNDRED_PERCENT {
-		residualPercentageRound = ONE_HUNDRED_PERCENT
+	// Calculate the residual percentage using integer arithmetic
+	// residual = (totalTime - timePassed) * ONE_HUNDRED_PERCENT / totalTime
+
+	// Step 1: (totalTime - timePassed)
+	timeRemaining := new(big.Int).Sub(totalTime, timePassed)
+
+	// Step 2: (totalTime - timePassed) * ONE_HUNDRED_PERCENT
+	scaledRemaining := new(big.Int).Mul(timeRemaining, BigOneHundredPercent)
+
+	// Step 3: ((totalTime - timePassed) * ONE_HUNDRED_PERCENT) / totalTime
+	// This gives us the residual percentage directly as an integer
+	residualPercentage := new(big.Int).Div(scaledRemaining, totalTime)
+
+	// Ensure residual doesn't exceed ONE_HUNDRED_PERCENT (shouldn't happen with correct inputs, but for safety)
+	if residualPercentage.Cmp(BigOneHundredPercent) > 0 {
+		residualPercentage = BigOneHundredPercent
 	}
-	u.logger.Debug("decay information",
+
+	u.logger.Debug(
+		"decay information",
 		"startTimestamp", startTimestamp,
 		"endTimestamp", endTimestamp,
 		"commitTimestamp", commitTimestamp,
 		"totalTime", totalTime,
 		"timePassed", timePassed,
-		"decayPercentage", decayPercentage,
-		"residual", residual,
+		"timeRemaining", timeRemaining,
+		"residualPercentage", residualPercentage,
 	)
-	return big.NewInt(int64(residualPercentageRound))
+
+	return residualPercentage
 }

--- a/oracle/pkg/updater/updater_test.go
+++ b/oracle/pkg/updater/updater_test.go
@@ -1322,14 +1322,14 @@ func TestComputeResidualAfterDecay(t *testing.T) {
 			start:  1000,
 			end:    2000,
 			commit: 500,
-			want:   big.NewInt(updater.ONE_HUNDRED_PERCENT),
+			want:   updater.BigOneHundredPercent,
 		},
 		{
 			name:   "Commit At Start",
 			start:  1000,
 			end:    2000,
 			commit: 1000,
-			want:   big.NewInt(updater.ONE_HUNDRED_PERCENT),
+			want:   updater.BigOneHundredPercent,
 		},
 		{
 			name:   "Commit After End",
@@ -1413,7 +1413,7 @@ func TestComputeResidualAfterDecay(t *testing.T) {
 			start:  0,
 			end:    1000,
 			commit: 0,
-			want:   big.NewInt(updater.ONE_HUNDRED_PERCENT),
+			want:   updater.BigOneHundredPercent,
 		},
 		{
 			name:   "Large Timestamps",
@@ -1429,7 +1429,7 @@ func TestComputeResidualAfterDecay(t *testing.T) {
 			start:  1000,
 			end:    1001, // duration 1
 			commit: 1000,
-			want:   big.NewInt(updater.ONE_HUNDRED_PERCENT),
+			want:   updater.BigOneHundredPercent,
 		},
 		{
 			name:   "Minimal Valid Duration, Commit slightly after start",
@@ -1446,16 +1446,9 @@ func TestComputeResidualAfterDecay(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := u.ComputeResidualAfterDecay(tc.start, tc.end, tc.commit)
-			if tc.name == "Commit Very Close To End" {
-				want1 := big.NewInt(10000000000000000)
-				want2 := big.NewInt(10000000000000008)
-				if got.Cmp(want1) != 0 && got.Cmp(want2) != 0 {
-					t.Errorf("ComputeResidualAfterDecay(%d, %d, %d) = %v, want either %v or %v", tc.start, tc.end, tc.commit, got, want1, want2)
-				}
-			} else {
-				if got.Cmp(tc.want) != 0 {
-					t.Errorf("ComputeResidualAfterDecay(%d, %d, %d) = %v, want %v", tc.start, tc.end, tc.commit, got, tc.want)
-				}
+
+			if got.Cmp(tc.want) != 0 {
+				t.Errorf("ComputeResidualAfterDecay(%d, %d, %d) = %v, want %v", tc.start, tc.end, tc.commit, got, tc.want)
 			}
 		})
 	}

--- a/oracle/pkg/updater/updater_test.go
+++ b/oracle/pkg/updater/updater_test.go
@@ -1446,8 +1446,16 @@ func TestComputeResidualAfterDecay(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := u.ComputeResidualAfterDecay(tc.start, tc.end, tc.commit)
-			if got.Cmp(tc.want) != 0 {
-				t.Errorf("ComputeResidualAfterDecay(%d, %d, %d) = %v, want %v", tc.start, tc.end, tc.commit, got, tc.want)
+			if tc.name == "Commit Very Close To End" {
+				want1 := big.NewInt(10000000000000000)
+				want2 := big.NewInt(10000000000000008)
+				if got.Cmp(want1) != 0 && got.Cmp(want2) != 0 {
+					t.Errorf("ComputeResidualAfterDecay(%d, %d, %d) = %v, want either %v or %v", tc.start, tc.end, tc.commit, got, want1, want2)
+				}
+			} else {
+				if got.Cmp(tc.want) != 0 {
+					t.Errorf("ComputeResidualAfterDecay(%d, %d, %d) = %v, want %v", tc.start, tc.end, tc.commit, got, tc.want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Describe your changes

If a provider commits to a bid before the decay start time, it counts as fully decayed. It should instead not decay at all in this case. It is also realistic that providers may commit before, especially since we describe in the docs as a good practice for bidders to add ~300 ms to the current time to the start to not have any decay if providers commit "immediately".

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
