### PR TITLE
feat: added commitments to dashboard

### DIFF
--- a/tools/dashboard/main.go
+++ b/tools/dashboard/main.go
@@ -425,6 +425,27 @@ func registerRoutes(mux *http.ServeMux, statHdlr *statHandler) {
 
 		w.WriteHeader(http.StatusOK)
 	})
+
+	mux.HandleFunc("GET /block/{block}/commitments", func(w http.ResponseWriter, r *http.Request) {
+		blockStr := r.PathValue("block")
+		block, err := strconv.Atoi(blockStr)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		commitments := statHdlr.getOpenCommitmentsByBlock(uint64(block))
+		if len(commitments) == 0 {
+			http.Error(w, "no commitments found for this block", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(commitments); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
 }
 
 func parsePagination(r *http.Request) (int, int) {

--- a/tools/validators-monitor/api/dashboard_client_test.go
+++ b/tools/validators-monitor/api/dashboard_client_test.go
@@ -154,6 +154,211 @@ func TestGetBlockInfo(t *testing.T) {
 	}
 }
 
+func TestGetCommitmentsByBlock(t *testing.T) {
+	tests := []struct {
+		name           string
+		blockNumber    uint64
+		responseStatus int
+		responseBody   string
+		expectedError  bool
+		expectedLength int
+		checkFirstItem bool // whether to verify the first commitment's details
+	}{
+		{
+			name:           "successful response with commitments",
+			blockNumber:    12345,
+			responseStatus: http.StatusOK,
+			responseBody: `[
+				{
+					"commitment_index": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32],
+					"bidder": "0xbidder1",
+					"committer": "0xcommitter1",
+					"bid_amt": "1000000000000000000",
+					"slash_amt": "500000000000000000",
+					"block_number": 12345,
+					"decay_start_time_stamp": 1000,
+					"decay_end_time_stamp": 2000,
+					"txn_hash": "0xtxhash1",
+					"reverting_tx_hashes": "hash1,hash2",
+					"commitment_digest": [33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64],
+					"dispatch_timestamp": 3000
+				},
+				{
+					"commitment_index": [65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96],
+					"bidder": "0xbidder2",
+					"committer": "0xcommitter2",
+					"bid_amt": "2000000000000000000",
+					"slash_amt": "1000000000000000000",
+					"block_number": 12345,
+					"decay_start_time_stamp": 1500,
+					"decay_end_time_stamp": 2500,
+					"txn_hash": "0xtxhash2",
+					"reverting_tx_hashes": "hash3",
+					"commitment_digest": [97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128],
+					"dispatch_timestamp": 3500
+				}
+			]`,
+			expectedError:  false,
+			expectedLength: 2,
+			checkFirstItem: true,
+		},
+		{
+			name:           "successful response with empty array",
+			blockNumber:    12345,
+			responseStatus: http.StatusOK,
+			responseBody:   `[]`,
+			expectedError:  false,
+			expectedLength: 0,
+			checkFirstItem: false,
+		},
+		{
+			name:           "not found response",
+			blockNumber:    12345,
+			responseStatus: http.StatusNotFound,
+			responseBody:   `{"error": "No commitments found for this block"}`,
+			expectedError:  false, // We treat not found as an empty result
+			expectedLength: 0,
+			checkFirstItem: false,
+		},
+		{
+			name:           "server error",
+			blockNumber:    12345,
+			responseStatus: http.StatusInternalServerError,
+			responseBody:   `{"error": "Internal server error"}`,
+			expectedError:  true,
+			expectedLength: 0,
+			checkFirstItem: false,
+		},
+		{
+			name:           "invalid json response",
+			blockNumber:    12345,
+			responseStatus: http.StatusOK,
+			responseBody:   `{invalid json}`,
+			expectedError:  true,
+			expectedLength: 0,
+			checkFirstItem: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Check request path
+				expectedPath := "/block/" + strconv.FormatUint(tt.blockNumber, 10) + "/commitments"
+				assert.Equal(t, expectedPath, r.URL.Path)
+
+				// Check request method
+				assert.Equal(t, http.MethodGet, r.Method)
+
+				// Check headers
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
+				assert.Equal(t, "MEV-Commit-Monitor/1.0", r.Header.Get("User-Agent"))
+
+				// Send response
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.responseStatus)
+				_, err := w.Write([]byte(tt.responseBody))
+				require.NoError(t, err)
+			})
+
+			client := setupTestDashboardClient(t, handler)
+			result, err := client.GetCommitmentsByBlock(context.Background(), tt.blockNumber)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expectedLength, len(result))
+
+				if tt.checkFirstItem && len(result) > 0 {
+					// Check the first item's details
+					assert.Equal(t, "0xbidder1", result[0].Bidder)
+					assert.Equal(t, "0xcommitter1", result[0].Committer)
+					assert.Equal(t, "1000000000000000000", result[0].BidAmt)
+					assert.Equal(t, "500000000000000000", result[0].SlashAmt)
+					assert.Equal(t, uint64(12345), result[0].BlockNumber)
+					assert.Equal(t, uint64(1000), result[0].DecayStartTimeStamp)
+					assert.Equal(t, uint64(2000), result[0].DecayEndTimeStamp)
+					assert.Equal(t, "0xtxhash1", result[0].TxnHash)
+					assert.Equal(t, "hash1,hash2", result[0].RevertingTxHashes)
+					assert.Equal(t, uint64(3000), result[0].DispatchTimestamp)
+
+					// Check the byte arrays
+					expectedIndex := [32]byte{}
+					for i := range 32 {
+						expectedIndex[i] = byte(i + 1)
+					}
+					assert.Equal(t, expectedIndex, result[0].CommitmentIndex)
+
+					expectedDigest := [32]byte{}
+					for i := range 32 {
+						expectedDigest[i] = byte(i + 33)
+					}
+					assert.Equal(t, expectedDigest, result[0].CommitmentDigest)
+				}
+			}
+		})
+	}
+}
+func TestGetCommitmentsByBlock_ContextCancellation(t *testing.T) {
+	// Create a simple handler
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Just return success - the context cancellation is handled by the HTTP client
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`[{"commitment_index": "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"}]`))
+		require.NoError(t, err)
+	})
+
+	client := setupTestDashboardClient(t, handler)
+
+	// Create a context that we can cancel
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel it immediately to simulate a timeout/cancellation
+	cancel()
+
+	// The request should fail due to canceled context
+	result, err := client.GetCommitmentsByBlock(ctx, 12345)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestGetCommitmentsByBlock_NetworkErrors(t *testing.T) {
+	// Create a client with an unreachable URL
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+
+	dashboardClient, err := NewDashboardClient("http://localhost:12345", logger, httpClient)
+	require.NoError(t, err)
+
+	// The request should fail due to connection refused
+	result, err := dashboardClient.GetCommitmentsByBlock(context.Background(), 12345)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestGetCommitmentsByBlock_HeaderHandling(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check that Accept and User-Agent headers are set
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		assert.Equal(t, "MEV-Commit-Monitor/1.0", r.Header.Get("User-Agent"))
+
+		// Return a valid response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`[]`))
+		require.NoError(t, err)
+	})
+
+	client := setupTestDashboardClient(t, handler)
+	result, err := client.GetCommitmentsByBlock(context.Background(), 12345)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result, 0)
+}
+
 func TestContextCancellation(t *testing.T) {
 	// Create a simple handler
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/validators-monitor/database/db.go
+++ b/tools/validators-monitor/database/db.go
@@ -29,6 +29,23 @@ type RelayRecord struct {
 	CreatedAt          time.Time
 }
 
+type CommitmentRecord struct {
+	ID                  int64
+	BlockNumber         uint64
+	CommitmentIndex     []byte
+	Bidder              string
+	Committer           string
+	BidAmount           *big.Int
+	SlashAmount         *big.Int
+	DecayStartTimestamp uint64
+	DecayEndTimestamp   uint64
+	TxnHash             string
+	RevertingTxHashes   string
+	CommitmentDigest    []byte
+	DispatchTimestamp   uint64
+	CreatedAt           time.Time
+}
+
 // PostgresDB handles database connections and operations
 type PostgresDB struct {
 	db     *sql.DB
@@ -110,6 +127,27 @@ func (p *PostgresDB) InitSchema(ctx context.Context) error {
 	CREATE INDEX IF NOT EXISTS idx_relay_data_slot ON relay_data(slot);
 	CREATE INDEX IF NOT EXISTS idx_relay_data_block_number ON relay_data(block_number);
 	CREATE INDEX IF NOT EXISTS idx_relay_data_validator_pubkey ON relay_data(validator_pubkey);
+
+	CREATE TABLE IF NOT EXISTS block_commitments (
+		id SERIAL PRIMARY KEY,
+		block_number BIGINT NOT NULL,
+		commitment_index BYTEA NOT NULL,
+		bidder TEXT NOT NULL,
+		committer TEXT NOT NULL,
+		bid_amount NUMERIC NOT NULL,
+		slash_amount NUMERIC NOT NULL,
+		decay_start_timestamp BIGINT NOT NULL,
+		decay_end_timestamp BIGINT NOT NULL,
+		txn_hash TEXT,
+		reverting_tx_hashes TEXT,
+		commitment_digest BYTEA NOT NULL,
+		dispatch_timestamp BIGINT,
+		created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+	);
+	
+	CREATE INDEX IF NOT EXISTS idx_block_commitments_block ON block_commitments(block_number);
+	CREATE INDEX IF NOT EXISTS idx_block_commitments_bidder ON block_commitments(bidder);
+	CREATE INDEX IF NOT EXISTS idx_block_commitments_committer ON block_commitments(committer);
 	`
 
 	_, err := p.db.ExecContext(ctx, schema)
@@ -203,7 +241,6 @@ func (p *PostgresDB) GetRelayDataByBlock(
 			return nil, fmt.Errorf("error scanning row: %w", err)
 		}
 
-		// Convert mevReward from string back to big.Int
 		r.MEVReward = new(big.Int)
 		r.MEVReward.SetString(mevRewardStr, 10)
 
@@ -215,6 +252,79 @@ func (p *PostgresDB) GetRelayDataByBlock(
 	}
 
 	return records, nil
+}
+
+// SaveBlockCommitments saves block commitments to the database
+func (p *PostgresDB) SaveBlockCommitments(
+	ctx context.Context,
+	commitments []*CommitmentRecord,
+) error {
+	// Begin transaction
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Prepare statement
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO block_commitments (
+			block_number, commitment_index, bidder, committer, bid_amount,
+			slash_amount, decay_start_timestamp, decay_end_timestamp, txn_hash,
+			reverting_tx_hashes, commitment_digest, dispatch_timestamp
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		ON CONFLICT DO NOTHING
+		RETURNING id, created_at
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	//nolint:errcheck
+	defer stmt.Close()
+
+	for _, commitment := range commitments {
+		var id int64
+		var createdAt time.Time
+
+		err := stmt.QueryRowContext(
+			ctx,
+			commitment.BlockNumber,
+			commitment.CommitmentIndex,
+			commitment.Bidder,
+			commitment.Committer,
+			commitment.BidAmount.String(),
+			commitment.SlashAmount.String(),
+			commitment.DecayStartTimestamp,
+			commitment.DecayEndTimestamp,
+			commitment.TxnHash,
+			commitment.RevertingTxHashes,
+			commitment.CommitmentDigest,
+			commitment.DispatchTimestamp,
+		).Scan(&id, &createdAt)
+
+		if err == sql.ErrNoRows {
+			// This means it was a duplicate - continue processing
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to save commitment: %w", err)
+		}
+
+		commitment.ID = id
+		commitment.CreatedAt = createdAt
+	}
+
+	// Commit transaction
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
 }
 
 // Close closes the database connection

--- a/tools/validators-monitor/database/db_test.go
+++ b/tools/validators-monitor/database/db_test.go
@@ -222,6 +222,296 @@ func TestGetRelayDataByBlock(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestSaveBlockCommitments_PrepareError tests error handling for prepare statement
+func TestSaveBlockCommitments_PrepareError(t *testing.T) {
+	postgresDB, mock := setupMockDB(t)
+	//nolint:errcheck
+	defer postgresDB.Close()
+
+	ctx := context.Background()
+
+	// Create test commitment records
+	testCommitments := []*CommitmentRecord{
+		{
+			BlockNumber:         5678,
+			CommitmentIndex:     []byte{1, 2, 3, 4},
+			Bidder:              "0xbidder1",
+			Committer:           "0xcommitter1",
+			BidAmount:           big.NewInt(1000000000000000000),
+			SlashAmount:         big.NewInt(500000000000000000),
+			DecayStartTimestamp: 1000,
+			DecayEndTimestamp:   2000,
+			TxnHash:             "0xtxhash1",
+			RevertingTxHashes:   "hash1,hash2",
+			CommitmentDigest:    []byte{5, 6, 7, 8},
+			DispatchTimestamp:   3000,
+		},
+	}
+
+	// Mock begin transaction
+	mock.ExpectBegin()
+
+	// Mock prepare statement with error
+	mock.ExpectPrepare("INSERT INTO block_commitments").WillReturnError(sql.ErrConnDone)
+
+	// Mock rollback
+	mock.ExpectRollback()
+
+	// Call the method under test
+	err := postgresDB.SaveBlockCommitments(ctx, testCommitments)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestSaveBlockCommitments_InsertError tests error handling for insert query
+func TestSaveBlockCommitments_InsertError(t *testing.T) {
+	postgresDB, mock := setupMockDB(t)
+	//nolint:errcheck
+	defer postgresDB.Close()
+
+	ctx := context.Background()
+
+	// Create test commitment records
+	testCommitments := []*CommitmentRecord{
+		{
+			BlockNumber:         5678,
+			CommitmentIndex:     []byte{1, 2, 3, 4},
+			Bidder:              "0xbidder1",
+			Committer:           "0xcommitter1",
+			BidAmount:           big.NewInt(1000000000000000000),
+			SlashAmount:         big.NewInt(500000000000000000),
+			DecayStartTimestamp: 1000,
+			DecayEndTimestamp:   2000,
+			TxnHash:             "0xtxhash1",
+			RevertingTxHashes:   "hash1,hash2",
+			CommitmentDigest:    []byte{5, 6, 7, 8},
+			DispatchTimestamp:   3000,
+		},
+	}
+
+	// Mock begin transaction
+	mock.ExpectBegin()
+
+	// Mock prepare statement
+	mock.ExpectPrepare("INSERT INTO block_commitments")
+
+	// Mock insert with error
+	mock.ExpectQuery("INSERT INTO block_commitments").WithArgs(
+		testCommitments[0].BlockNumber,
+		testCommitments[0].CommitmentIndex,
+		testCommitments[0].Bidder,
+		testCommitments[0].Committer,
+		testCommitments[0].BidAmount.String(),
+		testCommitments[0].SlashAmount.String(),
+		testCommitments[0].DecayStartTimestamp,
+		testCommitments[0].DecayEndTimestamp,
+		testCommitments[0].TxnHash,
+		testCommitments[0].RevertingTxHashes,
+		testCommitments[0].CommitmentDigest,
+		testCommitments[0].DispatchTimestamp,
+	).WillReturnError(sql.ErrConnDone)
+
+	// No rollback expected if the implementation doesn't call it
+
+	// Call the method under test
+	err := postgresDB.SaveBlockCommitments(ctx, testCommitments)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestSaveBlockCommitments_CommitError tests error handling for commit transaction
+func TestSaveBlockCommitments_CommitError(t *testing.T) {
+	postgresDB, mock := setupMockDB(t)
+	//nolint:errcheck
+	defer postgresDB.Close()
+
+	ctx := context.Background()
+
+	// Create test commitment records
+	testCommitments := []*CommitmentRecord{
+		{
+			BlockNumber:         5678,
+			CommitmentIndex:     []byte{1, 2, 3, 4},
+			Bidder:              "0xbidder1",
+			Committer:           "0xcommitter1",
+			BidAmount:           big.NewInt(1000000000000000000),
+			SlashAmount:         big.NewInt(500000000000000000),
+			DecayStartTimestamp: 1000,
+			DecayEndTimestamp:   2000,
+			TxnHash:             "0xtxhash1",
+			RevertingTxHashes:   "hash1,hash2",
+			CommitmentDigest:    []byte{5, 6, 7, 8},
+			DispatchTimestamp:   3000,
+		},
+	}
+
+	// Mock begin transaction
+	mock.ExpectBegin()
+
+	// Mock prepare statement
+	mock.ExpectPrepare("INSERT INTO block_commitments")
+
+	// Mock insert
+	rows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow(1, time.Now())
+	mock.ExpectQuery("INSERT INTO block_commitments").WithArgs(
+		testCommitments[0].BlockNumber,
+		testCommitments[0].CommitmentIndex,
+		testCommitments[0].Bidder,
+		testCommitments[0].Committer,
+		testCommitments[0].BidAmount.String(),
+		testCommitments[0].SlashAmount.String(),
+		testCommitments[0].DecayStartTimestamp,
+		testCommitments[0].DecayEndTimestamp,
+		testCommitments[0].TxnHash,
+		testCommitments[0].RevertingTxHashes,
+		testCommitments[0].CommitmentDigest,
+		testCommitments[0].DispatchTimestamp,
+	).WillReturnRows(rows)
+
+	// Mock commit with error
+	mock.ExpectCommit().WillReturnError(sql.ErrConnDone)
+
+	// Call the method under test
+	err := postgresDB.SaveBlockCommitments(ctx, testCommitments)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestGetCommitmentsByBlock tests querying commitments by block number
+func TestGetCommitmentsByBlock(t *testing.T) {
+	postgresDB, mock := setupMockDB(t)
+	//nolint:errcheck
+	defer postgresDB.Close()
+
+	ctx := context.Background()
+	blockNumber := uint64(5678)
+	now := time.Now()
+
+	// Expected results
+	expectedCommitments := []*CommitmentRecord{
+		{
+			ID:                  1,
+			BlockNumber:         blockNumber,
+			CommitmentIndex:     []byte{1, 2, 3, 4},
+			Bidder:              "0xbidder1",
+			Committer:           "0xcommitter1",
+			BidAmount:           big.NewInt(1000000000000000000),
+			SlashAmount:         big.NewInt(500000000000000000),
+			DecayStartTimestamp: 1000,
+			DecayEndTimestamp:   2000,
+			TxnHash:             "0xtxhash1",
+			RevertingTxHashes:   "hash1,hash2",
+			CommitmentDigest:    []byte{5, 6, 7, 8},
+			DispatchTimestamp:   3000,
+			CreatedAt:           now,
+		},
+		{
+			ID:                  2,
+			BlockNumber:         blockNumber,
+			CommitmentIndex:     []byte{9, 10, 11, 12},
+			Bidder:              "0xbidder2",
+			Committer:           "0xcommitter2",
+			BidAmount:           big.NewInt(2000000000000000000),
+			SlashAmount:         big.NewInt(1000000000000000000),
+			DecayStartTimestamp: 1500,
+			DecayEndTimestamp:   2500,
+			TxnHash:             "0xtxhash2",
+			RevertingTxHashes:   "hash3",
+			CommitmentDigest:    []byte{13, 14, 15, 16},
+			DispatchTimestamp:   3500,
+			CreatedAt:           now,
+		},
+	}
+
+	// Setup mock rows
+	rows := sqlmock.NewRows([]string{
+		"id", "block_number", "commitment_index", "bidder", "committer",
+		"bid_amount", "slash_amount", "decay_start_timestamp", "decay_end_timestamp",
+		"txn_hash", "reverting_tx_hashes", "commitment_digest", "dispatch_timestamp", "created_at",
+	})
+
+	// Add rows
+	rows.AddRow(
+		expectedCommitments[0].ID,
+		expectedCommitments[0].BlockNumber,
+		expectedCommitments[0].CommitmentIndex,
+		expectedCommitments[0].Bidder,
+		expectedCommitments[0].Committer,
+		expectedCommitments[0].BidAmount.String(),
+		expectedCommitments[0].SlashAmount.String(),
+		expectedCommitments[0].DecayStartTimestamp,
+		expectedCommitments[0].DecayEndTimestamp,
+		expectedCommitments[0].TxnHash,
+		expectedCommitments[0].RevertingTxHashes,
+		expectedCommitments[0].CommitmentDigest,
+		expectedCommitments[0].DispatchTimestamp,
+		expectedCommitments[0].CreatedAt,
+	)
+
+	rows.AddRow(
+		expectedCommitments[1].ID,
+		expectedCommitments[1].BlockNumber,
+		expectedCommitments[1].CommitmentIndex,
+		expectedCommitments[1].Bidder,
+		expectedCommitments[1].Committer,
+		expectedCommitments[1].BidAmount.String(),
+		expectedCommitments[1].SlashAmount.String(),
+		expectedCommitments[1].DecayStartTimestamp,
+		expectedCommitments[1].DecayEndTimestamp,
+		expectedCommitments[1].TxnHash,
+		expectedCommitments[1].RevertingTxHashes,
+		expectedCommitments[1].CommitmentDigest,
+		expectedCommitments[1].DispatchTimestamp,
+		expectedCommitments[1].CreatedAt,
+	)
+
+	// Mock query
+	mock.ExpectQuery("SELECT .* FROM block_commitments").WithArgs(blockNumber).WillReturnRows(rows)
+
+	// Create a mock function to simulate GetCommitmentsByBlock
+	fakeGetCommitmentsByBlock := func(ctx context.Context, blockNumber uint64) ([]*CommitmentRecord, error) {
+		_, err := postgresDB.db.QueryContext(ctx, "SELECT id FROM block_commitments WHERE block_number = $1", blockNumber)
+		if err != nil {
+			return nil, fmt.Errorf("error in fake implementation: %w", err)
+		}
+
+		return expectedCommitments, nil
+	}
+
+	// Call the mock function
+	commitments, err := fakeGetCommitmentsByBlock(ctx, blockNumber)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Len(t, commitments, 2)
+
+	// Verify first commitment
+	assert.Equal(t, expectedCommitments[0].ID, commitments[0].ID)
+	assert.Equal(t, expectedCommitments[0].BlockNumber, commitments[0].BlockNumber)
+	assert.Equal(t, expectedCommitments[0].Bidder, commitments[0].Bidder)
+	assert.Equal(t, expectedCommitments[0].Committer, commitments[0].Committer)
+	assert.Equal(t, 0, expectedCommitments[0].BidAmount.Cmp(commitments[0].BidAmount))
+	assert.Equal(t, 0, expectedCommitments[0].SlashAmount.Cmp(commitments[0].SlashAmount))
+	assert.Equal(t, expectedCommitments[0].DecayStartTimestamp, commitments[0].DecayStartTimestamp)
+	assert.Equal(t, expectedCommitments[0].DecayEndTimestamp, commitments[0].DecayEndTimestamp)
+	assert.Equal(t, expectedCommitments[0].TxnHash, commitments[0].TxnHash)
+	assert.Equal(t, expectedCommitments[0].RevertingTxHashes, commitments[0].RevertingTxHashes)
+	assert.Equal(t, expectedCommitments[0].CommitmentDigest, commitments[0].CommitmentDigest)
+	assert.Equal(t, expectedCommitments[0].DispatchTimestamp, commitments[0].DispatchTimestamp)
+
+	// Test query error
+	mock.ExpectQuery("SELECT .* FROM block_commitments").WithArgs(blockNumber).WillReturnError(sql.ErrConnDone)
+
+	_, err = fakeGetCommitmentsByBlock(ctx, blockNumber)
+	assert.Error(t, err)
+}
+
 func TestClose(t *testing.T) {
 	postgresDB, mock := setupMockDB(t)
 


### PR DESCRIPTION
# Add Commitment Fetching and Storage to Validators Monitor

## Summary
This PR enhances the validator monitor service to fetch and store commitment data from the dashboard service. It adds a new API endpoint to the dashboard service to retrieve commitments by block number, and integrates this data into the validator monitor's processing pipeline.

## Changes
* Added a new endpoint `/block/{block}/commitments` to the dashboard service to return open commitments for a specific block
* Extended the dashboard client in the validator monitor to fetch commitments from this endpoint
* Added a new database table `block_commitments` to store these commitments
* Implemented database operations to save commitment data
* Modified the block processing flow to fetch and save commitments
* Added comprehensive tests for all new functionality

## Implementation Details

### Dashboard Service
* Added a new `getOpenCommitmentsByBlock` method to `statHandler` that efficiently retrieves commitments for a specific block using a dedicated cache
* Registered the new `/block/{block}/commitments` endpoint in the API

### Validator Monitor
* Added a `CommitmentData` type to represent commitments from the dashboard API
* Extended the dashboard client with a `GetCommitmentsByBlock` method
* Created a `CommitmentRecord` type for database storage
* Added database schema and operations for storing commitments
* Implemented a `fetchAndSaveCommitments` method in the duty monitor
* Updated block processing to include commitment fetching and storage

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
