### PR TITLE
fix: points service get-all endpoint

### DIFF
--- a/tools/points-service/api.go
+++ b/tools/points-service/api.go
@@ -439,7 +439,7 @@ func (p *PointsAPI) GetAllPoints(w http.ResponseWriter, r *http.Request) {
 	//nolint:errcheck
 	defer rows.Close()
 
-	var result []map[string]interface{}
+	result := make([]map[string]interface{}, 0)
 	for rows.Next() {
 		var operatorAddr, vaultAddr string
 		if scanErr := rows.Scan(&operatorAddr, &vaultAddr); scanErr != nil {

--- a/tools/points-service/api_test.go
+++ b/tools/points-service/api_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"database/sql"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetAllPointsNoResult(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory database: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close database: %v", err)
+		}
+	}()
+
+	if _, err := db.Exec(createTableValidatorRecordsQuery); err != nil {
+		t.Fatalf("failed to create validator_records table: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	api := PointsAPI{logger: logger, db: db}
+
+	req, err := http.NewRequest("GET", "all?block_number=21831800&limit=100&offset=900", nil)
+	if err != nil {
+		t.Fatalf("failed creating request: %v", err)
+	}
+	rr := httptest.NewRecorder()
+	api.GetAllPoints(rr, req)
+	bodyBytes, err := io.ReadAll(rr.Body)
+	if err != nil {
+		t.Fatalf("failed reading response body: %v", err)
+	}
+	expected := "[]\n"
+	if string(bodyBytes) != expected {
+		t.Errorf("expected response to be %q, got %q", expected, string(bodyBytes))
+	}
+}


### PR DESCRIPTION
## Describe your changes

The points service's `all` endpoint now returns an empty array when requested pagination doesn't correspond to any DB rows, instead of returning "null". 

## Issue 

Fixes request from symbiotic team

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
