### PR TITLE
chore: rm pauseable init change

### DIFF
--- a/contracts/contracts/validator-registry/VanillaRegistry.sol
+++ b/contracts/contracts/validator-registry/VanillaRegistry.sol
@@ -46,7 +46,6 @@ contract VanillaRegistry is IVanillaRegistry, VanillaRegistryStorage,
         uint256 _slashingPayoutPeriodBlocks,
         address _owner
     ) external initializer {
-        __Pausable_init();
         _setMinStake(_minStake);
         _setSlashOracle(_slashOracle);
         _setUnstakePeriodBlocks(_unstakePeriodBlocks);


### PR DESCRIPTION
https://github.com/primev/mev-commit/pull/584 introduced a change to the vanilla registry without following proper guidelines for contract upgrades. That change is reverted in this PR and will be included in a proper contract upgrade PR
