### PR TITLE
fix: bidder log

### DIFF
--- a/p2p/pkg/preconfirmation/tracker/tracker.go
+++ b/p2p/pkg/preconfirmation/tracker/tracker.go
@@ -533,10 +533,11 @@ func (t *Tracker) openCommitments(
 				continue
 			}
 		}
-		if common.BytesToAddress(commitment.ProviderAddress).Cmp(newL1Block.Winner) != 0 {
-			t.logger.Debug(
+		providerAddress := common.BytesToAddress(commitment.ProviderAddress)
+		if providerAddress.Cmp(newL1Block.Winner) != 0 {
+			t.logger.Error(
 				"provider address does not match the winner",
-				"providerAddress", commitment.ProviderAddress,
+				"providerAddress", providerAddress,
 				"winner", newL1Block.Winner,
 			)
 			continue


### PR DESCRIPTION
## Describe your changes

To avoid silent failures the "provider address does not match the winner" log should be of Error severity. It should also print `commitment.ProviderAddress` properly as hex string

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
