### PR TITLE
fix: improvements to pricing strategy

### DIFF
--- a/tools/preconf-rpc/blocktracker/blocktracker.go
+++ b/tools/preconf-rpc/blocktracker/blocktracker.go
@@ -63,7 +63,7 @@ func (b *blockTracker) Start(ctx context.Context) <-chan struct{} {
 					}
 					_ = b.blocks.Add(blockNo, block)
 					b.latestBlockNo.Store(block.NumberU64())
-					b.log.Info("New block detected", "number", block.NumberU64(), "hash", block.Hash().Hex())
+					b.log.Debug("New block detected", "number", block.NumberU64(), "hash", block.Hash().Hex())
 					b.triggerCheck()
 				}
 			}

--- a/tools/preconf-rpc/handlers/handlers.go
+++ b/tools/preconf-rpc/handlers/handlers.go
@@ -192,11 +192,11 @@ func (h *rpcMethodHandler) RegisterMethods(server *rpcserver.JSONRPCServer) {
 
 func getNextBlockPrice(blockPrices *pricer.BlockPrices) *big.Int {
 	for _, price := range blockPrices.Prices {
-		if price.BlockNumber == blockPrices.CurrentBlockNumber {
+		if price.BlockNumber == blockPrices.CurrentBlockNumber+1 {
 			for _, estimate := range price.EstimatedPrices {
 				if estimate.Confidence == 99 {
-					priceInWei := estimate.PriorityFeePerGasGwei * 1e9                                     // Convert Gwei to Wei
-					return new(big.Int).Mul(new(big.Int).SetUint64(uint64(priceInWei)), big.NewInt(21000)) // Estimate for a standard transaction
+					priceInWei := estimate.PriorityFeePerGasGwei * 1e9
+					return new(big.Int).Mul(new(big.Int).SetUint64(uint64(priceInWei)), big.NewInt(21000))
 				}
 			}
 		}

--- a/tools/preconf-rpc/handlers/handlers.go
+++ b/tools/preconf-rpc/handlers/handlers.go
@@ -22,7 +22,7 @@ type Bidder interface {
 }
 
 type Pricer interface {
-	EstimatePrice(ctx context.Context, txn *types.Transaction) (*pricer.BlockPrice, error)
+	EstimatePrice(ctx context.Context) (*pricer.BlockPrices, error)
 }
 
 type Store interface {
@@ -136,10 +136,7 @@ func (h *rpcMethodHandler) RegisterMethods(server *rpcserver.JSONRPCServer) {
 		return json.RawMessage(fmt.Sprintf(`{"timeInSecs": "%d"}`, timeToOptIn)), false, nil
 	})
 	server.RegisterHandler("mevcommit_estimateDeposit", func(ctx context.Context, params ...any) (json.RawMessage, bool, error) {
-		blockPrice, err := h.pricer.EstimatePrice(
-			ctx,
-			types.NewTransaction(0, h.depositAddress, big.NewInt(0), 21000, big.NewInt(0), nil),
-		)
+		blockPrices, err := h.pricer.EstimatePrice(ctx)
 		if err != nil {
 			h.logger.Error("Failed to estimate deposit price", "error", err)
 			return nil, false, rpcserver.NewJSONErr(
@@ -147,15 +144,9 @@ func (h *rpcMethodHandler) RegisterMethods(server *rpcserver.JSONRPCServer) {
 				"failed to estimate deposit price",
 			)
 		}
-		if blockPrice == nil {
-			h.logger.Warn("No block price estimated for deposit")
-			return nil, false, rpcserver.NewJSONErr(
-				rpcserver.CodeCustomError,
-				"no block price available for deposit",
-			)
-		}
+		cost := getNextBlockPrice(blockPrices)
 		result := map[string]interface{}{
-			"bidAmount":      blockPrice.BidAmount.String(),
+			"bidAmount":      cost.String(),
 			"depositAddress": h.depositAddress.Hex(),
 		}
 
@@ -167,14 +158,11 @@ func (h *rpcMethodHandler) RegisterMethods(server *rpcserver.JSONRPCServer) {
 				"failed to marshal deposit estimate",
 			)
 		}
-		h.logger.Debug("Estimated deposit price", "bidAmount", blockPrice.BidAmount, "depositAddress", h.depositAddress.Hex())
+		h.logger.Debug("Estimated deposit price", "bidAmount", cost, "depositAddress", h.depositAddress.Hex())
 		return resultJSON, false, nil
 	})
 	server.RegisterHandler("mevcommit_estimateBridge", func(ctx context.Context, params ...any) (json.RawMessage, bool, error) {
-		blockPrice, err := h.pricer.EstimatePrice(
-			ctx,
-			types.NewTransaction(0, h.bridgeAddress, big.NewInt(0), 21000, big.NewInt(0), nil),
-		)
+		blockPrices, err := h.pricer.EstimatePrice(ctx)
 		if err != nil {
 			h.logger.Error("Failed to estimate bridge price", "error", err)
 			return nil, false, rpcserver.NewJSONErr(
@@ -182,11 +170,8 @@ func (h *rpcMethodHandler) RegisterMethods(server *rpcserver.JSONRPCServer) {
 				"failed to estimate bridge price",
 			)
 		}
-		if blockPrice == nil {
-			h.logger.Warn("No block price estimated for bridge")
-			return nil, true, nil // No price available, proxy
-		}
-		bridgeCost := new(big.Int).Mul(blockPrice.BidAmount, big.NewInt(2))
+		cost := getNextBlockPrice(blockPrices)
+		bridgeCost := new(big.Int).Mul(cost, big.NewInt(2))
 		result := map[string]interface{}{
 			"bidAmount":     bridgeCost.String(),
 			"bridgeAddress": h.bridgeAddress.Hex(),
@@ -200,9 +185,24 @@ func (h *rpcMethodHandler) RegisterMethods(server *rpcserver.JSONRPCServer) {
 				"failed to marshal bridge estimate",
 			)
 		}
-		h.logger.Debug("Estimated bridge price", "bidAmount", blockPrice.BidAmount, "bridgeAddress", h.bridgeAddress.Hex())
+		h.logger.Debug("Estimated bridge price", "bidAmount", bridgeCost, "bridgeAddress", h.bridgeAddress.Hex())
 		return resultJSON, false, nil
 	})
+}
+
+func getNextBlockPrice(blockPrices *pricer.BlockPrices) *big.Int {
+	for _, price := range blockPrices.Prices {
+		if price.BlockNumber == blockPrices.CurrentBlockNumber {
+			for _, estimate := range price.EstimatedPrices {
+				if estimate.Confidence == 99 {
+					priceInWei := estimate.PriorityFeePerGasGwei * 1e9                                     // Convert Gwei to Wei
+					return new(big.Int).Mul(new(big.Int).SetUint64(uint64(priceInWei)), big.NewInt(21000)) // Estimate for a standard transaction
+				}
+			}
+		}
+	}
+
+	return big.NewInt(0) // Return zero if no suitable estimate is found
 }
 
 func (h *rpcMethodHandler) handleGetBlockByHash(

--- a/tools/preconf-rpc/main.go
+++ b/tools/preconf-rpc/main.go
@@ -177,11 +177,10 @@ var (
 	}
 
 	optionBlocknativeAPIKey = &cli.StringFlag{
-		Name:     "blocknative-api-key",
-		Usage:    "Blocknative API key for transaction pricing",
-		EnvVars:  []string{"PRECONF_RPC_BLOCKNATIVE_API_KEY"},
-		Value:    "",
-		Required: true,
+		Name:    "blocknative-api-key",
+		Usage:   "Blocknative API key for transaction pricing",
+		EnvVars: []string{"PRECONF_RPC_BLOCKNATIVE_API_KEY"},
+		Value:   "",
 	}
 
 	optionLogFmt = &cli.StringFlag{

--- a/tools/preconf-rpc/main.go
+++ b/tools/preconf-rpc/main.go
@@ -176,6 +176,14 @@ var (
 		},
 	}
 
+	optionBlocknativeAPIKey = &cli.StringFlag{
+		Name:     "blocknative-api-key",
+		Usage:    "Blocknative API key for transaction pricing",
+		EnvVars:  []string{"PRECONF_RPC_BLOCKNATIVE_API_KEY"},
+		Value:    "",
+		Required: true,
+	}
+
 	optionLogFmt = &cli.StringFlag{
 		Name:    "log-fmt",
 		Usage:   "log format to use, options are 'text' or 'json'",
@@ -246,6 +254,7 @@ func main() {
 			optionAutoDepositAmount,
 			optionDepositAddress,
 			optionBridgeAddress,
+			optionBlocknativeAPIKey,
 		},
 		Action: func(c *cli.Context) error {
 			logger, err := util.NewLogger(
@@ -316,6 +325,7 @@ func main() {
 				Signer:                 signer,
 				DepositAddress:         common.HexToAddress(c.String(optionDepositAddress.Name)),
 				BridgeAddress:          common.HexToAddress(c.String(optionBridgeAddress.Name)),
+				PricerAPIKey:           c.String(optionBlocknativeAPIKey.Name),
 			}
 
 			s, err := service.New(&config)

--- a/tools/preconf-rpc/pricer/pricer.go
+++ b/tools/preconf-rpc/pricer/pricer.go
@@ -22,6 +22,7 @@ type BlockPrice struct {
 }
 
 type BlockPrices struct {
+	MsSinceLastBlock   int64        `json:"msSinceLastBlock"`
 	CurrentBlockNumber int64        `json:"currentBlockNumber"`
 	Prices             []BlockPrice `json:"blockPrices"`
 }

--- a/tools/preconf-rpc/sender/sender.go
+++ b/tools/preconf-rpc/sender/sender.go
@@ -365,9 +365,9 @@ BID_LOOP:
 				"bidAmount", result.bidAmount.String(),
 			)
 			blockTimeUsed := time.Since(result.startTime).Milliseconds() + result.msSinceLastBlock
-			if blockTimeUsed < (blockTime*1000 - bidTimeout.Milliseconds()) {
+			if blockTimeUsed < (blockTime*1000 - 1000) {
 				// If not all builders committed, we will retry the bid process
-				// immediately if we have atleast 3 seconds left before the next block
+				// immediately if we have atleast 1 second left before the next block
 				continue
 			}
 		}

--- a/tools/preconf-rpc/sender/sender.go
+++ b/tools/preconf-rpc/sender/sender.go
@@ -37,8 +37,11 @@ const (
 )
 
 const (
-	blockTime  = 12              // seconds, typical Ethereum block time
-	bidTimeout = 3 * time.Second // timeout for bid operations
+	blockTime                    = 12              // seconds, typical Ethereum block time
+	bidTimeout                   = 3 * time.Second // timeout for bid operations
+	defaultConfidence            = 90              // default confidence level for the next block
+	confidenceSecondAttempt      = 95              // confidence level for the second attempt
+	confidenceSubsequentAttempts = 99              // confidence level for subsequent attempts
 )
 
 var (
@@ -588,21 +591,21 @@ func (t *TxSender) calculatePriceForNextBlock(txn *Transaction, prices *pricer.B
 	}
 
 	// default confidence level for the next block
-	confidence := 90
+	confidence := defaultConfidence
 
 	for _, attempt := range attempts.attempts {
 		if attempt.blockNumber == prices.CurrentBlockNumber+1 {
 			attempt.attempts++
 			switch {
 			case attempt.attempts == 2:
-				confidence = 95 // Increase confidence for the second attempt
+				confidence = confidenceSecondAttempt
 			case attempt.attempts > 2:
-				confidence = 99 // Max confidence for subsequent attempts
+				confidence = confidenceSubsequentAttempts
 			}
 		}
 	}
 	// If this is the first attempt for the next block, we add it with confidence 90
-	if confidence == 90 {
+	if confidence == defaultConfidence {
 		attempts.attempts = append(attempts.attempts, &blockAttempt{
 			blockNumber: prices.CurrentBlockNumber + 1,
 			attempts:    1,

--- a/tools/preconf-rpc/sender/sender.go
+++ b/tools/preconf-rpc/sender/sender.go
@@ -8,9 +8,11 @@ import (
 	"math/big"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	lru "github.com/hashicorp/golang-lru/v2"
 	bidderapiv1 "github.com/primev/mev-commit/p2p/gen/go/bidderapi/v1"
 	"github.com/primev/mev-commit/tools/preconf-rpc/pricer"
 	optinbidder "github.com/primev/mev-commit/x/opt-in-bidder"
@@ -35,7 +37,8 @@ const (
 )
 
 const (
-	blockTime = 12 // seconds, typical Ethereum block time
+	blockTime  = 12              // seconds, typical Ethereum block time
+	bidTimeout = 4 * time.Second // timeout for bid operations
 )
 
 var (
@@ -79,7 +82,7 @@ type Bidder interface {
 }
 
 type Pricer interface {
-	EstimatePrice(ctx context.Context, txn *types.Transaction) (*pricer.BlockPrice, error)
+	EstimatePrice(ctx context.Context) (*pricer.BlockPrices, error)
 }
 
 type BlockTracker interface {
@@ -88,6 +91,17 @@ type BlockTracker interface {
 
 type Transferer interface {
 	Transfer(ctx context.Context, to common.Address, chainID *big.Int, amount *big.Int) error
+}
+
+type blockAttempt struct {
+	blockNumber int64
+	attempts    int
+}
+
+type txnAttempt struct {
+	txnHash   common.Hash
+	startTime time.Time
+	attempts  []*blockAttempt
 }
 
 type TxSender struct {
@@ -105,6 +119,7 @@ type TxSender struct {
 	inflightTxns      map[common.Hash]struct{}
 	inflightAccount   map[common.Address]struct{}
 	inflightMu        sync.Mutex
+	txnAttemptHistory *lru.Cache[common.Hash, *txnAttempt]
 }
 
 func NewTxSender(
@@ -115,7 +130,13 @@ func NewTxSender(
 	transferer Transferer,
 	settlementChainId *big.Int,
 	logger *slog.Logger,
-) *TxSender {
+) (*TxSender, error) {
+	txnAttemptHistory, err := lru.New[common.Hash, *txnAttempt](1000)
+	if err != nil {
+		logger.Error("Failed to create transaction attempt history cache", "error", err)
+		return nil, fmt.Errorf("failed to create transaction attempt history cache: %w", err)
+	}
+
 	return &TxSender{
 		store:             st,
 		bidder:            bidder,
@@ -128,7 +149,8 @@ func NewTxSender(
 		trigger:           make(chan struct{}, 1),
 		inflightTxns:      make(map[common.Hash]struct{}),
 		inflightAccount:   make(map[common.Address]struct{}),
-	}
+		txnAttemptHistory: txnAttemptHistory,
+	}, nil
 }
 
 func validateTransaction(tx *Transaction) error {
@@ -309,6 +331,7 @@ BID_LOOP:
 					"blockNumber", result.blockNumber,
 					"bidAmount", result.bidAmount.String(),
 				)
+				t.clearBlockAttemptHistory(txn.Hash())
 				break BID_LOOP
 			}
 		default:
@@ -331,6 +354,7 @@ BID_LOOP:
 				"blockNumber", result.blockNumber,
 				"bidAmount", result.bidAmount.String(),
 			)
+			t.clearBlockAttemptHistory(txn.Hash())
 			break BID_LOOP
 		}
 	}
@@ -385,35 +409,42 @@ func (t *TxSender) sendBid(
 
 	optedInSlot := timeToOptIn <= blockTime
 
-	price, err := t.pricer.EstimatePrice(ctx, txn.Transaction)
+	prices, err := t.pricer.EstimatePrice(ctx)
 	if err != nil {
 		t.logger.Error("Failed to estimate transaction price", "error", err)
 		return bidResult{}, fmt.Errorf("failed to estimate transaction price: %w", err)
 	}
 
+	cost, blockNo, err := t.calculatePriceForNextBlock(txn, prices)
+	if err != nil {
+		t.logger.Error("Failed to calculate price for next block", "error", err)
+		return bidResult{}, fmt.Errorf("failed to calculate price: %w", err)
+	}
+
+	slashAmount := big.NewInt(0)
 	switch txn.Type {
 	case TxTypeRegular:
-		if !t.store.HasBalance(ctx, txn.Sender, price.BidAmount) {
+		if !t.store.HasBalance(ctx, txn.Sender, cost) {
 			t.logger.Error("Insufficient balance for sender", "sender", txn.Sender.Hex())
 			return bidResult{}, fmt.Errorf("insufficient balance for sender: %s", txn.Sender.Hex())
 		}
 	case TxTypeDeposit:
-		if txn.Value().Cmp(price.BidAmount) < 0 {
+		if txn.Value().Cmp(cost) < 0 {
 			t.logger.Error(
 				"Deposit amount is less than price of deposit",
 				"sender", txn.Sender.Hex(),
 				"deposit", txn.Value().String(),
-				"price", price.BidAmount.String(),
+				"price", cost.String(),
 			)
 			return bidResult{}, fmt.Errorf(
 				"deposit amount is less than price of deposit: %s, deposit: %s, price: %s",
 				txn.Sender.Hex(),
 				txn.Value().String(),
-				price.BidAmount.String(),
+				cost.String(),
 			)
 		}
 	case TxTypeInstantBridge:
-		costOfBridge := new(big.Int).Mul(price.BidAmount, big.NewInt(2)) // 2x the price for instant bridge
+		costOfBridge := new(big.Int).Mul(cost, big.NewInt(2)) // 2x the price for instant bridge
 		if txn.Value().Cmp(costOfBridge) < 0 {
 			t.logger.Error(
 				"Instant bridge amount is less than price of bridge",
@@ -428,17 +459,22 @@ func (t *TxSender) sendBid(
 				costOfBridge.String(),
 			)
 		}
+		slashAmount = new(big.Int).Set(txn.Value())
 	}
 
+	cctx, cancel := context.WithTimeout(ctx, bidTimeout)
+	defer cancel()
+
 	bidC, err := t.bidder.Bid(
-		ctx,
-		price.BidAmount,
-		big.NewInt(0),
+		cctx,
+		cost,
+		slashAmount,
 		strings.TrimPrefix(txn.Raw, "0x"),
 		&optinbidder.BidOpts{
 			WaitForOptIn:      false,
-			BlockNumber:       uint64(price.BlockNumber),
+			BlockNumber:       uint64(blockNo),
 			RevertingTxHashes: []string{txn.Hash().Hex()},
+			DecayDuration:     bidTimeout,
 		},
 	)
 	if err != nil {
@@ -448,7 +484,7 @@ func (t *TxSender) sendBid(
 
 	result := bidResult{
 		commitments: make([]*bidderapiv1.Commitment, 0),
-		bidAmount:   price.BidAmount,
+		bidAmount:   cost,
 	}
 BID_LOOP:
 	for {
@@ -487,4 +523,86 @@ BID_LOOP:
 
 	result.optedInSlot = optedInSlot
 	return result, nil
+}
+
+func (t *TxSender) calculatePriceForNextBlock(txn *Transaction, prices *pricer.BlockPrices) (*big.Int, int64, error) {
+	attempts, found := t.txnAttemptHistory.Get(txn.Hash())
+	if !found {
+		attempts = &txnAttempt{
+			txnHash:   txn.Hash(),
+			startTime: time.Now(),
+		}
+	}
+
+	// default confidence level for the next block
+	confidence := 90
+
+	for _, attempt := range attempts.attempts {
+		if attempt.blockNumber == prices.CurrentBlockNumber+1 {
+			attempt.attempts++
+			switch {
+			case attempt.attempts == 2:
+				confidence = 95 // Increase confidence for the second attempt
+			case attempt.attempts > 2:
+				confidence = 99 // Max confidence for subsequent attempts
+			}
+		}
+	}
+	// If this is the first attempt for the next block, we add it with confidence 90
+	if confidence == 90 {
+		attempts.attempts = append(attempts.attempts, &blockAttempt{
+			blockNumber: prices.CurrentBlockNumber + 1,
+			attempts:    1,
+		})
+	}
+
+	_ = t.txnAttemptHistory.Add(txn.Hash(), attempts)
+
+	var (
+		cost    *big.Int
+		blockNo int64
+	)
+
+	for _, price := range prices.Prices {
+		if price.BlockNumber == prices.CurrentBlockNumber+1 {
+			for _, estimatedPrice := range price.EstimatedPrices {
+				if estimatedPrice.Confidence == confidence {
+					priceWei := new(big.Int).Mul(big.NewInt(int64(estimatedPrice.PriorityFeePerGasGwei)), big.NewInt(1e9))
+					cost = new(big.Int).Mul(priceWei, big.NewInt(int64(txn.Gas())))
+					blockNo = price.BlockNumber
+					break
+				}
+			}
+		}
+	}
+	if cost == nil || blockNo == 0 {
+		return nil, 0, fmt.Errorf(
+			"no estimated price found for block %d with confidence %d", prices.CurrentBlockNumber+1, confidence,
+		)
+	}
+
+	return cost, blockNo, nil
+}
+
+func (t *TxSender) clearBlockAttemptHistory(txnHash common.Hash) {
+	attempts, found := t.txnAttemptHistory.Get(txnHash)
+	if !found {
+		return
+	}
+
+	totalAttempts := 0
+	for _, attempt := range attempts.attempts {
+		totalAttempts += attempt.attempts
+	}
+
+	t.logger.Info(
+		"Clearing block attempt history for transaction",
+		"hash", txnHash.Hex(),
+		"blockAttempts", len(attempts.attempts),
+		"startTime", attempts.startTime.Format(time.RFC3339),
+		"startBlockNumber", attempts.attempts[0].blockNumber,
+		"totalAttempts", totalAttempts,
+	)
+
+	_ = t.txnAttemptHistory.Remove(txnHash)
 }

--- a/tools/preconf-rpc/sender/sender_test.go
+++ b/tools/preconf-rpc/sender/sender_test.go
@@ -270,7 +270,7 @@ func TestSender(t *testing.T) {
 		Raw:    "0x1234567890123456789012345678901234567890",
 	}
 
-	if err := st.AddBalance(ctx, tx1.Sender, big.NewInt(1000)); err != nil {
+	if err := st.AddBalance(ctx, tx1.Sender, big.NewInt(5e18)); err != nil {
 		t.Fatalf("failed to add balance: %v", err)
 	}
 
@@ -359,7 +359,7 @@ func TestSender(t *testing.T) {
 		Transaction: types.NewTransaction(
 			2,
 			common.HexToAddress("0x1234567890123456789012345678901234567890"),
-			big.NewInt(1000),
+			big.NewInt(1e18),
 			21000,
 			big.NewInt(1),
 			nil,


### PR DESCRIPTION
## Describe your changes
This PR fixes some of the issues found in the initial testing of the RPC. It also improves the pricing strategy based on history.

- Bid timeout
  It was observed that providers can simply not respond to the bid. The default timeout on the bidder node is 30s. We can reduce this but its better to control this ourselves.
- Pricing strategy
  Previously we were always using the max confidence value of the blocknative API. Now we switch to an approach where we start with the 90% confidence and move up to 99 on the third attempt.
- Use Block native API with API Key
## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
