### PR TITLE
fix: tuning bidding logic

### DIFF
--- a/tools/preconf-rpc/sender/sender.go
+++ b/tools/preconf-rpc/sender/sender.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"math/big"
 	"strings"
 	"sync"
@@ -522,7 +523,7 @@ func (t *TxSender) sendBid(
 	}
 
 	start := time.Now()
-	optedInSlot := timeToOptIn <= blockTime-(prices.MsSinceLastBlock/1000)
+	optedInSlot := math.Abs(float64(timeToOptIn)-float64(blockTime-(prices.MsSinceLastBlock/1000))) < float64(blockTime/2)
 
 	cctx, cancel := context.WithTimeout(ctx, bidTimeout)
 	defer cancel()

--- a/tools/preconf-rpc/sender/sender.go
+++ b/tools/preconf-rpc/sender/sender.go
@@ -512,14 +512,7 @@ func (t *TxSender) sendBid(
 		timeToOptIn = blockTime * 32
 	}
 
-	optedInSlot := timeToOptIn <= blockTime
-
-	start := time.Now()
-
-	cctx, cancel := context.WithTimeout(ctx, bidTimeout)
-	defer cancel()
-
-	prices, err := t.pricer.EstimatePrice(cctx)
+	prices, err := t.pricer.EstimatePrice(ctx)
 	if err != nil {
 		t.logger.Error("Failed to estimate transaction price", "error", err)
 		return bidResult{}, &errRetry{
@@ -528,7 +521,13 @@ func (t *TxSender) sendBid(
 		}
 	}
 
-	cost, blockNo, err := t.calculatePriceForNextBlock(txn, prices)
+	start := time.Now()
+	optedInSlot := timeToOptIn <= blockTime-(prices.MsSinceLastBlock/1000)
+
+	cctx, cancel := context.WithTimeout(ctx, bidTimeout)
+	defer cancel()
+
+	cost, blockNo, err := t.calculatePriceForNextBlock(txn, prices, optedInSlot)
 	if err != nil {
 		t.logger.Error("Failed to calculate price for next block", "error", err)
 		return bidResult{}, &errRetry{
@@ -587,7 +586,7 @@ func (t *TxSender) sendBid(
 			WaitForOptIn:      false,
 			BlockNumber:       uint64(blockNo),
 			RevertingTxHashes: []string{txn.Hash().Hex()},
-			DecayDuration:     bidTimeout,
+			DecayDuration:     bidTimeout * 2,
 		},
 	)
 	if err != nil {
@@ -640,7 +639,11 @@ BID_LOOP:
 	return result, nil
 }
 
-func (t *TxSender) calculatePriceForNextBlock(txn *Transaction, prices *pricer.BlockPrices) (*big.Int, int64, error) {
+func (t *TxSender) calculatePriceForNextBlock(
+	txn *Transaction,
+	prices *pricer.BlockPrices,
+	optedInSlot bool,
+) (*big.Int, int64, error) {
 	attempts, found := t.txnAttemptHistory.Get(txn.Hash())
 	if !found {
 		attempts = &txnAttempt{
@@ -651,9 +654,11 @@ func (t *TxSender) calculatePriceForNextBlock(txn *Transaction, prices *pricer.B
 
 	// default confidence level for the next block
 	confidence := defaultConfidence
+	isRetry := false
 
 	for _, attempt := range attempts.attempts {
 		if attempt.blockNumber == prices.CurrentBlockNumber+1 {
+			isRetry = true
 			attempt.attempts++
 			switch {
 			case attempt.attempts == 2:
@@ -663,8 +668,13 @@ func (t *TxSender) calculatePriceForNextBlock(txn *Transaction, prices *pricer.B
 			}
 		}
 	}
-	// If this is the first attempt for the next block, we add it with confidence 90
-	if confidence == defaultConfidence {
+
+	if optedInSlot {
+		confidence = confidenceSubsequentAttempts
+	}
+
+	// If this is the first attempt for the next block, we add it to the history
+	if !isRetry {
 		attempts.attempts = append(attempts.attempts, &blockAttempt{
 			blockNumber: prices.CurrentBlockNumber + 1,
 			attempts:    1,

--- a/tools/preconf-rpc/sender/sender_test.go
+++ b/tools/preconf-rpc/sender/sender_test.go
@@ -552,7 +552,7 @@ func TestCancelTransaction(t *testing.T) {
 	st := newMockStore()
 	testPricer := &mockPricer{
 		out:    make(chan *pricer.BlockPrices, 10),
-		errOut: make(chan error, 1),
+		errOut: make(chan error, 3),
 	}
 	bidder := &mockBidder{
 		optinEstimate: make(chan int64),
@@ -603,7 +603,9 @@ func TestCancelTransaction(t *testing.T) {
 		t.Fatalf("failed to enqueue transaction: %v", err)
 	}
 
-	bidder.optinEstimate <- 18
+	testPricer.errOut <- errors.New("simulated error for testing")
+	testPricer.errOut <- errors.New("simulated error for testing")
+	bidder.optinEstimate <- 2
 
 	cancelled, err := sndr.CancelTransaction(ctx, tx1.Hash())
 	if err != nil {

--- a/tools/preconf-rpc/sender/sender_test.go
+++ b/tools/preconf-rpc/sender/sender_test.go
@@ -313,7 +313,7 @@ func TestSender(t *testing.T) {
 	// simulate error and ensure retry happens
 	testPricer.errOut <- errors.New("simulated error for testing")
 
-	bidder.optinEstimate <- 1
+	bidder.optinEstimate <- 7
 
 	// Simulate a price estimate
 	testPricer.out <- &pricer.BlockPrices{

--- a/x/opt-in-bidder/bidder.go
+++ b/x/opt-in-bidder/bidder.go
@@ -274,7 +274,7 @@ func (b *BidderClient) Bid(
 			Amount:              bidAmount.String(),
 			BlockNumber:         int64(blkNumber),
 			RawTransactions:     []string{rawTx},
-			DecayStartTimestamp: nowFunc().Add(100 * time.Millisecond).UnixMilli(),
+			DecayStartTimestamp: nowFunc().Add(200 * time.Millisecond).UnixMilli(),
 			SlashAmount:         slashAmount.String(),
 			RevertingTxHashes:   opts.RevertingTxHashes,
 		}


### PR DESCRIPTION
## Describe your changes
This is a small fix to estimate the opt in slot correctly. Previously we were not considering the time since the last block in the estimate.

Also in the bidder, we have increased the decay start timestamp delay to 200ms. This is more generous and gives providers some leeway to avoid decay. Also increased the decay time to twice the timeout. Which would make the bid decay atmost to half of its value if provider takes the entire timeout duration to respond. This is still crude but need to give more thought on pricing. Especially since we also need to consider clients which are setting the priority fee on their own.


## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
