### PR TITLE
fix: event handling for points service

### DIFF
--- a/tools/points-service/main.go
+++ b/tools/points-service/main.go
@@ -777,15 +777,15 @@ func main() {
 					},
 				),
 				events.NewEventHandler(
-					"ValRecordDeleted",
-					func(ev *middleware.MevcommitmiddlewareValRecordDeleted) {
+					"ValidatorDeregistrationRequested",
+					func(ev *middleware.MevcommitmiddlewareValidatorDeregistrationRequested) {
 						pubkey := common.Bytes2Hex(ev.BlsPubkey)
 						adder, err := getMsgSenderFromTxnHash(ethClient, ev.Raw.TxHash)
 						if err != nil {
 							logger.Error("failed to get msg sender", "error", err)
 							return
 						}
-						insertOptOut(db, logger, pubkey, adder.Hex(), "ValRecordDeleted", ev.Raw.BlockNumber)
+						insertOptOut(db, logger, pubkey, adder.Hex(), "ValidatorDeregistrationRequested", ev.Raw.BlockNumber)
 					},
 				),
 				events.NewEventHandler(


### PR DESCRIPTION
Points service currently checks `MevCommitMiddleware.ValRecordDeleted` event twice, and wasn't checking `MevCommitMiddleware.ValidatorDeregistrationRequested. This PR fixes the issue and properly monitors both events