### PR TITLE
chore: bump forge-std

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "contracts/lib/openzeppelin-foundry-upgrades"]
 	path = contracts/lib/openzeppelin-foundry-upgrades
 	url = https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades
-[submodule "contracts/lib/forge-std"]
-	path = contracts/lib/forge-std
-	url = https://github.com/foundry-rs/forge-std
 [submodule "contracts/lib/eigenlayer-contracts"]
 	path = contracts/lib/eigenlayer-contracts
 	url = https://github.com/Layr-Labs/eigenlayer-contracts.git
@@ -25,3 +22,6 @@
 [submodule "contracts/lib/burners"]
 	path = contracts/lib/burners
 	url = https://github.com/symbioticfi/burners
+[submodule "contracts/lib/forge-std"]
+	path = contracts/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std


### PR DESCRIPTION
Bumps our https://github.com/foundry-rs/forge-std solidity dependency to latest release https://github.com/foundry-rs/forge-std/releases/tag/v1.10.0. This enables eip-7702 related cheatcodes for future prs, ex: https://getfoundry.sh/reference/cheatcodes/sign-delegation/
