### PR TITLE
feat: validate el timestamp

### DIFF
--- a/cl/blockbuilder/blockbuilder.go
+++ b/cl/blockbuilder/blockbuilder.go
@@ -544,6 +544,13 @@ func (bb *BlockBuilder) loadExecutionHead(ctx context.Context) (*types.Execution
 		return nil, fmt.Errorf("failed to get the latest block header: %w", err)
 	}
 
+	if !IsTimestampInUnixMilli(header.Time) {
+		return nil, fmt.Errorf(
+			"invalid header.Time from EL: %d, must be in unix milliseconds",
+			header.Time,
+		)
+	}
+
 	bb.executionHead = &types.ExecutionHead{
 		BlockHeight: header.Number.Uint64(),
 		BlockHash:   header.Hash().Bytes(),
@@ -569,4 +576,11 @@ func (bb *BlockBuilder) GetMempoolStatus(ctx context.Context) (*MempoolStatus, e
 		return nil, err
 	}
 	return &result, nil
+}
+
+func IsTimestampInUnixMilli(timestamp uint64) bool {
+	const oneYear = time.Duration(365 * 24 * time.Hour)
+	lowerBound := uint64(time.Now().Add(-10 * oneYear).UnixMilli())
+	upperBound := uint64(time.Now().Add(10 * oneYear).UnixMilli())
+	return timestamp > lowerBound && timestamp < upperBound
 }

--- a/cl/blockbuilder/blockbuilder_test.go
+++ b/cl/blockbuilder/blockbuilder_test.go
@@ -652,3 +652,22 @@ func matchPayloadAttributes(expectedHash common.Hash, executionHeadTime uint64) 
 		return true
 	}
 }
+
+func TestIsTimestampInUnixMilli(t *testing.T) {
+	var nineYears = time.Duration(9 * 365 * 24 * time.Hour)
+	assert.True(t, IsTimestampInUnixMilli(uint64(time.Now().UnixMilli())))
+	assert.True(t, IsTimestampInUnixMilli(uint64(time.Now().Add(-nineYears).UnixMilli())))
+	assert.True(t, IsTimestampInUnixMilli(uint64(time.Now().Add(nineYears).UnixMilli())))
+
+	assert.False(t, IsTimestampInUnixMilli(uint64(time.Now().Unix())))
+	assert.False(t, IsTimestampInUnixMilli(uint64(time.Now().Add(-nineYears).Unix())))
+	assert.False(t, IsTimestampInUnixMilli(uint64(time.Now().Add(nineYears).Unix())))
+
+	assert.False(t, IsTimestampInUnixMilli(uint64(time.Now().UnixMicro())))
+	assert.False(t, IsTimestampInUnixMilli(uint64(time.Now().Add(nineYears).UnixMicro())))
+	assert.False(t, IsTimestampInUnixMilli(uint64(time.Now().Add(-nineYears).UnixMicro())))
+
+	assert.False(t, IsTimestampInUnixMilli(uint64(time.Now().UnixNano())))
+	assert.False(t, IsTimestampInUnixMilli(uint64(time.Now().Add(nineYears).UnixNano())))
+	assert.False(t, IsTimestampInUnixMilli(uint64(time.Now().Add(-nineYears).UnixNano())))
+}


### PR DESCRIPTION
Validates the `header.Time` from the EL is in unix milliseconds, within bounds of +- 10 years from now
