### PR TITLE
feat: simplify single node cl implementation 

### DIFF
--- a/cl/blockbuilder/blockbuilder.go
+++ b/cl/blockbuilder/blockbuilder.go
@@ -55,10 +55,7 @@ type BlockBuilder struct {
 	buildDelay            time.Duration
 	buildEmptyBlocksDelay time.Duration
 	feeRecipient          common.Address
-	// Execution head of the previous block.
-	// This field should only be set upon restart in setExecutionHeadFromRPC,
-	// OR at the end of FinalizeBlock.
-	executionHead *types.ExecutionHead
+	executionHead         *types.ExecutionHead
 }
 
 func NewBlockBuilder(

--- a/cl/blockbuilder/blockbuilder.go
+++ b/cl/blockbuilder/blockbuilder.go
@@ -138,12 +138,10 @@ func (bb *BlockBuilder) GetPayload(ctx context.Context) error {
 		bb.logger.Debug("executionHead is not nil, using cached value")
 	}
 
-	beforeMempoolStatus := time.Now()
 	mempoolStatus, err := bb.GetMempoolStatus(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get pending transaction count: %w", err)
 	}
-	bb.logger.Debug("GetMempoolStatus rpc duration", "duration", time.Since(beforeMempoolStatus))
 
 	lastBlockTime := time.UnixMilli(int64(bb.executionHead.BlockTime))
 	bb.logger.Debug("lastBlockTime from execution head", "lastBlockTime", lastBlockTime)

--- a/cl/blockbuilder/blockbuilder.go
+++ b/cl/blockbuilder/blockbuilder.go
@@ -54,7 +54,6 @@ type BlockBuilder struct {
 	logger                *slog.Logger
 	buildDelay            time.Duration
 	buildEmptyBlocksDelay time.Duration
-	buildDelayMs          uint64
 	feeRecipient          common.Address
 	// Execution head of the previous block.
 	// This field should only be set upon restart in setExecutionHeadFromRPC,
@@ -76,7 +75,6 @@ func NewBlockBuilder(
 		engineCl:              engineCl,
 		logger:                logger,
 		buildDelay:            buildDelay,
-		buildDelayMs:          uint64(buildDelay.Milliseconds()),
 		buildEmptyBlocksDelay: buildDelayEmptyBlocks,
 		feeRecipient:          common.HexToAddress(feeReceipt),
 		rpcClient:             rpcClient,

--- a/cl/blockbuilder/blockbuilder.go
+++ b/cl/blockbuilder/blockbuilder.go
@@ -55,9 +55,11 @@ type BlockBuilder struct {
 	buildDelay            time.Duration
 	buildEmptyBlocksDelay time.Duration
 	buildDelayMs          uint64
-	lastBlockTime         time.Time
 	feeRecipient          common.Address
-	executionHead         *types.ExecutionHead
+	// Execution head of the previous block.
+	// This field should only be set upon restart in setExecutionHeadFromRPC,
+	// OR at the end of FinalizeBlock.
+	executionHead *types.ExecutionHead
 }
 
 func NewBlockBuilder(
@@ -77,7 +79,6 @@ func NewBlockBuilder(
 		buildDelayMs:          uint64(buildDelay.Milliseconds()),
 		buildEmptyBlocksDelay: buildDelayEmptyBlocks,
 		feeRecipient:          common.HexToAddress(feeReceipt),
-		lastBlockTime:         time.Now().Add(-buildDelayEmptyBlocks),
 		rpcClient:             rpcClient,
 	}
 }
@@ -89,12 +90,8 @@ func NewMemberBlockBuilder(engineCL EngineClient, logger *slog.Logger) *BlockBui
 	}
 }
 
-func (bb *BlockBuilder) SetLastCallTimeToZero() {
-	bb.lastBlockTime = time.Time{}
-}
-
-func (bb *BlockBuilder) startBuild(ctx context.Context, head *types.ExecutionHead, ts uint64) (engine.ForkChoiceResponse, error) {
-	hash := common.BytesToHash(head.BlockHash)
+func (bb *BlockBuilder) startBuild(ctx context.Context, ts uint64) (engine.ForkChoiceResponse, error) {
+	hash := common.BytesToHash(bb.executionHead.BlockHash)
 
 	fcs := engine.ForkchoiceStateV1{
 		HeadBlockHash:      hash,
@@ -123,19 +120,41 @@ func (bb *BlockBuilder) startBuild(ctx context.Context, head *types.ExecutionHea
 func (bb *BlockBuilder) GetPayload(ctx context.Context) error {
 	var (
 		payloadID *engine.PayloadID
-		head      *types.ExecutionHead
 		err       error
 	)
-	currentCallTime := time.Now()
 
+	if bb.executionHead == nil {
+		bb.logger.Debug("executionHead is nil, it'll be set by RPC. CL is likely being restarted")
+		err = util.RetryWithBackoff(ctx, maxAttempts, bb.logger, func() error {
+			innerErr := bb.setExecutionHeadFromRPC(ctx)
+			if innerErr != nil {
+				bb.logger.Warn(
+					"Failed to set execution head from rpc, retrying...",
+					"error", innerErr,
+				)
+				return innerErr // Will retry
+			}
+			return nil // Success
+		})
+		if err != nil {
+			return fmt.Errorf("failed to set execution head from rpc: %w", err)
+		}
+	} else {
+		bb.logger.Debug("executionHead is not nil, using cached value")
+	}
+
+	beforeMempoolStatus := time.Now()
 	mempoolStatus, err := bb.GetMempoolStatus(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get pending transaction count: %w", err)
 	}
-	bb.logger.Debug("GetMempoolStatus rpc duration", "duration", time.Since(currentCallTime))
+	bb.logger.Debug("GetMempoolStatus rpc duration", "duration", time.Since(beforeMempoolStatus))
+
+	lastBlockTime := time.UnixMilli(int64(bb.executionHead.BlockTime))
+	bb.logger.Debug("lastBlockTime from execution head", "lastBlockTime", lastBlockTime)
 
 	if mempoolStatus.Pending == 0 {
-		timeSinceLastBlock := currentCallTime.Sub(bb.lastBlockTime)
+		timeSinceLastBlock := time.Since(lastBlockTime)
 		if timeSinceLastBlock < bb.buildEmptyBlocksDelay {
 			bb.logger.Debug(
 				"Leader: Skipping empty block",
@@ -153,50 +172,18 @@ func (bb *BlockBuilder) GetPayload(ctx context.Context) error {
 		)
 	}
 
-	// Load execution head to get previous block timestamp
-	err = util.RetryWithBackoff(ctx, maxAttempts, bb.logger, func() error {
-		head, err = bb.loadExecutionHead(ctx)
-		if err != nil {
-			bb.logger.Warn(
-				"Failed to load execution head, retrying...",
-				"error", err,
-			)
-			return err // Will retry
-		}
-		return nil // Success
-	})
-	if err != nil {
-		return fmt.Errorf("latest execution block: %w", err)
-	}
-
-	prevTimestamp := head.BlockTime
-
-	var ts uint64
-
-	if bb.lastBlockTime.IsZero() {
-		// First block, initialize LastCallTime and set default timestamp
-		ts = uint64(time.Now().UnixMilli()) + bb.buildDelayMs
-	} else {
-		// Compute diff in milliseconds
-		diff := currentCallTime.Sub(bb.lastBlockTime)
-		diffMillis := diff.Milliseconds()
-
-		if uint64(diffMillis) <= bb.buildDelayMs {
-			ts = prevTimestamp + bb.buildDelayMs
-		} else {
-			// For every multiple of buildDelay that diff exceeds, increment the block time by that multiple.
-			multiples := (uint64(diffMillis) + bb.buildDelayMs - 1) / bb.buildDelayMs // Round up to next multiple of buildDelay
-			ts = prevTimestamp + multiples*bb.buildDelayMs
-		}
-	}
-
-	// Very low chance to happen, only after restart and time.Now is broken
-	if ts <= head.BlockTime {
-		ts = head.BlockTime + 1 // Subsequent blocks must have a higher timestamp.
+	ts := uint64(time.Now().UnixMilli())
+	if ts <= bb.executionHead.BlockTime {
+		bb.logger.Warn("Leader: Current timestamp is less than or equal to the previous block timestamp",
+			"current_ts", ts,
+			"prev_head_block_time", bb.executionHead.BlockTime,
+		)
+		ts = bb.executionHead.BlockTime + 1
+		time.Sleep(time.Until(time.UnixMilli(int64(ts))))
 	}
 
 	err = util.RetryWithBackoff(ctx, maxAttempts, bb.logger, func() error {
-		response, err := bb.startBuild(ctx, head, ts)
+		response, err := bb.startBuild(ctx, ts)
 		if err != nil {
 			bb.logger.Warn(
 				"Failed to build new EVM payload, will retry",
@@ -275,8 +262,6 @@ func (bb *BlockBuilder) GetPayload(ctx context.Context) error {
 		"Leader: BuildBlock completed and block is distributed",
 		"PayloadID", payloadIDStr,
 	)
-
-	bb.lastBlockTime = time.Now()
 	return nil
 }
 
@@ -418,30 +403,13 @@ func (bb *BlockBuilder) FinalizeBlock(ctx context.Context, payloadIDStr, executi
 		return fmt.Errorf("failed to deserialize ExecutionPayload: %w", err)
 	}
 
-	var head *types.ExecutionHead
-	err = util.RetryWithBackoff(ctx, maxAttempts, bb.logger, func() error {
-		head, err = bb.loadExecutionHead(ctx)
-		if err != nil {
-			bb.logger.Warn(
-				"Failed to load execution head, retrying...",
-				"error", err,
-			)
-			return err // Will retry
-		}
-		return nil // Success
-	})
-	if err != nil {
-		return fmt.Errorf("failed to load execution head: %w", err)
-	}
-
-	if err := bb.validateExecutionPayload(executionPayload, head); err != nil {
+	if err := bb.validateExecutionPayload(executionPayload); err != nil {
 		return fmt.Errorf("failed to validate execution payload: %w", err)
 	}
 
-	hash := common.BytesToHash(head.BlockHash)
 	retryFunc := bb.selectRetryFunction(ctx, msgID)
 
-	if err := bb.pushNewPayload(ctx, executionPayload, hash, retryFunc); err != nil {
+	if err := bb.pushNewPayload(ctx, executionPayload, retryFunc); err != nil {
 		return fmt.Errorf("failed to push new payload: %w", err)
 	}
 
@@ -464,20 +432,20 @@ func (bb *BlockBuilder) FinalizeBlock(ctx context.Context, payloadIDStr, executi
 	return nil
 }
 
-func (bb *BlockBuilder) validateExecutionPayload(executionPayload engine.ExecutableData, head *types.ExecutionHead) error {
-	if executionPayload.Number != head.BlockHeight+1 {
-		return fmt.Errorf("invalid block height: %d, expected: %d", executionPayload.Number, head.BlockHeight+1)
+func (bb *BlockBuilder) validateExecutionPayload(executionPayload engine.ExecutableData) error {
+	if executionPayload.Number != bb.executionHead.BlockHeight+1 {
+		return fmt.Errorf("invalid block height: %d, expected: %d", executionPayload.Number, bb.executionHead.BlockHeight+1)
 	}
-	if executionPayload.ParentHash != common.Hash(head.BlockHash) {
-		return fmt.Errorf("invalid parent hash: %s, head: %s", executionPayload.ParentHash, head.BlockHash)
+	if executionPayload.ParentHash != common.Hash(bb.executionHead.BlockHash) {
+		return fmt.Errorf("invalid parent hash: %s, head: %s", executionPayload.ParentHash, bb.executionHead.BlockHash)
 	}
-	minTimestamp := head.BlockTime + 1
+	minTimestamp := bb.executionHead.BlockTime + 1
 	if executionPayload.Timestamp < minTimestamp && executionPayload.Number != 1 {
 		return fmt.Errorf("invalid timestamp: %d, min: %d", executionPayload.Timestamp, minTimestamp)
 	}
-	hash := common.BytesToHash(head.BlockHash)
+	hash := common.BytesToHash(bb.executionHead.BlockHash)
 	if executionPayload.Random != hash {
-		return fmt.Errorf("invalid random: %s, head: %s", executionPayload.Random, head.BlockHash)
+		return fmt.Errorf("invalid random: %s, head: %s", executionPayload.Random, bb.executionHead.BlockHash)
 	}
 	return nil
 }
@@ -493,10 +461,11 @@ func (bb *BlockBuilder) selectRetryFunction(ctx context.Context, msgID string) f
 	}
 }
 
-func (bb *BlockBuilder) pushNewPayload(ctx context.Context, executionPayload engine.ExecutableData, hash common.Hash, retryFunc func(f func() error) error) error {
+func (bb *BlockBuilder) pushNewPayload(ctx context.Context, executionPayload engine.ExecutableData, retryFunc func(f func() error) error) error {
 	emptyVersionHashes := []common.Hash{}
+	parentHash := common.BytesToHash(bb.executionHead.BlockHash)
 	return retryFunc(func() error {
-		status, err := bb.engineCl.NewPayloadV4(ctx, executionPayload, emptyVersionHashes, &hash, []hexutil.Bytes{})
+		status, err := bb.engineCl.NewPayloadV4(ctx, executionPayload, emptyVersionHashes, &parentHash, []hexutil.Bytes{})
 		bb.logger.Debug("newPayload result",
 			"status", status.Status,
 			"validationError", status.ValidationError,
@@ -534,23 +503,17 @@ func (bb *BlockBuilder) updateForkChoice(ctx context.Context, fcs engine.Forkcho
 	})
 }
 
-func (bb *BlockBuilder) loadExecutionHead(ctx context.Context) (*types.ExecutionHead, error) {
-	if bb.executionHead != nil {
-		return bb.executionHead, nil
-	}
-
+func (bb *BlockBuilder) setExecutionHeadFromRPC(ctx context.Context) error {
 	header, err := bb.engineCl.HeaderByNumber(ctx, nil) // nil for the latest block
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the latest block header: %w", err)
+		return fmt.Errorf("failed to get the latest block header: %w", err)
 	}
-
 	bb.executionHead = &types.ExecutionHead{
 		BlockHeight: header.Number.Uint64(),
 		BlockHash:   header.Hash().Bytes(),
 		BlockTime:   header.Time,
 	}
-
-	return bb.executionHead, nil
+	return nil
 }
 
 func (bb *BlockBuilder) GetExecutionHead() *types.ExecutionHead {

--- a/cl/blockbuilder/blockbuilder.go
+++ b/cl/blockbuilder/blockbuilder.go
@@ -122,7 +122,7 @@ func (bb *BlockBuilder) GetPayload(ctx context.Context) error {
 	)
 
 	if bb.executionHead == nil {
-		bb.logger.Debug("executionHead is nil, it'll be set by RPC. CL is likely being restarted")
+		bb.logger.Info("executionHead is nil, it'll be set by RPC. CL is likely being restarted")
 		err = util.RetryWithBackoff(ctx, maxAttempts, bb.logger, func() error {
 			innerErr := bb.setExecutionHeadFromRPC(ctx)
 			if innerErr != nil {
@@ -172,7 +172,8 @@ func (bb *BlockBuilder) GetPayload(ctx context.Context) error {
 
 	ts := uint64(time.Now().UnixMilli())
 	if ts <= bb.executionHead.BlockTime {
-		bb.logger.Warn("Leader: Current timestamp is less than or equal to the previous block timestamp",
+		bb.logger.Warn(`Leader: Current timestamp is less than or equal to
+			previous block timestamp. Genesis timestamp could have been set incorrectly`,
 			"current_ts", ts,
 			"prev_head_block_time", bb.executionHead.BlockTime,
 		)

--- a/cl/blockbuilder/blockbuilder_test.go
+++ b/cl/blockbuilder/blockbuilder_test.go
@@ -116,6 +116,8 @@ func TestBlockBuilder_startBuild(t *testing.T) {
 	}
 	mockEngineClient.On("ForkchoiceUpdatedV3", mock.Anything, expectedFCS, mock.MatchedBy(matchPayloadAttributes(hash, executionHead.BlockTime))).Return(forkChoiceResponse, nil)
 
+	blockBuilder.executionHead = executionHead
+
 	resp, err := blockBuilder.startBuild(ctx, uint64(timestamp.UnixMilli()))
 
 	require.NoError(t, err)
@@ -323,6 +325,8 @@ func TestBlockBuilder_startBuild_ForkchoiceUpdatedError(t *testing.T) {
 
 	mockEngineClient.On("ForkchoiceUpdatedV3", mock.Anything, expectedFCS, mock.MatchedBy(matchPayloadAttributes(hash, executionHead.BlockTime))).Return(engine.ForkChoiceResponse{}, errors.New("engine error"))
 
+	blockBuilder.executionHead = executionHead
+
 	resp, err := blockBuilder.startBuild(ctx, uint64(timestamp.UnixMilli()))
 
 	require.Error(t, err)
@@ -372,6 +376,8 @@ func TestBlockBuilder_startBuild_InvalidPayloadStatus(t *testing.T) {
 		PayloadID: nil,
 	}
 	mockEngineClient.On("ForkchoiceUpdatedV3", mock.Anything, expectedFCS, mock.MatchedBy(matchPayloadAttributes(hash, executionHead.BlockTime))).Return(forkChoiceResponse, nil)
+
+	blockBuilder.executionHead = executionHead
 
 	resp, err := blockBuilder.startBuild(ctx, uint64(timestamp.UnixMilli()))
 

--- a/cl/blockbuilder/blockbuilder_test.go
+++ b/cl/blockbuilder/blockbuilder_test.go
@@ -117,7 +117,7 @@ func TestBlockBuilder_startBuild(t *testing.T) {
 	}
 	mockEngineClient.On("ForkchoiceUpdatedV3", mock.Anything, expectedFCS, mock.MatchedBy(matchPayloadAttributes(hash, executionHead.BlockTime))).Return(forkChoiceResponse, nil)
 
-	resp, err := blockBuilder.startBuild(ctx, executionHead, uint64(timestamp.UnixMilli()))
+	resp, err := blockBuilder.startBuild(ctx, uint64(timestamp.UnixMilli()))
 
 	require.NoError(t, err)
 	assert.Equal(t, forkChoiceResponse, resp)
@@ -327,7 +327,7 @@ func TestBlockBuilder_startBuild_ForkchoiceUpdatedError(t *testing.T) {
 
 	mockEngineClient.On("ForkchoiceUpdatedV3", mock.Anything, expectedFCS, mock.MatchedBy(matchPayloadAttributes(hash, executionHead.BlockTime))).Return(engine.ForkChoiceResponse{}, errors.New("engine error"))
 
-	resp, err := blockBuilder.startBuild(ctx, executionHead, uint64(timestamp.UnixMilli()))
+	resp, err := blockBuilder.startBuild(ctx, uint64(timestamp.UnixMilli()))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forkchoice update")
@@ -378,7 +378,7 @@ func TestBlockBuilder_startBuild_InvalidPayloadStatus(t *testing.T) {
 	}
 	mockEngineClient.On("ForkchoiceUpdatedV3", mock.Anything, expectedFCS, mock.MatchedBy(matchPayloadAttributes(hash, executionHead.BlockTime))).Return(forkChoiceResponse, nil)
 
-	resp, err := blockBuilder.startBuild(ctx, executionHead, uint64(timestamp.UnixMilli()))
+	resp, err := blockBuilder.startBuild(ctx, uint64(timestamp.UnixMilli()))
 
 	require.NoError(t, err)
 	assert.Equal(t, forkChoiceResponse, resp)

--- a/cl/blockbuilder/blockbuilder_test.go
+++ b/cl/blockbuilder/blockbuilder_test.go
@@ -97,7 +97,6 @@ func TestBlockBuilder_startBuild(t *testing.T) {
 		engineCl:     mockEngineClient,
 		rpcClient:    createMockRPCClient(),
 		buildDelay:   buildDelay,
-		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 	}
 	timestamp := time.Now()
@@ -162,7 +161,6 @@ func TestBlockBuilder_getPayload(t *testing.T) {
 		engineCl:     mockEngineClient,
 		rpcClient:    createMockRPCClient(),
 		buildDelay:   buildDelay,
-		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 	}
 
@@ -229,7 +227,6 @@ func TestBlockBuilder_FinalizeBlock(t *testing.T) {
 		engineCl:     mockEngineClient,
 		rpcClient:    createMockRPCClient(),
 		buildDelay:   buildDelay,
-		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 	}
 
@@ -312,7 +309,6 @@ func TestBlockBuilder_startBuild_ForkchoiceUpdatedError(t *testing.T) {
 		engineCl:     mockEngineClient,
 		rpcClient:    createMockRPCClient(),
 		buildDelay:   buildDelay,
-		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 	}
 
@@ -357,7 +353,6 @@ func TestBlockBuilder_startBuild_InvalidPayloadStatus(t *testing.T) {
 		engineCl:     mockEngineClient,
 		rpcClient:    createMockRPCClient(),
 		buildDelay:   buildDelay,
-		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 	}
 
@@ -459,7 +454,6 @@ func TestBlockBuilder_FinalizeBlock_InvalidBlockHeight(t *testing.T) {
 		engineCl:     mockEngineClient,
 		rpcClient:    createMockRPCClient(),
 		buildDelay:   buildDelay,
-		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 	}
 
@@ -515,7 +509,6 @@ func TestBlockBuilder_FinalizeBlock_NewPayloadInvalidStatus(t *testing.T) {
 		engineCl:     mockEngineClient,
 		rpcClient:    createMockRPCClient(),
 		buildDelay:   buildDelay,
-		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 	}
 
@@ -576,7 +569,6 @@ func TestBlockBuilder_FinalizeBlock_ForkchoiceUpdatedInvalidStatus(t *testing.T)
 		engineCl:     mockEngineClient,
 		rpcClient:    createMockRPCClient(),
 		buildDelay:   buildDelay,
-		buildDelayMs: uint64(buildDelay.Milliseconds()),
 		logger:       stLog,
 	}
 

--- a/cl/redisapp/leaderfollower/leaderfollower.go
+++ b/cl/redisapp/leaderfollower/leaderfollower.go
@@ -263,7 +263,6 @@ func (lfm *LeaderFollowerManager) leaderWork(ctx context.Context) error {
 					lfm.logger.Error("Leader: failed to reach geth node after max attempts, exiting")
 					stopElecErr := lfm.leaderProc.Stop()
 					// todo: refactor to generate timestamp outside blockbuilder
-					lfm.blockBuilder.SetLastCallTimeToZero()
 					if stopElecErr != nil {
 						lfm.logger.Error(
 							"Leader: Failed to stop leader election",

--- a/cl/redisapp/leaderfollower/leaderfollower.go
+++ b/cl/redisapp/leaderfollower/leaderfollower.go
@@ -39,9 +39,6 @@ type blockBuilder interface {
 
 	// Processes any unfinished payload from a previous session
 	ProcessLastPayload(ctx context.Context) error
-
-	// Sets the last call time to zero
-	SetLastCallTimeToZero()
 }
 
 // todo: work with block state through block builder, not directly


### PR DESCRIPTION
The current implementation of our consensus layer is exhibiting odd behavior where recently built block timestamps will jump up to 20 minutes ahead of system time. This PR streamlines implementation, removes unnecessary variables, and makes the logic easier to comprehend/debug. After testing, these changes have fixed the issue. 

* `bb.lastBlockTime` variable was being set independently from `bb.executionHead.BlockTime`. We now use existing `bb.executionHead.BlockTime` in-place
* `head` variable local to `GetPayload` was being set independently from `bb.executionHead`. We now use existing `bb.executionHead` in-place
* `loadExecutionHead` was removed. We now just set `bb.executionHead` once upon service restart in `setExecutionHeadFromRPC` and subsequently update `bb.executionHead` at the end of every `FinalizeBlock`
* Block timestamp computation was simplified
* `bb.buildDelayMs` removed, `bb.buildDelay` remains
