### PR TITLE
Lido registry hoodi

### DIFF
--- a/contracts/contracts/validator-registry/lido/LidoV3Middleware.sol
+++ b/contracts/contracts/validator-registry/lido/LidoV3Middleware.sol
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: BSL 1.1
+pragma solidity 0.8.26;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+import {LidoV3MiddlewareStorage} from "./LidoV3MiddlewareStorage.sol";
+import {TimestampOccurrence} from "../../utils/Occurrence.sol";
+
+interface IVaultHub {
+    function isVaultConnected(address vault) external view returns (bool);
+    function totalValue(address vault) external view returns (uint256);
+}
+
+interface IStakingVault {
+    function nodeOperator() external view returns (address);
+}
+
+contract LidoV3Middleware is
+    Initializable,
+    Ownable2StepUpgradeable,
+    ReentrancyGuardUpgradeable,
+    UUPSUpgradeable,
+    LidoV3MiddlewareStorage
+{
+    // ---- Constants ----
+    uint256 private constant BLS_PUBKEY_LEN = 48;
+
+    // ---- Events ----
+    event VaultHubUpdated(address indexed newHub);
+    event WhitelistUpdated(address indexed operator, bool allowed);
+    event SlashAmountUpdated(uint256 newSlashAmount);
+    event UnfreezeFeeUpdated(uint256 newUnfreezeFee);
+    event UnfreezeReceiverUpdated(address indexed newReceiver);
+    event UnfreezePeriodUpdated(uint256 newPeriod);
+    event DeregistrationPeriodUpdated(uint256 newPeriod);
+
+    event ValidatorRegistered(bytes indexed pubkey, address indexed registrar, address indexed vault);
+    event ValidatorDeregistrationRequested(bytes indexed pubkey, address indexed registrar);
+    event ValidatorDeregistered(bytes indexed pubkey, address indexed deregistrar);
+    event ValidatorFrozen(bytes indexed pubkey, address indexed freezer);
+    event ValidatorUnfrozen(bytes indexed pubkey, address indexed unfreezer);
+
+    // ---- Errors ----
+    error ZeroAddress();
+    error NotWhitelisted();
+    error InvalidVault();
+    error HubDoesNotOwnVault();
+    error NodeOperatorMismatch(address expected, address actual);
+    error CapacityExceeded(uint256 want, uint256 have);
+    error InvalidBLSPubKeyLength(uint256 expected, uint256 actual);
+    error ValidatorAlreadyRegistered(bytes pubkey);
+    error ValidatorNotRegistered(bytes pubkey);
+    error ValidatorAlreadyRequestedDeregistration(bytes pubkey);
+    error ValidatorNotFrozen(bytes pubkey);
+    error UnfreezeTooSoon();
+    error UnfreezeFeeRequired(uint256 requiredFee);
+    error TransferFailed();
+
+    // ---- Initializer ----
+    /**
+     * @param _owner            initial owner (Ownable2StepUpgradeable)
+     * @param _vaultHub         canonical VaultHub (Hoodi: 0x26b92f0fdfeBAf43E5Ea5b5974EeBee95F17Fe08)
+     * @param _unfreezeReceiver receiver of unfreeze fees (can be owner same as _owner)
+     * @param _deregPeriod      seconds from request to allow deregistration
+     * @param _unfreezePeriod   seconds after freeze until unfreeze is permitted
+     */
+    function initialize(
+        address _owner,
+        address _vaultHub,
+        address _unfreezeReceiver,
+        uint256 _deregPeriod,
+        uint256 _unfreezePeriod,
+        uint256 _slashAmount,
+        uint256 _unfreezeFee
+    ) external initializer {
+        if (_owner == address(0) || _vaultHub == address(0) || _unfreezeReceiver == address(0)) revert ZeroAddress();
+
+        __Ownable_init(_owner);
+        __Ownable2Step_init();
+        __ReentrancyGuard_init();
+        __UUPSUpgradeable_init();
+
+        vaultHub = _vaultHub;
+        slashAmount = _slashAmount;
+        unfreezeFee = _unfreezeFee;
+        unfreezeReceiver = _unfreezeReceiver;
+        deregistrationPeriod = _deregPeriod;
+        unfreezePeriod = _unfreezePeriod;
+
+        emit VaultHubUpdated(_vaultHub);
+        emit SlashAmountUpdated(slashAmount);
+        emit UnfreezeFeeUpdated(unfreezeFee);
+        emit UnfreezeReceiverUpdated(_unfreezeReceiver);
+        emit DeregistrationPeriodUpdated(_deregPeriod);
+        emit UnfreezePeriodUpdated(_unfreezePeriod);
+    }
+
+    // ---- Setters ----
+
+    function setVaultHub(address newHub) external onlyOwner {
+        if (newHub == address(0)) revert ZeroAddress();
+        vaultHub = newHub;
+        emit VaultHubUpdated(newHub);
+    }
+
+    function setWhitelist(address operator, bool allowed) external onlyOwner {
+        if (operator == address(0)) revert ZeroAddress();
+        isWhitelisted[operator] = allowed;
+        emit WhitelistUpdated(operator, allowed);
+    }
+
+    function setSlashAmount(uint256 newSlashAmount) external onlyOwner {
+        // allow zero? probably not, but testnet—you decide.
+        slashAmount = newSlashAmount;
+        emit SlashAmountUpdated(newSlashAmount);
+    }
+
+    function setUnfreezeFee(uint256 newFee) external onlyOwner {
+        unfreezeFee = newFee;
+        emit UnfreezeFeeUpdated(newFee);
+    }
+
+    function setUnfreezeReceiver(address newReceiver) external onlyOwner {
+        if (newReceiver == address(0)) revert ZeroAddress();
+        unfreezeReceiver = newReceiver;
+        emit UnfreezeReceiverUpdated(newReceiver);
+    }
+
+    function setUnfreezePeriod(uint256 newPeriod) external onlyOwner {
+        unfreezePeriod = newPeriod;
+        emit UnfreezePeriodUpdated(newPeriod);
+    }
+
+    function setDeregistrationPeriod(uint256 newPeriod) external onlyOwner {
+        deregistrationPeriod = newPeriod;
+        emit DeregistrationPeriodUpdated(newPeriod);
+    }
+
+    // ---- View ----
+
+    function isValidatorOptedIn(bytes calldata valBLSPubKey) external view returns (bool) {
+        return _isValidatorOptedIn(valBLSPubKey);
+    }
+
+    function maxRegistrableByVault(address vault) public view returns (uint256) {
+        // Capacity = floor( totalValue / slashAmount )
+        uint256 tv = IVaultHub(vaultHub).totalValue(vault);
+        if (slashAmount == 0) return 0; // avoid div by zero; owner should set non-zero
+        return tv / slashAmount;
+    }
+
+    function remainingRegistrable(address vault) public view returns (uint256) {
+        uint256 cap = maxRegistrableByVault(vault);
+        uint256 used = vaultRegisteredCount[vault];
+        return cap > used ? (cap - used) : 0;
+    }
+
+    // ---- Core logic ----
+
+    /**
+     * @notice Register validator BLS pubkeys for a specific Lido V3 vault.
+     *         - caller must be whitelisted
+     *         - vault must be connected to our configured VaultHub
+     *         - vault's nodeOperator() must equal msg.sender
+     *         - capacity check: (registered + new) <= floor(totalValue(vault) / slashAmount)
+     */
+    function registerValidators(address vault, bytes[] calldata blsPubKeys) external {
+        if (!isWhitelisted[msg.sender]) revert NotWhitelisted();
+        if (!_isValidVault(vault)) revert InvalidVault();
+
+        // Node operator must be the caller
+        address operator = IStakingVault(vault).nodeOperator();
+        if (operator != msg.sender) revert NodeOperatorMismatch(operator, msg.sender);
+
+        uint256 n = blsPubKeys.length;
+        if (n == 0) revert CapacityExceeded(0, remainingRegistrable(vault)); // keep a consistent revert
+
+        uint256 remaining = remainingRegistrable(vault);
+        if (n > remaining) revert CapacityExceeded(n, remaining);
+
+        for (uint256 i = 0; i < n; ++i) {
+            bytes calldata pk = blsPubKeys[i];
+            if (pk.length != BLS_PUBKEY_LEN) revert InvalidBLSPubKeyLength(BLS_PUBKEY_LEN, pk.length);
+            LidoV3MiddlewareStorage.ValidatorRecord storage r = validatorRecords[pk];
+            if (r.exists) revert ValidatorAlreadyRegistered(pk);
+
+            validatorRecords[pk] = LidoV3MiddlewareStorage.ValidatorRecord({
+                exists: true,
+                registrar: msg.sender,
+                freezeOccurrence: TimestampOccurrence.Occurrence({exists: false, timestamp: 0}),
+                deregRequestOccurrence: TimestampOccurrence.Occurrence({exists: false, timestamp: 0})
+            });
+
+            emit ValidatorRegistered(pk, msg.sender, vault);
+        }
+
+        // bump per-vault count
+        vaultRegisteredCount[vault] += n;
+    }
+
+    /**
+     * @notice Operators request deregistration. Completion can happen after `deregistrationPeriod`.
+     */
+    function requestDeregistrations(bytes[] calldata blsPubKeys) external {
+        if (!isWhitelisted[msg.sender]) revert NotWhitelisted();
+
+        uint256 n = blsPubKeys.length;
+        for (uint256 i = 0; i < n; ++i) {
+            bytes calldata pk = blsPubKeys[i];
+            if (pk.length != BLS_PUBKEY_LEN) revert InvalidBLSPubKeyLength(BLS_PUBKEY_LEN, pk.length);
+
+            LidoV3MiddlewareStorage.ValidatorRecord storage r = validatorRecords[pk];
+            if (!r.exists) revert ValidatorNotRegistered(pk);
+            // Optional: only the original registrar can request dereg
+            if (r.registrar != msg.sender) revert NotWhitelisted(); // reuse error to avoid extra bytecode
+
+            if (r.deregRequestOccurrence.exists) revert ValidatorAlreadyRequestedDeregistration(pk);
+            TimestampOccurrence.captureOccurrence(r.deregRequestOccurrence);
+
+            emit ValidatorDeregistrationRequested(pk, msg.sender);
+        }
+    }
+
+    /**
+     * @notice Complete deregistration after the delay. Only the original registrar can complete.
+     * @param vault The vault this batch was originally accounted toward (to reduce its count).
+     */
+    function deregisterValidators(address vault, bytes[] calldata blsPubKeys) external {
+        if (!isWhitelisted[msg.sender]) revert NotWhitelisted();
+
+        uint256 removed = 0;
+        uint256 n = blsPubKeys.length;
+
+        for (uint256 i = 0; i < n; ++i) {
+            bytes calldata pk = blsPubKeys[i];
+            if (pk.length != BLS_PUBKEY_LEN) revert InvalidBLSPubKeyLength(BLS_PUBKEY_LEN, pk.length);
+
+            LidoV3MiddlewareStorage.ValidatorRecord storage r = validatorRecords[pk];
+            if (!r.exists) revert ValidatorNotRegistered(pk);
+            if (r.registrar != msg.sender) revert NotWhitelisted();
+            if (!r.deregRequestOccurrence.exists) revert ValidatorAlreadyRequestedDeregistration(pk);
+            // Wait out the deregistration window
+            if (block.timestamp < r.deregRequestOccurrence.timestamp + deregistrationPeriod) revert UnfreezeTooSoon();
+
+            delete validatorRecords[pk];
+            unchecked { ++removed; }
+
+            emit ValidatorDeregistered(pk, msg.sender);
+        }
+
+        if (removed > 0) {
+            // reduce per-vault count (saturating)
+            uint256 prev = vaultRegisteredCount[vault];
+            vaultRegisteredCount[vault] = removed > prev ? 0 : (prev - removed);
+        }
+    }
+
+    // ---- Freeze / Unfreeze ----
+
+    function freezeValidators(bytes[] calldata blsPubKeys) external onlyOwner {
+        uint256 n = blsPubKeys.length;
+        for (uint256 i = 0; i < n; ++i) {
+            bytes calldata pk = blsPubKeys[i];
+            if (pk.length != BLS_PUBKEY_LEN) revert InvalidBLSPubKeyLength(BLS_PUBKEY_LEN, pk.length);
+
+            LidoV3MiddlewareStorage.ValidatorRecord storage r = validatorRecords[pk];
+            if (!r.exists) revert ValidatorNotRegistered(pk);
+
+            TimestampOccurrence.captureOccurrence(r.freezeOccurrence);
+            emit ValidatorFrozen(pk, msg.sender);
+        }
+    }
+
+    /**
+     * @notice Anyone can unfreeze for a fee, after `unfreezePeriod` from freeze time.
+     */
+    function unfreeze(bytes[] calldata blsPubKeys) external payable nonReentrant {
+        uint256 n = blsPubKeys.length;
+        uint256 required = unfreezeFee * n;
+        if (msg.value < required) revert UnfreezeFeeRequired(required);
+
+        for (uint256 i = 0; i < n; ++i) {
+            bytes calldata pk = blsPubKeys[i];
+            if (pk.length != BLS_PUBKEY_LEN) revert InvalidBLSPubKeyLength(BLS_PUBKEY_LEN, pk.length);
+
+            LidoV3MiddlewareStorage.ValidatorRecord storage r = validatorRecords[pk];
+            if (!r.exists) revert ValidatorNotRegistered(pk);
+            if (!r.freezeOccurrence.exists) revert ValidatorNotFrozen(pk);
+            if (block.timestamp < r.freezeOccurrence.timestamp + unfreezePeriod) revert UnfreezeTooSoon();
+
+            TimestampOccurrence.del(r.freezeOccurrence);
+            emit ValidatorUnfrozen(pk, msg.sender);
+        }
+
+        if (required > 0) {
+            (bool ok1, ) = payable(unfreezeReceiver).call{value: required}("");
+            if (!ok1) revert TransferFailed();
+        }
+        // refund dust
+        uint256 excess = msg.value - required;
+        if (excess != 0) {
+            (bool ok2, ) = payable(msg.sender).call{value: excess}("");
+            if (!ok2) revert TransferFailed();
+        }
+    }
+
+    // ---- Internals ----
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    function _isValidVault(address vault) internal view returns (bool) {
+        // must be connected to our configured VaultHub
+        if (!IVaultHub(vaultHub).isVaultConnected(vault)) return false;
+        return true;
+    }
+
+    function _isValidatorOptedIn(bytes calldata pubkey) internal view returns (bool) {
+        LidoV3MiddlewareStorage.ValidatorRecord storage r = validatorRecords[pubkey];
+        return 
+            r.exists && 
+            isWhitelisted[r.registrar] &&
+            !r.freezeOccurrence.exists && 
+            !r.deregRequestOccurrence.exists;
+    }
+
+    // storage gap reserved in *storage* contract
+}

--- a/contracts/contracts/validator-registry/lido/LidoV3MiddlewareStorage.sol
+++ b/contracts/contracts/validator-registry/lido/LidoV3MiddlewareStorage.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSL 1.1
+pragma solidity 0.8.26;
+
+import {TimestampOccurrence} from "../../utils/Occurrence.sol";
+
+/**
+ * @dev Storage layout for LidoV3Middleware (upgrade-safe).
+ * Keep ordering and types stable across upgrades.
+ */
+abstract contract LidoV3MiddlewareStorage {
+    struct ValidatorRecord {
+        bool exists;
+        address registrar; // operator who registered this pubkey
+        TimestampOccurrence.Occurrence freezeOccurrence;
+        TimestampOccurrence.Occurrence deregRequestOccurrence;
+    }
+
+    // --- Config ---
+    address public vaultHub;              // canonical VaultHub to verify connections
+    uint256 public slashAmount;           // denominator for capacity (ETH / slashAmount)
+    uint256 public unfreezeFee;           // fee per validator to unfreeze
+    address public unfreezeReceiver;      // where unfreeze fees go
+    uint256 public unfreezePeriod;        // min seconds from freeze until unfreeze allowed
+    uint256 public deregistrationPeriod;  // min seconds from request until deregister allowed
+
+    // --- Operator gating ---
+    mapping(address => bool) public isWhitelisted; // whitelisted operators
+
+    // mapping(pubkey -> record). Keys must be 48-byte BLS pubkeys.
+    mapping(bytes => ValidatorRecord) public validatorRecords;
+    // How many validators each vault has registered here
+    mapping(address vault => uint256) public vaultRegisteredCount;
+
+    // --- Storage gap for upgrades ---
+    uint256[48] private __gap;
+}

--- a/contracts/l1-deployer-cli.sh
+++ b/contracts/l1-deployer-cli.sh
@@ -261,15 +261,15 @@ get_chain_params() {
 }
 
 check_git_status() {
-    # if ! current_tag=$(git describe --tags --exact-match 2>/dev/null); then
-    #     echo "Error: Current commit is not tagged. Please ensure the commit is tagged before deploying."
-    #     exit 1
-    # fi
+    if ! current_tag=$(git describe --tags --exact-match 2>/dev/null); then
+        echo "Error: Current commit is not tagged. Please ensure the commit is tagged before deploying."
+        exit 1
+    fi
 
-    # if [[ -n "$(git status --porcelain)" ]]; then
-    #     echo "Error: There are uncommitted changes. Please commit or stash them before deploying."
-    #     exit 1
-    # fi
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "Error: There are uncommitted changes. Please commit or stash them before deploying."
+        exit 1
+    fi
 
     if [[ "$skip_release_verification_flag" != true ]]; then
         releases_url="https://api.github.com/repos/primev/mev-commit/releases?per_page=100"

--- a/contracts/scripts/validator-registry/lido/DeployLidoMiddleware.s.sol
+++ b/contracts/scripts/validator-registry/lido/DeployLidoMiddleware.s.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BSL 1.1
+
+// solhint-disable no-console
+// solhint-disable one-contract-per-file
+
+pragma solidity 0.8.26;
+
+import {Script} from "forge-std/Script.sol";
+import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {console} from "forge-std/console.sol";
+
+// Update the import path to wherever you placed the contract
+import {LidoV3Middleware} from "../../../contracts/validator-registry/lido/LidoV3Middleware.sol";
+
+contract BaseDeploy is Script {
+    function deployLidoMiddleware(
+        address owner,
+        address vaultHub,
+        address unfreezeReceiver,
+        uint256 deregistrationPeriodBlocks,
+        uint256 unfreezePeriodBlocks,
+        uint256 slashAmountWei,
+        uint256 unfreezeFeeWei
+    ) public returns (address) {
+        console.log("Deploying LidoV3Middleware (UUPS) on chain:", block.chainid);
+        address proxy = Upgrades.deployUUPSProxy(
+            "LidoV3Middleware.sol:LidoV3Middleware",
+            abi.encodeCall(
+                LidoV3Middleware.initialize,
+                (
+                    owner,
+                    vaultHub,
+                    unfreezeReceiver,
+                    deregistrationPeriodBlocks,
+                    unfreezePeriodBlocks,
+                    slashAmountWei,
+                    unfreezeFeeWei
+                )
+            )
+        );
+
+        console.log("LidoV3Middleware UUPS proxy deployed to:", proxy);
+        LidoV3Middleware mw = LidoV3Middleware(payable(proxy));
+        console.log("LidoV3Middleware owner:", mw.owner());
+        console.log("LidoV3Middleware vaultHub:", mw.vaultHub());
+        console.log("LidoV3Middleware slashAmount:", mw.slashAmount());
+        console.log("LidoV3Middleware unfreezeFee:", mw.unfreezeFee());
+        console.log("LidoV3Middleware deregistrationPeriod:", mw.deregistrationPeriod());
+        console.log("LidoV3Middleware unfreezePeriod:", mw.unfreezePeriod());
+
+        return proxy;
+    }
+}
+
+contract DeployHoodi is BaseDeploy {
+    // ---- fixed params for this env ----
+    address constant public OWNER             = 0x1623fE21185c92BB43bD83741E226288B516134a;
+    address constant public UNFREEZE_RECEIVER = 0x1623fE21185c92BB43bD83741E226288B516134a;
+    address constant public VAULT_HUB         = 0x26b92f0fdfeBAf43E5Ea5b5974EeBee95F17Fe08; // Hoodi VaultHub proxy
+
+    // periods in seconds
+    uint256 constant public DEREGISTRATION_PERIOD = 600;
+    uint256 constant public UNFREEZE_PERIOD       = 600;
+
+    // low on hoodi for testing
+    uint256 constant public SLASH_AMOUNT_WEI = 10; // 10 wei
+    uint256 constant public UNFREEZE_FEE_WEI = 0;
+
+    function run() external {
+        require(block.chainid == 560048, "must deploy on Hoodi");
+
+        vm.startBroadcast();
+        deployLidoMiddleware(
+            OWNER,
+            VAULT_HUB,
+            UNFREEZE_RECEIVER,
+            DEREGISTRATION_PERIOD,
+            UNFREEZE_PERIOD,
+            SLASH_AMOUNT_WEI,
+            UNFREEZE_FEE_WEI
+        );
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/test/validator-registry/lido/LidoV3MiddlewareTest.sol
+++ b/contracts/test/validator-registry/lido/LidoV3MiddlewareTest.sol
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {LidoV3Middleware} from "../../../contracts/validator-registry/lido/LidoV3Middleware.sol";
+import {MockVaultHub} from "./mocks/MockVaultHub.sol";
+import {MockStakingVault} from "./mocks/MockStakingVault.sol";
+
+contract LidoV3MiddlewareTest is Test {
+    // env constants
+    address constant OWNER             = 0x1623fE21185c92BB43bD83741E226288B516134a;
+    address constant UNFREEZE_RECEIVER = 0x1623fE21185c92BB43bD83741E226288B516134a;
+
+    // periods: seconds (per your correction)
+    uint256 constant DEREG_PERIOD     = 600;
+    uint256 constant UNFREEZE_PERIOD  = 600;
+
+    // econ
+    uint256 constant SLASH_AMOUNT_WEI = 10; // capacity = totalValue / 10 wei
+    uint256 constant UNFREEZE_FEE_WEI = 0;
+
+    // actors
+    address operator = address(0xa11ce);
+    address bob    = address(0xb0bb1);
+
+    // sut
+    MockVaultHub hub;
+    MockStakingVault stakingVault;
+    LidoV3Middleware mw;
+
+    address vaultAddr;
+    address hubAddr;
+
+    function setUp() public {
+        // deploy mocks
+        hub = new MockVaultHub();
+        hubAddr = address(hub);
+
+        stakingVault = new MockStakingVault(operator);
+        vaultAddr = address(stakingVault);
+
+        // deploy implementation
+        LidoV3Middleware impl = new LidoV3Middleware();
+
+        // initializer (note the two extra args: slashAmount, unfreezeFee)
+        bytes memory initData = abi.encodeWithSelector(
+            LidoV3Middleware.initialize.selector,
+            OWNER,
+            hubAddr,
+            UNFREEZE_RECEIVER,
+            DEREG_PERIOD,
+            UNFREEZE_PERIOD,
+            SLASH_AMOUNT_WEI,
+            UNFREEZE_FEE_WEI
+        );
+
+        // deploy proxy
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        mw = LidoV3Middleware(address(proxy));
+
+        // baseline: connected & large value
+        hub.setConnected(vaultAddr, true);
+        hub.setTotalValue(vaultAddr, 1_000_000 ether);
+
+        // whitelist operator
+        vm.prank(OWNER);
+        mw.setWhitelist(operator, true);
+    }
+
+    // helper to fabricate 48-byte “BLS pubkeys”
+    function _pk(bytes32 seed) internal pure returns (bytes memory pk) {
+        pk = new bytes(48);
+        assembly {
+            mstore(add(pk, 32), seed)
+            mstore(add(pk, 64), seed)
+        }
+    }
+
+    function _keys(uint256 n) internal pure returns (bytes[] memory arr) {
+        arr = new bytes[](n);
+        for (uint256 i = 0; i < n; ++i) {
+            arr[i] = _pk(bytes32(i + 1));
+        }
+    }
+
+    // -----------------------
+    // core tests
+    // -----------------------
+
+    function test_OwnerAndHubConfigured() public {
+        assertEq(mw.owner(), OWNER, "owner");
+        assertEq(mw.vaultHub(), hubAddr, "hub");
+        assertEq(mw.unfreezePeriod(), UNFREEZE_PERIOD);
+        assertEq(mw.deregistrationPeriod(), DEREG_PERIOD);
+        assertEq(mw.slashAmount(), SLASH_AMOUNT_WEI);
+        assertEq(mw.unfreezeFee(), UNFREEZE_FEE_WEI);
+    }
+
+    function test_WhitelistBlocksNonWhitelisted() public {
+        bytes[] memory keys = _keys(2);
+
+        vm.prank(bob);
+        vm.expectRevert(LidoV3Middleware.NotWhitelisted.selector);
+        mw.registerValidators(vaultAddr, keys);
+    }
+
+    function test_WhitelistedOperatorCanRegister() public {
+        bytes[] memory keys = _keys(2);
+
+        vm.prank(operator);
+        mw.registerValidators(vaultAddr, keys);
+
+        // both keys opted-in
+        assertTrue(mw.isValidatorOptedIn(keys[0]));
+        assertTrue(mw.isValidatorOptedIn(keys[1]));
+
+        // capacity still huge
+        assertGt(mw.remainingRegistrable(vaultAddr), 0);
+    }
+
+    function test_RevertIfVaultNotConnected() public {
+        hub.setConnected(vaultAddr, false);
+        bytes[] memory keys = _keys(1);
+
+        vm.prank(operator);
+        vm.expectRevert(LidoV3Middleware.InvalidVault.selector);
+        mw.registerValidators(vaultAddr, keys);
+    }
+
+    function test_RevertIfNodeOperatorMismatch() public {
+        stakingVault.setNodeOperator(address(0xDEAD));
+        bytes[] memory keys = _keys(1);
+
+        vm.prank(operator);
+        vm.expectRevert(abi.encodeWithSelector(LidoV3Middleware.NodeOperatorMismatch.selector, address(0xDEAD), operator));
+        mw.registerValidators(vaultAddr, keys);
+    }
+
+    function test_RevertIfCapacityExceeded() public {
+        // totalValue=15 wei, slash=10 wei -> floor(1.5)=1
+        hub.setTotalValue(vaultAddr, 15);
+
+        bytes[] memory two = _keys(2);
+        vm.prank(operator);
+        vm.expectRevert(abi.encodeWithSelector(LidoV3Middleware.CapacityExceeded.selector, 2, 1));
+        mw.registerValidators(vaultAddr, two);
+
+        bytes[] memory one = _keys(1);
+        vm.prank(operator);
+        mw.registerValidators(vaultAddr, one);
+        assertTrue(mw.isValidatorOptedIn(one[0]));
+    }
+
+    function test_InvalidBLSPubKeyLength() public {
+        bytes[] memory bad = _keys(1);
+        bad[0] = new bytes(47); // not 48 bytes
+
+        vm.prank(operator);
+        vm.expectRevert(abi.encodeWithSelector(LidoV3Middleware.InvalidBLSPubKeyLength.selector, 48, 47));
+        mw.registerValidators(vaultAddr, bad);
+    }
+
+    function test_FreezeAndUnfreeze() public {
+        // register 1 key
+        bytes[] memory one = _keys(1);
+        vm.prank(operator);
+        mw.registerValidators(vaultAddr, one);
+        assertTrue(mw.isValidatorOptedIn(one[0]));
+
+        // owner freezes → optedIn becomes false
+        vm.prank(OWNER);
+        mw.freezeValidators(one);
+        assertFalse(mw.isValidatorOptedIn(one[0]));
+
+        // set receiver to a plain EOA and fee = 1 wei
+        address recv = address(0xA11CE);
+        vm.prank(OWNER);
+        mw.setUnfreezeReceiver(recv);
+        vm.prank(OWNER);
+        mw.setUnfreezeFee(1);
+
+        // too soon → revert
+        vm.expectRevert(LidoV3Middleware.UnfreezeTooSoon.selector);
+        mw.unfreeze{value: 1}(one);
+
+        // after period → success; exact fee delivered
+        uint256 before = recv.balance;
+        vm.warp(block.timestamp + UNFREEZE_PERIOD + 1);
+        mw.unfreeze{value: 1}(one);
+        assertEq(recv.balance, before + 1, "receiver got fee");
+        assertTrue(mw.isValidatorOptedIn(one[0]), "unfrozen opted in again");
+    }
+
+    function test_Unfreeze_InsufficientFee_Reverts() public {
+        // register & freeze
+        bytes[] memory one = _keys(1);
+        vm.prank(operator); mw.registerValidators(vaultAddr, one);
+        vm.prank(OWNER);    mw.freezeValidators(one);
+
+        // set receiver to any EOA; fee = 2 wei
+        vm.prank(OWNER); mw.setUnfreezeReceiver(address(0xB0B));
+        vm.prank(OWNER); mw.setUnfreezeFee(2);
+
+        vm.warp(block.timestamp + UNFREEZE_PERIOD + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(LidoV3Middleware.UnfreezeFeeRequired.selector, uint256(2)));
+        mw.unfreeze{value: 1}(one);
+    }
+
+    function test_Unfreeze_Refunds_Excess() public {
+        // register & freeze
+        bytes[] memory one = _keys(1);
+        vm.prank(operator); mw.registerValidators(vaultAddr, one);
+        vm.prank(OWNER);    mw.freezeValidators(one);
+
+        // receiver: plain EOA
+        address recv = address(0xC0FFEE);
+        vm.prank(OWNER); mw.setUnfreezeReceiver(recv);
+        vm.prank(OWNER); mw.setUnfreezeFee(3); // need 3 wei
+
+        vm.warp(block.timestamp + UNFREEZE_PERIOD + 1);
+
+        // call unfreeze from a funded EOA so refund succeeds
+        address payer = address(0xD00D);
+        vm.deal(payer, 100);
+        uint256 payerBefore = payer.balance;
+        uint256 recvBefore  = recv.balance;
+
+        vm.prank(payer);
+        mw.unfreeze{value: 10}(one); // pays 10, fee=3, refund=7 to payer (EOA can receive ETH)
+
+        assertEq(recv.balance,  recvBefore + 3, "receiver got exact fee");
+        assertEq(payer.balance, payerBefore - 3, "only fee retained; refund returned");
+    }
+
+    function test_Unfreeze_TransferFailed_Reverts() public {
+        // register & freeze
+        bytes[] memory one = _keys(1);
+        vm.prank(operator); mw.registerValidators(vaultAddr, one);
+        vm.prank(OWNER);    mw.freezeValidators(one);
+
+        // set receiver to THIS contract, which has NO payable receive/fallback → low-level .call with value will revert
+        vm.prank(OWNER); mw.setUnfreezeReceiver(address(this));
+        vm.prank(OWNER); mw.setUnfreezeFee(1);
+
+        vm.warp(block.timestamp + UNFREEZE_PERIOD + 1);
+        vm.expectRevert(LidoV3Middleware.TransferFailed.selector);
+        mw.unfreeze{value: 1}(one);
+    }
+
+    function test_Deregister_Flow_WithTiming() public {
+        // register 2 keys
+        bytes[] memory two = _keys(2);
+        vm.prank(operator);
+        mw.registerValidators(vaultAddr, two);
+
+        // request dereg → optedIn becomes false
+        vm.prank(operator);
+        mw.requestDeregistrations(two);
+        assertFalse(mw.isValidatorOptedIn(two[0]));
+        assertFalse(mw.isValidatorOptedIn(two[1]));
+
+        // too early to deregister → revert
+        vm.expectRevert(LidoV3Middleware.UnfreezeTooSoon.selector);
+        vm.prank(operator);
+        mw.deregisterValidators(vaultAddr, two);
+
+        // after window → success; per-vault count decreases by 2
+        uint256 before = mw.vaultRegisteredCount(vaultAddr);
+        vm.warp(block.timestamp + DEREG_PERIOD + 1);
+        vm.prank(operator);
+        mw.deregisterValidators(vaultAddr, two);
+
+        uint256 after_ = mw.vaultRegisteredCount(vaultAddr);
+        assertEq(before - 2, after_, "count decreased");
+        // Not registered anymore
+        assertFalse(mw.isValidatorOptedIn(two[0]));
+        assertFalse(mw.isValidatorOptedIn(two[1]));
+    }
+
+    function test_AdminSetters_OnlyOwner() public {
+        // non-owner setWhitelist
+        vm.prank(bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+                bob
+            )
+        );
+        mw.setWhitelist(bob, true);
+
+        // owner actions
+        vm.prank(OWNER);
+        mw.setSlashAmount(123);
+        assertEq(mw.slashAmount(), 123);
+
+        vm.prank(OWNER);
+        mw.setUnfreezeFee(5);
+        assertEq(mw.unfreezeFee(), 5);
+
+        vm.prank(OWNER);
+        mw.setUnfreezePeriod(777);
+        assertEq(mw.unfreezePeriod(), 777);
+
+        vm.prank(OWNER);
+        mw.setDeregistrationPeriod(888);
+        assertEq(mw.deregistrationPeriod(), 888);
+    }
+
+    function test_OptedIn_False_IfRegistrarRemovedFromWhitelist() public {
+        bytes[] memory one = _keys(1);
+        vm.prank(operator);
+        mw.registerValidators(vaultAddr, one);
+        assertTrue(mw.isValidatorOptedIn(one[0]));
+
+        // remove operator from whitelist → becomes false
+        vm.prank(OWNER);
+        mw.setWhitelist(operator, false);
+        assertFalse(mw.isValidatorOptedIn(one[0]));
+    }
+
+    function test_SwitchVaultHub_BlocksNewRegistrations() public {
+        // allow one successful registration under current hub
+        bytes[] memory one = _keys(1);
+        vm.prank(operator);
+        mw.registerValidators(vaultAddr, one);
+
+        // switch to a fresh hub mock that does NOT know our vault
+        MockVaultHub newHub = new MockVaultHub();
+        vm.prank(OWNER);
+        mw.setVaultHub(address(newHub));
+
+        // any new registration should fail InvalidVault
+        bytes[] memory another = _keys(1);
+        vm.prank(operator);
+        vm.expectRevert(LidoV3Middleware.InvalidVault.selector);
+        mw.registerValidators(vaultAddr, another);
+    }
+
+    function test_CapacityMath_RemainingRegistrable() public {
+        // capacity = floor(totalValue / slashAmount)
+        // make it small: 105 wei / 10 wei = 10 keys
+        hub.setTotalValue(vaultAddr, 105);
+
+        // none registered yet
+        assertEq(mw.maxRegistrableByVault(vaultAddr), 10);
+        assertEq(mw.remainingRegistrable(vaultAddr), 10);
+
+        // register 3
+        bytes[] memory three = _keys(3);
+        vm.prank(operator);
+        mw.registerValidators(vaultAddr, three);
+
+        assertEq(mw.vaultRegisteredCount(vaultAddr), 3);
+        assertEq(mw.remainingRegistrable(vaultAddr), 7);
+    }
+
+}

--- a/contracts/test/validator-registry/lido/mocks/MockStakingVault.sol
+++ b/contracts/test/validator-registry/lido/mocks/MockStakingVault.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+contract MockStakingVault {
+    address public nodeOperator_;
+
+    constructor(address _nodeOperator) {
+        nodeOperator_ = _nodeOperator;
+    }
+
+    function setNodeOperator(address n) external { nodeOperator_ = n; }
+
+    // ---- IStakingVault ----
+    function nodeOperator() external view returns (address) {
+        return nodeOperator_;
+    }
+
+    // allow receiving ETH (not required, but handy)
+    receive() external payable {}
+}

--- a/contracts/test/validator-registry/lido/mocks/MockVaultHub.sol
+++ b/contracts/test/validator-registry/lido/mocks/MockVaultHub.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSL 1.1
+pragma solidity 0.8.26;
+
+contract MockVaultHub {
+    mapping(address => bool) public connected;
+    mapping(address => uint256) public _totalValue;
+
+    function setConnected(address _vault, bool _connected) external {
+        connected[_vault] = _connected;
+    }
+
+    function setTotalValue(address _vault, uint256 _amount) external {
+        _totalValue[_vault] = _amount;
+    }
+
+    // ---- IVaultHubMinimal ----
+    function isVaultConnected(address _vault) external view returns (bool) {
+        return connected[_vault];
+    }
+
+    function totalValue(address _vault) external view returns (uint256) {
+        return _totalValue[_vault];
+    }
+}


### PR DESCRIPTION
## Describe your changes
Initial registry for Lido V3 Staking Vaults
-No staking/slashing, only freezing
-Operator must be whitelisted
-Operator specifies their vault and keys to register
-Specified Vault's node operator must match the msg.sender, Vault must also be indexed within Lido's Vault Hub
-Lido V3 is not on mainnet yet, this is just for Hoodi test usage

Potential future design:
-Lido Staking Vaults accept ETH and mint steth to users, we can have our registry accept steth so to allow slashing on our side.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
