### PR TITLE
fix: ws publisher and flaky test

### DIFF
--- a/x/contracts/events/publisher/ws_test.go
+++ b/x/contracts/events/publisher/ws_test.go
@@ -54,8 +54,7 @@ func TestWSPublisher(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	doneChan := p.Start(ctx)
-	p.AddContracts(common.Address{})
+	doneChan := p.Start(ctx, common.Address{})
 
 	// Wait for first subscribe (will immediately error and cause resubscribe)
 	select {


### PR DESCRIPTION
Following up on issue created by https://github.com/primev/mev-commit/pull/774

* `wsPublisher` was flawed in that when calling `Start`, the `AddContracts` function was signaling `updateCh`, causing an unnecessary re-subscription whenever someone calls `Start`. 
* Separately, `TestWSPublisher` was calling `AddContracts` right after `Start`, causing another unnecessary re-subscription. The test logic relies on there not being unnecessary re-subscriptions like this, so it was sometimes failing via race conditions. This should all be fixed now. 