### PR TITLE
fix: prevent opts shadowing in ProcessBid

### DIFF
--- a/p2p/pkg/rpc/provider/service.go
+++ b/p2p/pkg/rpc/provider/service.go
@@ -129,7 +129,7 @@ func (s *Service) ProcessBid(
 		if err := proto.Unmarshal(bid.BidOptions, bidderOpts); err != nil {
 			return nil, fmt.Errorf("unmarshalling bid options: %w", err)
 		}
-		opts := new(providerapiv1.BidOptions)
+		opts = new(providerapiv1.BidOptions)
 		for _, bOpt := range bidderOpts.Options {
 			switch {
 			case bOpt.GetPositionConstraint() != nil:


### PR DESCRIPTION
## Describe your changes
Fixed a bug in `ProcessBid` where `opts` was shadowed due to `:=` usage.  
Now it correctly assigns with `=` to avoid losing the outer reference.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
