### PR TITLE
perf: optimization to redis for leader follower setup 

### DIFF
--- a/cl/singlenode/payloadstore/redis.go
+++ b/cl/singlenode/payloadstore/redis.go
@@ -167,7 +167,7 @@ func (r *RedisRepository) GetLatestHeight(ctx context.Context) (uint64, error) {
 	}
 	h, perr := strconv.ParseUint(s, 10, 64)
 	if perr != nil {
-		return 0, nil
+		return 0, fmt.Errorf("parse uint: %w", perr)
 	}
 	return h, nil
 }


### PR DESCRIPTION
Improves upon https://github.com/primev/mev-commit/pull/793 by:
* Added a string index for O(1) retrieval of the latest height
* Wrapped payload writes in a single atomic Lua scrip
* Left GetPayloadsSince as O(log n) and did not optimize GetPayloadByHeight, since it’s only used by legacy code
* Tests are untouched as function behavior shouldn't have changed