### PR TITLE
feat: rocketpool registry for minipool operators

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "contracts/lib/forge-std"]
 	path = contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "contracts/lib/rocketpool"]
+	path = contracts/lib/rocketpool
+	url = https://github.com/rocket-pool/rocketpool

--- a/contracts-abi/abi/RocketMinipoolRegistry.abi
+++ b/contracts-abi/abi/RocketMinipoolRegistry.abi
@@ -282,6 +282,11 @@
     "name": "isOperatorValidForKey",
     "inputs": [
       {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
         "name": "validatorPubkey",
         "type": "bytes",
         "internalType": "bytes"
@@ -720,7 +725,7 @@
       {
         "name": "validatorPubKey",
         "type": "bytes",
-        "indexed": false,
+        "indexed": true,
         "internalType": "bytes"
       },
       {
@@ -739,7 +744,7 @@
       {
         "name": "validatorPubKey",
         "type": "bytes",
-        "indexed": false,
+        "indexed": true,
         "internalType": "bytes"
       },
       {
@@ -758,7 +763,7 @@
       {
         "name": "validatorPubKey",
         "type": "bytes",
-        "indexed": false,
+        "indexed": true,
         "internalType": "bytes"
       }
     ],
@@ -771,7 +776,7 @@
       {
         "name": "validatorPubKey",
         "type": "bytes",
-        "indexed": false,
+        "indexed": true,
         "internalType": "bytes"
       },
       {
@@ -790,7 +795,7 @@
       {
         "name": "validatorPubKey",
         "type": "bytes",
-        "indexed": false,
+        "indexed": true,
         "internalType": "bytes"
       }
     ],
@@ -980,6 +985,11 @@
   },
   {
     "type": "error",
+    "name": "ReentrancyGuardReentrantCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "RefundFailed",
     "inputs": []
   },
@@ -1069,5 +1079,10 @@
         "internalType": "bytes"
       }
     ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroParam",
+    "inputs": []
   }
 ]

--- a/contracts-abi/abi/RocketMinipoolRegistry.abi
+++ b/contracts-abi/abi/RocketMinipoolRegistry.abi
@@ -1,0 +1,1048 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "fallback",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "receive",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "acceptOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deregisterValidators",
+    "inputs": [
+      {
+        "name": "valPubKeys",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deregistrationPeriod",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "freeze",
+    "inputs": [
+      {
+        "name": "valPubKeys",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "freezeOracle",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEligibleTimeForDeregistration",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMinipoolFromPubkey",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNodeAddressFromMinipool",
+    "inputs": [
+      {
+        "name": "minipool",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNodeAddressFromPubkey",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getValidOperatorsForKey",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getValidatorRegInfo",
+    "inputs": [
+      {
+        "name": "valPubKey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IRocketMinipoolRegistry.ValidatorRegistration",
+        "components": [
+          {
+            "name": "exists",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "deregTimestamp",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "freezeTimestamp",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isMinipoolActive",
+    "inputs": [
+      {
+        "name": "minipool",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isOperatorValidForKey",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isValidatorOptedIn",
+    "inputs": [
+      {
+        "name": "valPubKey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isValidatorRegistered",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownerUnfreeze",
+    "inputs": [
+      {
+        "name": "valPubKeys",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingOwner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "registerValidators",
+    "inputs": [
+      {
+        "name": "valPubKeys",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestValidatorDeregistration",
+    "inputs": [
+      {
+        "name": "valPubKeys",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "rocketStorage",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract RocketStorageInterface"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setDeregistrationPeriod",
+    "inputs": [
+      {
+        "name": "newDeregistrationPeriod",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setFreezeOracle",
+    "inputs": [
+      {
+        "name": "newFreezeOracle",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRocketStorage",
+    "inputs": [
+      {
+        "name": "newRocketStorage",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setUnfreezeFee",
+    "inputs": [
+      {
+        "name": "newUnfreezeFee",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setUnfreezeReceiver",
+    "inputs": [
+      {
+        "name": "newUnfreezeReceiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unfreeze",
+    "inputs": [
+      {
+        "name": "valPubKeys",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "unfreezeFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "unfreezeReceiver",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "unpause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "validatorRegistrations",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "exists",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "deregTimestamp",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "freezeTimestamp",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferStarted",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ValidatorDeregistered",
+    "inputs": [
+      {
+        "name": "validatorPubKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "nodeAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ValidatorDeregistrationRequested",
+    "inputs": [
+      {
+        "name": "validatorPubKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "nodeAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ValidatorFrozen",
+    "inputs": [
+      {
+        "name": "validatorPubKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ValidatorRegistered",
+    "inputs": [
+      {
+        "name": "validatorPubKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "nodeAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ValidatorUnfrozen",
+    "inputs": [
+      {
+        "name": "validatorPubKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "DeregRequestAlreadyExists",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "DeregRequestDoesNotExist",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "DeregistrationTooSoon",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EnforcedPause",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ExpectedPause",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedInnerCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FrozenValidatorCannotDeregister",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidBLSPubKeyLength",
+    "inputs": [
+      {
+        "name": "expectedLength",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "actualLength",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidFallback",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidReceive",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MinipoolNotActive",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoMinipoolForKey",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotMinipoolOperator",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OnlyFreezeOracle",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "RefundFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnfreezeFeeRequired",
+    "inputs": [
+      {
+        "name": "requiredFee",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnfreezeTransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ValidatorAlreadyFrozen",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ValidatorAlreadyRegistered",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ValidatorDeregistrationNotExpired",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ValidatorNotFrozen",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ValidatorNotRegistered",
+    "inputs": [
+      {
+        "name": "validatorPubkey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  }
+]

--- a/contracts-abi/abi/RocketMinipoolRegistry.abi
+++ b/contracts-abi/abi/RocketMinipoolRegistry.abi
@@ -228,6 +228,31 @@
         "name": "owner",
         "type": "address",
         "internalType": "address"
+      },
+      {
+        "name": "freezeOracle",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "unfreezeReceiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "rocketStorage",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "unfreezeFee",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deregistrationPeriod",
+        "type": "uint64",
+        "internalType": "uint64"
       }
     ],
     "outputs": [],

--- a/contracts-abi/clients/AlwaysFalseRegistry/AlwaysFalseRegistry.go
+++ b/contracts-abi/clients/AlwaysFalseRegistry/AlwaysFalseRegistry.go
@@ -1,0 +1,212 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package alwaysfalseregistry
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// AlwaysfalseregistryMetaData contains all meta data concerning the Alwaysfalseregistry contract.
+var AlwaysfalseregistryMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"function\",\"name\":\"isValidatorOptedIn\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"pure\"}]",
+}
+
+// AlwaysfalseregistryABI is the input ABI used to generate the binding from.
+// Deprecated: Use AlwaysfalseregistryMetaData.ABI instead.
+var AlwaysfalseregistryABI = AlwaysfalseregistryMetaData.ABI
+
+// Alwaysfalseregistry is an auto generated Go binding around an Ethereum contract.
+type Alwaysfalseregistry struct {
+	AlwaysfalseregistryCaller     // Read-only binding to the contract
+	AlwaysfalseregistryTransactor // Write-only binding to the contract
+	AlwaysfalseregistryFilterer   // Log filterer for contract events
+}
+
+// AlwaysfalseregistryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type AlwaysfalseregistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AlwaysfalseregistryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type AlwaysfalseregistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AlwaysfalseregistryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type AlwaysfalseregistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AlwaysfalseregistrySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type AlwaysfalseregistrySession struct {
+	Contract     *Alwaysfalseregistry // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts        // Call options to use throughout this session
+	TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
+}
+
+// AlwaysfalseregistryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type AlwaysfalseregistryCallerSession struct {
+	Contract *AlwaysfalseregistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts              // Call options to use throughout this session
+}
+
+// AlwaysfalseregistryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type AlwaysfalseregistryTransactorSession struct {
+	Contract     *AlwaysfalseregistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts              // Transaction auth options to use throughout this session
+}
+
+// AlwaysfalseregistryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type AlwaysfalseregistryRaw struct {
+	Contract *Alwaysfalseregistry // Generic contract binding to access the raw methods on
+}
+
+// AlwaysfalseregistryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type AlwaysfalseregistryCallerRaw struct {
+	Contract *AlwaysfalseregistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// AlwaysfalseregistryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type AlwaysfalseregistryTransactorRaw struct {
+	Contract *AlwaysfalseregistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewAlwaysfalseregistry creates a new instance of Alwaysfalseregistry, bound to a specific deployed contract.
+func NewAlwaysfalseregistry(address common.Address, backend bind.ContractBackend) (*Alwaysfalseregistry, error) {
+	contract, err := bindAlwaysfalseregistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Alwaysfalseregistry{AlwaysfalseregistryCaller: AlwaysfalseregistryCaller{contract: contract}, AlwaysfalseregistryTransactor: AlwaysfalseregistryTransactor{contract: contract}, AlwaysfalseregistryFilterer: AlwaysfalseregistryFilterer{contract: contract}}, nil
+}
+
+// NewAlwaysfalseregistryCaller creates a new read-only instance of Alwaysfalseregistry, bound to a specific deployed contract.
+func NewAlwaysfalseregistryCaller(address common.Address, caller bind.ContractCaller) (*AlwaysfalseregistryCaller, error) {
+	contract, err := bindAlwaysfalseregistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AlwaysfalseregistryCaller{contract: contract}, nil
+}
+
+// NewAlwaysfalseregistryTransactor creates a new write-only instance of Alwaysfalseregistry, bound to a specific deployed contract.
+func NewAlwaysfalseregistryTransactor(address common.Address, transactor bind.ContractTransactor) (*AlwaysfalseregistryTransactor, error) {
+	contract, err := bindAlwaysfalseregistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AlwaysfalseregistryTransactor{contract: contract}, nil
+}
+
+// NewAlwaysfalseregistryFilterer creates a new log filterer instance of Alwaysfalseregistry, bound to a specific deployed contract.
+func NewAlwaysfalseregistryFilterer(address common.Address, filterer bind.ContractFilterer) (*AlwaysfalseregistryFilterer, error) {
+	contract, err := bindAlwaysfalseregistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &AlwaysfalseregistryFilterer{contract: contract}, nil
+}
+
+// bindAlwaysfalseregistry binds a generic wrapper to an already deployed contract.
+func bindAlwaysfalseregistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := AlwaysfalseregistryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Alwaysfalseregistry *AlwaysfalseregistryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Alwaysfalseregistry.Contract.AlwaysfalseregistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Alwaysfalseregistry *AlwaysfalseregistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Alwaysfalseregistry.Contract.AlwaysfalseregistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Alwaysfalseregistry *AlwaysfalseregistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Alwaysfalseregistry.Contract.AlwaysfalseregistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Alwaysfalseregistry *AlwaysfalseregistryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Alwaysfalseregistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Alwaysfalseregistry *AlwaysfalseregistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Alwaysfalseregistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Alwaysfalseregistry *AlwaysfalseregistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Alwaysfalseregistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsValidatorOptedIn is a free data retrieval call binding the contract method 0x470b690f.
+//
+// Solidity: function isValidatorOptedIn(bytes ) pure returns(bool)
+func (_Alwaysfalseregistry *AlwaysfalseregistryCaller) IsValidatorOptedIn(opts *bind.CallOpts, arg0 []byte) (bool, error) {
+	var out []interface{}
+	err := _Alwaysfalseregistry.contract.Call(opts, &out, "isValidatorOptedIn", arg0)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsValidatorOptedIn is a free data retrieval call binding the contract method 0x470b690f.
+//
+// Solidity: function isValidatorOptedIn(bytes ) pure returns(bool)
+func (_Alwaysfalseregistry *AlwaysfalseregistrySession) IsValidatorOptedIn(arg0 []byte) (bool, error) {
+	return _Alwaysfalseregistry.Contract.IsValidatorOptedIn(&_Alwaysfalseregistry.CallOpts, arg0)
+}
+
+// IsValidatorOptedIn is a free data retrieval call binding the contract method 0x470b690f.
+//
+// Solidity: function isValidatorOptedIn(bytes ) pure returns(bool)
+func (_Alwaysfalseregistry *AlwaysfalseregistryCallerSession) IsValidatorOptedIn(arg0 []byte) (bool, error) {
+	return _Alwaysfalseregistry.Contract.IsValidatorOptedIn(&_Alwaysfalseregistry.CallOpts, arg0)
+}

--- a/contracts-abi/clients/BlockRewardManager/BlockRewardManager.go
+++ b/contracts-abi/clients/BlockRewardManager/BlockRewardManager.go
@@ -1,0 +1,1807 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package blockrewardmanager
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BlockrewardmanagerMetaData contains all meta data concerning the Blockrewardmanager contract.
+var BlockrewardmanagerMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"initialOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"rewardsPctBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"treasury\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"payProposer\",\"inputs\":[{\"name\":\"feeRecipient\",\"type\":\"address\",\"internalType\":\"addresspayable\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"rewardsPctBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setRewardsPctBps\",\"inputs\":[{\"name\":\"rewardsPctBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setTreasury\",\"inputs\":[{\"name\":\"treasury\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"toTreasury\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"treasury\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"addresspayable\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"withdrawToTreasury\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProposerPaid\",\"inputs\":[{\"name\":\"feeRecipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"proposerAmt\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"rewardAmt\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardsPctBpsSet\",\"inputs\":[{\"name\":\"rewardsPctBps\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TreasurySet\",\"inputs\":[{\"name\":\"treasury\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TreasuryWithdrawn\",\"inputs\":[{\"name\":\"treasuryAmt\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReceive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoFundsToWithdraw\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OnlyOwnerOrTreasury\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ProposerTransferFailed\",\"inputs\":[{\"name\":\"feeRecipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RewardsPctTooHigh\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TreasuryIsZero\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TreasuryTransferFailed\",\"inputs\":[{\"name\":\"treasury\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]",
+}
+
+// BlockrewardmanagerABI is the input ABI used to generate the binding from.
+// Deprecated: Use BlockrewardmanagerMetaData.ABI instead.
+var BlockrewardmanagerABI = BlockrewardmanagerMetaData.ABI
+
+// Blockrewardmanager is an auto generated Go binding around an Ethereum contract.
+type Blockrewardmanager struct {
+	BlockrewardmanagerCaller     // Read-only binding to the contract
+	BlockrewardmanagerTransactor // Write-only binding to the contract
+	BlockrewardmanagerFilterer   // Log filterer for contract events
+}
+
+// BlockrewardmanagerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BlockrewardmanagerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BlockrewardmanagerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BlockrewardmanagerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BlockrewardmanagerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BlockrewardmanagerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BlockrewardmanagerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BlockrewardmanagerSession struct {
+	Contract     *Blockrewardmanager // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts       // Call options to use throughout this session
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// BlockrewardmanagerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BlockrewardmanagerCallerSession struct {
+	Contract *BlockrewardmanagerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts             // Call options to use throughout this session
+}
+
+// BlockrewardmanagerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BlockrewardmanagerTransactorSession struct {
+	Contract     *BlockrewardmanagerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts             // Transaction auth options to use throughout this session
+}
+
+// BlockrewardmanagerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BlockrewardmanagerRaw struct {
+	Contract *Blockrewardmanager // Generic contract binding to access the raw methods on
+}
+
+// BlockrewardmanagerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BlockrewardmanagerCallerRaw struct {
+	Contract *BlockrewardmanagerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BlockrewardmanagerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BlockrewardmanagerTransactorRaw struct {
+	Contract *BlockrewardmanagerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBlockrewardmanager creates a new instance of Blockrewardmanager, bound to a specific deployed contract.
+func NewBlockrewardmanager(address common.Address, backend bind.ContractBackend) (*Blockrewardmanager, error) {
+	contract, err := bindBlockrewardmanager(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Blockrewardmanager{BlockrewardmanagerCaller: BlockrewardmanagerCaller{contract: contract}, BlockrewardmanagerTransactor: BlockrewardmanagerTransactor{contract: contract}, BlockrewardmanagerFilterer: BlockrewardmanagerFilterer{contract: contract}}, nil
+}
+
+// NewBlockrewardmanagerCaller creates a new read-only instance of Blockrewardmanager, bound to a specific deployed contract.
+func NewBlockrewardmanagerCaller(address common.Address, caller bind.ContractCaller) (*BlockrewardmanagerCaller, error) {
+	contract, err := bindBlockrewardmanager(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerCaller{contract: contract}, nil
+}
+
+// NewBlockrewardmanagerTransactor creates a new write-only instance of Blockrewardmanager, bound to a specific deployed contract.
+func NewBlockrewardmanagerTransactor(address common.Address, transactor bind.ContractTransactor) (*BlockrewardmanagerTransactor, error) {
+	contract, err := bindBlockrewardmanager(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerTransactor{contract: contract}, nil
+}
+
+// NewBlockrewardmanagerFilterer creates a new log filterer instance of Blockrewardmanager, bound to a specific deployed contract.
+func NewBlockrewardmanagerFilterer(address common.Address, filterer bind.ContractFilterer) (*BlockrewardmanagerFilterer, error) {
+	contract, err := bindBlockrewardmanager(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerFilterer{contract: contract}, nil
+}
+
+// bindBlockrewardmanager binds a generic wrapper to an already deployed contract.
+func bindBlockrewardmanager(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BlockrewardmanagerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Blockrewardmanager *BlockrewardmanagerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Blockrewardmanager.Contract.BlockrewardmanagerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Blockrewardmanager *BlockrewardmanagerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.BlockrewardmanagerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Blockrewardmanager *BlockrewardmanagerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.BlockrewardmanagerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Blockrewardmanager *BlockrewardmanagerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Blockrewardmanager.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Blockrewardmanager *BlockrewardmanagerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Blockrewardmanager *BlockrewardmanagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.contract.Transact(opts, method, params...)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Blockrewardmanager *BlockrewardmanagerCaller) UPGRADEINTERFACEVERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _Blockrewardmanager.contract.Call(opts, &out, "UPGRADE_INTERFACE_VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Blockrewardmanager *BlockrewardmanagerSession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _Blockrewardmanager.Contract.UPGRADEINTERFACEVERSION(&_Blockrewardmanager.CallOpts)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Blockrewardmanager *BlockrewardmanagerCallerSession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _Blockrewardmanager.Contract.UPGRADEINTERFACEVERSION(&_Blockrewardmanager.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Blockrewardmanager *BlockrewardmanagerCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Blockrewardmanager.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Blockrewardmanager *BlockrewardmanagerSession) Owner() (common.Address, error) {
+	return _Blockrewardmanager.Contract.Owner(&_Blockrewardmanager.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Blockrewardmanager *BlockrewardmanagerCallerSession) Owner() (common.Address, error) {
+	return _Blockrewardmanager.Contract.Owner(&_Blockrewardmanager.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Blockrewardmanager *BlockrewardmanagerCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Blockrewardmanager.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Blockrewardmanager *BlockrewardmanagerSession) PendingOwner() (common.Address, error) {
+	return _Blockrewardmanager.Contract.PendingOwner(&_Blockrewardmanager.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Blockrewardmanager *BlockrewardmanagerCallerSession) PendingOwner() (common.Address, error) {
+	return _Blockrewardmanager.Contract.PendingOwner(&_Blockrewardmanager.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Blockrewardmanager *BlockrewardmanagerCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Blockrewardmanager.contract.Call(opts, &out, "proxiableUUID")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Blockrewardmanager *BlockrewardmanagerSession) ProxiableUUID() ([32]byte, error) {
+	return _Blockrewardmanager.Contract.ProxiableUUID(&_Blockrewardmanager.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Blockrewardmanager *BlockrewardmanagerCallerSession) ProxiableUUID() ([32]byte, error) {
+	return _Blockrewardmanager.Contract.ProxiableUUID(&_Blockrewardmanager.CallOpts)
+}
+
+// RewardsPctBps is a free data retrieval call binding the contract method 0xd8dd8d11.
+//
+// Solidity: function rewardsPctBps() view returns(uint256)
+func (_Blockrewardmanager *BlockrewardmanagerCaller) RewardsPctBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Blockrewardmanager.contract.Call(opts, &out, "rewardsPctBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// RewardsPctBps is a free data retrieval call binding the contract method 0xd8dd8d11.
+//
+// Solidity: function rewardsPctBps() view returns(uint256)
+func (_Blockrewardmanager *BlockrewardmanagerSession) RewardsPctBps() (*big.Int, error) {
+	return _Blockrewardmanager.Contract.RewardsPctBps(&_Blockrewardmanager.CallOpts)
+}
+
+// RewardsPctBps is a free data retrieval call binding the contract method 0xd8dd8d11.
+//
+// Solidity: function rewardsPctBps() view returns(uint256)
+func (_Blockrewardmanager *BlockrewardmanagerCallerSession) RewardsPctBps() (*big.Int, error) {
+	return _Blockrewardmanager.Contract.RewardsPctBps(&_Blockrewardmanager.CallOpts)
+}
+
+// ToTreasury is a free data retrieval call binding the contract method 0x79900169.
+//
+// Solidity: function toTreasury() view returns(uint256)
+func (_Blockrewardmanager *BlockrewardmanagerCaller) ToTreasury(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Blockrewardmanager.contract.Call(opts, &out, "toTreasury")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ToTreasury is a free data retrieval call binding the contract method 0x79900169.
+//
+// Solidity: function toTreasury() view returns(uint256)
+func (_Blockrewardmanager *BlockrewardmanagerSession) ToTreasury() (*big.Int, error) {
+	return _Blockrewardmanager.Contract.ToTreasury(&_Blockrewardmanager.CallOpts)
+}
+
+// ToTreasury is a free data retrieval call binding the contract method 0x79900169.
+//
+// Solidity: function toTreasury() view returns(uint256)
+func (_Blockrewardmanager *BlockrewardmanagerCallerSession) ToTreasury() (*big.Int, error) {
+	return _Blockrewardmanager.Contract.ToTreasury(&_Blockrewardmanager.CallOpts)
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_Blockrewardmanager *BlockrewardmanagerCaller) Treasury(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Blockrewardmanager.contract.Call(opts, &out, "treasury")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_Blockrewardmanager *BlockrewardmanagerSession) Treasury() (common.Address, error) {
+	return _Blockrewardmanager.Contract.Treasury(&_Blockrewardmanager.CallOpts)
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_Blockrewardmanager *BlockrewardmanagerCallerSession) Treasury() (common.Address, error) {
+	return _Blockrewardmanager.Contract.Treasury(&_Blockrewardmanager.CallOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.AcceptOwnership(&_Blockrewardmanager.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.AcceptOwnership(&_Blockrewardmanager.TransactOpts)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc350a1b5.
+//
+// Solidity: function initialize(address initialOwner, uint256 rewardsPctBps, address treasury) returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) Initialize(opts *bind.TransactOpts, initialOwner common.Address, rewardsPctBps *big.Int, treasury common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.Transact(opts, "initialize", initialOwner, rewardsPctBps, treasury)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc350a1b5.
+//
+// Solidity: function initialize(address initialOwner, uint256 rewardsPctBps, address treasury) returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) Initialize(initialOwner common.Address, rewardsPctBps *big.Int, treasury common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.Initialize(&_Blockrewardmanager.TransactOpts, initialOwner, rewardsPctBps, treasury)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc350a1b5.
+//
+// Solidity: function initialize(address initialOwner, uint256 rewardsPctBps, address treasury) returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) Initialize(initialOwner common.Address, rewardsPctBps *big.Int, treasury common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.Initialize(&_Blockrewardmanager.TransactOpts, initialOwner, rewardsPctBps, treasury)
+}
+
+// PayProposer is a paid mutator transaction binding the contract method 0x4256053f.
+//
+// Solidity: function payProposer(address feeRecipient) payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) PayProposer(opts *bind.TransactOpts, feeRecipient common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.Transact(opts, "payProposer", feeRecipient)
+}
+
+// PayProposer is a paid mutator transaction binding the contract method 0x4256053f.
+//
+// Solidity: function payProposer(address feeRecipient) payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) PayProposer(feeRecipient common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.PayProposer(&_Blockrewardmanager.TransactOpts, feeRecipient)
+}
+
+// PayProposer is a paid mutator transaction binding the contract method 0x4256053f.
+//
+// Solidity: function payProposer(address feeRecipient) payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) PayProposer(feeRecipient common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.PayProposer(&_Blockrewardmanager.TransactOpts, feeRecipient)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.RenounceOwnership(&_Blockrewardmanager.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.RenounceOwnership(&_Blockrewardmanager.TransactOpts)
+}
+
+// SetRewardsPctBps is a paid mutator transaction binding the contract method 0x12dfd7d2.
+//
+// Solidity: function setRewardsPctBps(uint256 rewardsPctBps) returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) SetRewardsPctBps(opts *bind.TransactOpts, rewardsPctBps *big.Int) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.Transact(opts, "setRewardsPctBps", rewardsPctBps)
+}
+
+// SetRewardsPctBps is a paid mutator transaction binding the contract method 0x12dfd7d2.
+//
+// Solidity: function setRewardsPctBps(uint256 rewardsPctBps) returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) SetRewardsPctBps(rewardsPctBps *big.Int) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.SetRewardsPctBps(&_Blockrewardmanager.TransactOpts, rewardsPctBps)
+}
+
+// SetRewardsPctBps is a paid mutator transaction binding the contract method 0x12dfd7d2.
+//
+// Solidity: function setRewardsPctBps(uint256 rewardsPctBps) returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) SetRewardsPctBps(rewardsPctBps *big.Int) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.SetRewardsPctBps(&_Blockrewardmanager.TransactOpts, rewardsPctBps)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address treasury) returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) SetTreasury(opts *bind.TransactOpts, treasury common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.Transact(opts, "setTreasury", treasury)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address treasury) returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) SetTreasury(treasury common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.SetTreasury(&_Blockrewardmanager.TransactOpts, treasury)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address treasury) returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) SetTreasury(treasury common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.SetTreasury(&_Blockrewardmanager.TransactOpts, treasury)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.TransferOwnership(&_Blockrewardmanager.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.TransferOwnership(&_Blockrewardmanager.TransactOpts, newOwner)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.UpgradeToAndCall(&_Blockrewardmanager.TransactOpts, newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.UpgradeToAndCall(&_Blockrewardmanager.TransactOpts, newImplementation, data)
+}
+
+// WithdrawToTreasury is a paid mutator transaction binding the contract method 0x7e80c186.
+//
+// Solidity: function withdrawToTreasury() returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) WithdrawToTreasury(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.Transact(opts, "withdrawToTreasury")
+}
+
+// WithdrawToTreasury is a paid mutator transaction binding the contract method 0x7e80c186.
+//
+// Solidity: function withdrawToTreasury() returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) WithdrawToTreasury() (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.WithdrawToTreasury(&_Blockrewardmanager.TransactOpts)
+}
+
+// WithdrawToTreasury is a paid mutator transaction binding the contract method 0x7e80c186.
+//
+// Solidity: function withdrawToTreasury() returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) WithdrawToTreasury() (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.WithdrawToTreasury(&_Blockrewardmanager.TransactOpts)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.RawTransact(opts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.Fallback(&_Blockrewardmanager.TransactOpts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.Fallback(&_Blockrewardmanager.TransactOpts, calldata)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Blockrewardmanager.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerSession) Receive() (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.Receive(&_Blockrewardmanager.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Blockrewardmanager *BlockrewardmanagerTransactorSession) Receive() (*types.Transaction, error) {
+	return _Blockrewardmanager.Contract.Receive(&_Blockrewardmanager.TransactOpts)
+}
+
+// BlockrewardmanagerInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Blockrewardmanager contract.
+type BlockrewardmanagerInitializedIterator struct {
+	Event *BlockrewardmanagerInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BlockrewardmanagerInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BlockrewardmanagerInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BlockrewardmanagerInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BlockrewardmanagerInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BlockrewardmanagerInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BlockrewardmanagerInitialized represents a Initialized event raised by the Blockrewardmanager contract.
+type BlockrewardmanagerInitialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) FilterInitialized(opts *bind.FilterOpts) (*BlockrewardmanagerInitializedIterator, error) {
+
+	logs, sub, err := _Blockrewardmanager.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerInitializedIterator{contract: _Blockrewardmanager.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *BlockrewardmanagerInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _Blockrewardmanager.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BlockrewardmanagerInitialized)
+				if err := _Blockrewardmanager.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) ParseInitialized(log types.Log) (*BlockrewardmanagerInitialized, error) {
+	event := new(BlockrewardmanagerInitialized)
+	if err := _Blockrewardmanager.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BlockrewardmanagerOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the Blockrewardmanager contract.
+type BlockrewardmanagerOwnershipTransferStartedIterator struct {
+	Event *BlockrewardmanagerOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BlockrewardmanagerOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BlockrewardmanagerOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BlockrewardmanagerOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BlockrewardmanagerOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BlockrewardmanagerOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BlockrewardmanagerOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the Blockrewardmanager contract.
+type BlockrewardmanagerOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BlockrewardmanagerOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerOwnershipTransferStartedIterator{contract: _Blockrewardmanager.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *BlockrewardmanagerOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BlockrewardmanagerOwnershipTransferStarted)
+				if err := _Blockrewardmanager.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) ParseOwnershipTransferStarted(log types.Log) (*BlockrewardmanagerOwnershipTransferStarted, error) {
+	event := new(BlockrewardmanagerOwnershipTransferStarted)
+	if err := _Blockrewardmanager.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BlockrewardmanagerOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Blockrewardmanager contract.
+type BlockrewardmanagerOwnershipTransferredIterator struct {
+	Event *BlockrewardmanagerOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BlockrewardmanagerOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BlockrewardmanagerOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BlockrewardmanagerOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BlockrewardmanagerOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BlockrewardmanagerOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BlockrewardmanagerOwnershipTransferred represents a OwnershipTransferred event raised by the Blockrewardmanager contract.
+type BlockrewardmanagerOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BlockrewardmanagerOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerOwnershipTransferredIterator{contract: _Blockrewardmanager.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BlockrewardmanagerOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BlockrewardmanagerOwnershipTransferred)
+				if err := _Blockrewardmanager.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) ParseOwnershipTransferred(log types.Log) (*BlockrewardmanagerOwnershipTransferred, error) {
+	event := new(BlockrewardmanagerOwnershipTransferred)
+	if err := _Blockrewardmanager.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BlockrewardmanagerProposerPaidIterator is returned from FilterProposerPaid and is used to iterate over the raw logs and unpacked data for ProposerPaid events raised by the Blockrewardmanager contract.
+type BlockrewardmanagerProposerPaidIterator struct {
+	Event *BlockrewardmanagerProposerPaid // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BlockrewardmanagerProposerPaidIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BlockrewardmanagerProposerPaid)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BlockrewardmanagerProposerPaid)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BlockrewardmanagerProposerPaidIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BlockrewardmanagerProposerPaidIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BlockrewardmanagerProposerPaid represents a ProposerPaid event raised by the Blockrewardmanager contract.
+type BlockrewardmanagerProposerPaid struct {
+	FeeRecipient common.Address
+	ProposerAmt  *big.Int
+	RewardAmt    *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterProposerPaid is a free log retrieval operation binding the contract event 0x0c8bf8e02773e67b63846688d6d74c4460cba72aa13c61b5e36ce9fe3d034a56.
+//
+// Solidity: event ProposerPaid(address indexed feeRecipient, uint256 indexed proposerAmt, uint256 indexed rewardAmt)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) FilterProposerPaid(opts *bind.FilterOpts, feeRecipient []common.Address, proposerAmt []*big.Int, rewardAmt []*big.Int) (*BlockrewardmanagerProposerPaidIterator, error) {
+
+	var feeRecipientRule []interface{}
+	for _, feeRecipientItem := range feeRecipient {
+		feeRecipientRule = append(feeRecipientRule, feeRecipientItem)
+	}
+	var proposerAmtRule []interface{}
+	for _, proposerAmtItem := range proposerAmt {
+		proposerAmtRule = append(proposerAmtRule, proposerAmtItem)
+	}
+	var rewardAmtRule []interface{}
+	for _, rewardAmtItem := range rewardAmt {
+		rewardAmtRule = append(rewardAmtRule, rewardAmtItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.FilterLogs(opts, "ProposerPaid", feeRecipientRule, proposerAmtRule, rewardAmtRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerProposerPaidIterator{contract: _Blockrewardmanager.contract, event: "ProposerPaid", logs: logs, sub: sub}, nil
+}
+
+// WatchProposerPaid is a free log subscription operation binding the contract event 0x0c8bf8e02773e67b63846688d6d74c4460cba72aa13c61b5e36ce9fe3d034a56.
+//
+// Solidity: event ProposerPaid(address indexed feeRecipient, uint256 indexed proposerAmt, uint256 indexed rewardAmt)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) WatchProposerPaid(opts *bind.WatchOpts, sink chan<- *BlockrewardmanagerProposerPaid, feeRecipient []common.Address, proposerAmt []*big.Int, rewardAmt []*big.Int) (event.Subscription, error) {
+
+	var feeRecipientRule []interface{}
+	for _, feeRecipientItem := range feeRecipient {
+		feeRecipientRule = append(feeRecipientRule, feeRecipientItem)
+	}
+	var proposerAmtRule []interface{}
+	for _, proposerAmtItem := range proposerAmt {
+		proposerAmtRule = append(proposerAmtRule, proposerAmtItem)
+	}
+	var rewardAmtRule []interface{}
+	for _, rewardAmtItem := range rewardAmt {
+		rewardAmtRule = append(rewardAmtRule, rewardAmtItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.WatchLogs(opts, "ProposerPaid", feeRecipientRule, proposerAmtRule, rewardAmtRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BlockrewardmanagerProposerPaid)
+				if err := _Blockrewardmanager.contract.UnpackLog(event, "ProposerPaid", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProposerPaid is a log parse operation binding the contract event 0x0c8bf8e02773e67b63846688d6d74c4460cba72aa13c61b5e36ce9fe3d034a56.
+//
+// Solidity: event ProposerPaid(address indexed feeRecipient, uint256 indexed proposerAmt, uint256 indexed rewardAmt)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) ParseProposerPaid(log types.Log) (*BlockrewardmanagerProposerPaid, error) {
+	event := new(BlockrewardmanagerProposerPaid)
+	if err := _Blockrewardmanager.contract.UnpackLog(event, "ProposerPaid", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BlockrewardmanagerRewardsPctBpsSetIterator is returned from FilterRewardsPctBpsSet and is used to iterate over the raw logs and unpacked data for RewardsPctBpsSet events raised by the Blockrewardmanager contract.
+type BlockrewardmanagerRewardsPctBpsSetIterator struct {
+	Event *BlockrewardmanagerRewardsPctBpsSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BlockrewardmanagerRewardsPctBpsSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BlockrewardmanagerRewardsPctBpsSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BlockrewardmanagerRewardsPctBpsSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BlockrewardmanagerRewardsPctBpsSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BlockrewardmanagerRewardsPctBpsSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BlockrewardmanagerRewardsPctBpsSet represents a RewardsPctBpsSet event raised by the Blockrewardmanager contract.
+type BlockrewardmanagerRewardsPctBpsSet struct {
+	RewardsPctBps *big.Int
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardsPctBpsSet is a free log retrieval operation binding the contract event 0xecd960b831b304435f2e2028908a05dbb70756ab3aaf9d16927526264f64cd03.
+//
+// Solidity: event RewardsPctBpsSet(uint256 indexed rewardsPctBps)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) FilterRewardsPctBpsSet(opts *bind.FilterOpts, rewardsPctBps []*big.Int) (*BlockrewardmanagerRewardsPctBpsSetIterator, error) {
+
+	var rewardsPctBpsRule []interface{}
+	for _, rewardsPctBpsItem := range rewardsPctBps {
+		rewardsPctBpsRule = append(rewardsPctBpsRule, rewardsPctBpsItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.FilterLogs(opts, "RewardsPctBpsSet", rewardsPctBpsRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerRewardsPctBpsSetIterator{contract: _Blockrewardmanager.contract, event: "RewardsPctBpsSet", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardsPctBpsSet is a free log subscription operation binding the contract event 0xecd960b831b304435f2e2028908a05dbb70756ab3aaf9d16927526264f64cd03.
+//
+// Solidity: event RewardsPctBpsSet(uint256 indexed rewardsPctBps)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) WatchRewardsPctBpsSet(opts *bind.WatchOpts, sink chan<- *BlockrewardmanagerRewardsPctBpsSet, rewardsPctBps []*big.Int) (event.Subscription, error) {
+
+	var rewardsPctBpsRule []interface{}
+	for _, rewardsPctBpsItem := range rewardsPctBps {
+		rewardsPctBpsRule = append(rewardsPctBpsRule, rewardsPctBpsItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.WatchLogs(opts, "RewardsPctBpsSet", rewardsPctBpsRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BlockrewardmanagerRewardsPctBpsSet)
+				if err := _Blockrewardmanager.contract.UnpackLog(event, "RewardsPctBpsSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardsPctBpsSet is a log parse operation binding the contract event 0xecd960b831b304435f2e2028908a05dbb70756ab3aaf9d16927526264f64cd03.
+//
+// Solidity: event RewardsPctBpsSet(uint256 indexed rewardsPctBps)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) ParseRewardsPctBpsSet(log types.Log) (*BlockrewardmanagerRewardsPctBpsSet, error) {
+	event := new(BlockrewardmanagerRewardsPctBpsSet)
+	if err := _Blockrewardmanager.contract.UnpackLog(event, "RewardsPctBpsSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BlockrewardmanagerTreasurySetIterator is returned from FilterTreasurySet and is used to iterate over the raw logs and unpacked data for TreasurySet events raised by the Blockrewardmanager contract.
+type BlockrewardmanagerTreasurySetIterator struct {
+	Event *BlockrewardmanagerTreasurySet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BlockrewardmanagerTreasurySetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BlockrewardmanagerTreasurySet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BlockrewardmanagerTreasurySet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BlockrewardmanagerTreasurySetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BlockrewardmanagerTreasurySetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BlockrewardmanagerTreasurySet represents a TreasurySet event raised by the Blockrewardmanager contract.
+type BlockrewardmanagerTreasurySet struct {
+	Treasury common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterTreasurySet is a free log retrieval operation binding the contract event 0x3c864541ef71378c6229510ed90f376565ee42d9c5e0904a984a9e863e6db44f.
+//
+// Solidity: event TreasurySet(address indexed treasury)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) FilterTreasurySet(opts *bind.FilterOpts, treasury []common.Address) (*BlockrewardmanagerTreasurySetIterator, error) {
+
+	var treasuryRule []interface{}
+	for _, treasuryItem := range treasury {
+		treasuryRule = append(treasuryRule, treasuryItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.FilterLogs(opts, "TreasurySet", treasuryRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerTreasurySetIterator{contract: _Blockrewardmanager.contract, event: "TreasurySet", logs: logs, sub: sub}, nil
+}
+
+// WatchTreasurySet is a free log subscription operation binding the contract event 0x3c864541ef71378c6229510ed90f376565ee42d9c5e0904a984a9e863e6db44f.
+//
+// Solidity: event TreasurySet(address indexed treasury)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) WatchTreasurySet(opts *bind.WatchOpts, sink chan<- *BlockrewardmanagerTreasurySet, treasury []common.Address) (event.Subscription, error) {
+
+	var treasuryRule []interface{}
+	for _, treasuryItem := range treasury {
+		treasuryRule = append(treasuryRule, treasuryItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.WatchLogs(opts, "TreasurySet", treasuryRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BlockrewardmanagerTreasurySet)
+				if err := _Blockrewardmanager.contract.UnpackLog(event, "TreasurySet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTreasurySet is a log parse operation binding the contract event 0x3c864541ef71378c6229510ed90f376565ee42d9c5e0904a984a9e863e6db44f.
+//
+// Solidity: event TreasurySet(address indexed treasury)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) ParseTreasurySet(log types.Log) (*BlockrewardmanagerTreasurySet, error) {
+	event := new(BlockrewardmanagerTreasurySet)
+	if err := _Blockrewardmanager.contract.UnpackLog(event, "TreasurySet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BlockrewardmanagerTreasuryWithdrawnIterator is returned from FilterTreasuryWithdrawn and is used to iterate over the raw logs and unpacked data for TreasuryWithdrawn events raised by the Blockrewardmanager contract.
+type BlockrewardmanagerTreasuryWithdrawnIterator struct {
+	Event *BlockrewardmanagerTreasuryWithdrawn // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BlockrewardmanagerTreasuryWithdrawnIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BlockrewardmanagerTreasuryWithdrawn)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BlockrewardmanagerTreasuryWithdrawn)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BlockrewardmanagerTreasuryWithdrawnIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BlockrewardmanagerTreasuryWithdrawnIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BlockrewardmanagerTreasuryWithdrawn represents a TreasuryWithdrawn event raised by the Blockrewardmanager contract.
+type BlockrewardmanagerTreasuryWithdrawn struct {
+	TreasuryAmt *big.Int
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterTreasuryWithdrawn is a free log retrieval operation binding the contract event 0xdcfb70a6f0f5eab41644ac0cde62fe5f51ce0bb0a53b88ea72c4b2b78ad887bc.
+//
+// Solidity: event TreasuryWithdrawn(uint256 indexed treasuryAmt)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) FilterTreasuryWithdrawn(opts *bind.FilterOpts, treasuryAmt []*big.Int) (*BlockrewardmanagerTreasuryWithdrawnIterator, error) {
+
+	var treasuryAmtRule []interface{}
+	for _, treasuryAmtItem := range treasuryAmt {
+		treasuryAmtRule = append(treasuryAmtRule, treasuryAmtItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.FilterLogs(opts, "TreasuryWithdrawn", treasuryAmtRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerTreasuryWithdrawnIterator{contract: _Blockrewardmanager.contract, event: "TreasuryWithdrawn", logs: logs, sub: sub}, nil
+}
+
+// WatchTreasuryWithdrawn is a free log subscription operation binding the contract event 0xdcfb70a6f0f5eab41644ac0cde62fe5f51ce0bb0a53b88ea72c4b2b78ad887bc.
+//
+// Solidity: event TreasuryWithdrawn(uint256 indexed treasuryAmt)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) WatchTreasuryWithdrawn(opts *bind.WatchOpts, sink chan<- *BlockrewardmanagerTreasuryWithdrawn, treasuryAmt []*big.Int) (event.Subscription, error) {
+
+	var treasuryAmtRule []interface{}
+	for _, treasuryAmtItem := range treasuryAmt {
+		treasuryAmtRule = append(treasuryAmtRule, treasuryAmtItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.WatchLogs(opts, "TreasuryWithdrawn", treasuryAmtRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BlockrewardmanagerTreasuryWithdrawn)
+				if err := _Blockrewardmanager.contract.UnpackLog(event, "TreasuryWithdrawn", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTreasuryWithdrawn is a log parse operation binding the contract event 0xdcfb70a6f0f5eab41644ac0cde62fe5f51ce0bb0a53b88ea72c4b2b78ad887bc.
+//
+// Solidity: event TreasuryWithdrawn(uint256 indexed treasuryAmt)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) ParseTreasuryWithdrawn(log types.Log) (*BlockrewardmanagerTreasuryWithdrawn, error) {
+	event := new(BlockrewardmanagerTreasuryWithdrawn)
+	if err := _Blockrewardmanager.contract.UnpackLog(event, "TreasuryWithdrawn", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BlockrewardmanagerUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the Blockrewardmanager contract.
+type BlockrewardmanagerUpgradedIterator struct {
+	Event *BlockrewardmanagerUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BlockrewardmanagerUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BlockrewardmanagerUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BlockrewardmanagerUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BlockrewardmanagerUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BlockrewardmanagerUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BlockrewardmanagerUpgraded represents a Upgraded event raised by the Blockrewardmanager contract.
+type BlockrewardmanagerUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*BlockrewardmanagerUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockrewardmanagerUpgradedIterator{contract: _Blockrewardmanager.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *BlockrewardmanagerUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _Blockrewardmanager.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BlockrewardmanagerUpgraded)
+				if err := _Blockrewardmanager.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Blockrewardmanager *BlockrewardmanagerFilterer) ParseUpgraded(log types.Log) (*BlockrewardmanagerUpgraded, error) {
+	event := new(BlockrewardmanagerUpgraded)
+	if err := _Blockrewardmanager.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts-abi/clients/RewardDistributor/RewardDistributor.go
+++ b/contracts-abi/clients/RewardDistributor/RewardDistributor.go
@@ -1,0 +1,3774 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package rewarddistributor
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IRewardDistributorDistribution is an auto generated low-level Go binding around an user-defined struct.
+type IRewardDistributorDistribution struct {
+	Operator  common.Address
+	Recipient common.Address
+	Amount    *big.Int
+}
+
+// RewarddistributorMetaData contains all meta data concerning the Rewarddistributor contract.
+var RewarddistributorMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"claimDelegate\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delegate\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"claimOnbehalfOfOperator\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"recipients\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"tokenID\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"claimRewards\",\"inputs\":[{\"name\":\"recipients\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"tokenID\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getKeyRecipient\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"pubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getPendingRewards\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"tokenID\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint128\",\"internalType\":\"uint128\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantETHRewards\",\"inputs\":[{\"name\":\"rewardList\",\"type\":\"tuple[]\",\"internalType\":\"structIRewardDistributor.Distribution[]\",\"components\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint128\",\"internalType\":\"uint128\"}]}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"grantTokenRewards\",\"inputs\":[{\"name\":\"rewardList\",\"type\":\"tuple[]\",\"internalType\":\"structIRewardDistributor.Distribution[]\",\"components\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint128\",\"internalType\":\"uint128\"}]},{\"name\":\"tokenID\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_rewardManager\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"migrateExistingRewards\",\"inputs\":[{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"tokenID\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"operatorGlobalOverride\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"operatorKeyOverrides\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"keyhash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"overrideRecipientByPubkey\",\"inputs\":[{\"name\":\"pubkeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"},{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"reclaimStipendsToOwner\",\"inputs\":[{\"name\":\"operators\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"recipients\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"tokenID\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"rewardData\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"tokenID\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"accrued\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"claimed\",\"type\":\"uint128\",\"internalType\":\"uint128\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"rewardManager\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"rewardTokens\",\"inputs\":[{\"name\":\"id\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setClaimDelegate\",\"inputs\":[{\"name\":\"delegate\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"status\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setOperatorGlobalOverride\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRewardManager\",\"inputs\":[{\"name\":\"_rewardManager\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRewardToken\",\"inputs\":[{\"name\":\"_rewardToken\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_id\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"event\",\"name\":\"ClaimDelegateSet\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"delegate\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"status\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ETHGranted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ETHRewardsClaimed\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorGlobalOverrideSet\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RecipientSet\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"pubkey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardManagerSet\",\"inputs\":[{\"name\":\"rewardManager\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardTokenSet\",\"inputs\":[{\"name\":\"rewardToken\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"tokenID\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardsBatchGranted\",\"inputs\":[{\"name\":\"tokenID\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardsMigrated\",\"inputs\":[{\"name\":\"tokenID\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"from\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint128\",\"indexed\":false,\"internalType\":\"uint128\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardsReclaimed\",\"inputs\":[{\"name\":\"tokenID\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TokenRewardsClaimed\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TokensGranted\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"AddressInsufficientBalance\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IncorrectPaymentAmount\",\"inputs\":[{\"name\":\"received\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"expected\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidBLSPubKeyLength\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidClaimDelegate\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidOperator\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReceive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidRecipient\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidRewardToken\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidTokenID\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LengthMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoClaimableRewards\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotOwnerOrRewardManager\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RewardsTransferFailed\",\"inputs\":[{\"name\":\"recipient\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]}]",
+}
+
+// RewarddistributorABI is the input ABI used to generate the binding from.
+// Deprecated: Use RewarddistributorMetaData.ABI instead.
+var RewarddistributorABI = RewarddistributorMetaData.ABI
+
+// Rewarddistributor is an auto generated Go binding around an Ethereum contract.
+type Rewarddistributor struct {
+	RewarddistributorCaller     // Read-only binding to the contract
+	RewarddistributorTransactor // Write-only binding to the contract
+	RewarddistributorFilterer   // Log filterer for contract events
+}
+
+// RewarddistributorCaller is an auto generated read-only Go binding around an Ethereum contract.
+type RewarddistributorCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RewarddistributorTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type RewarddistributorTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RewarddistributorFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type RewarddistributorFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RewarddistributorSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type RewarddistributorSession struct {
+	Contract     *Rewarddistributor // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts      // Call options to use throughout this session
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// RewarddistributorCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type RewarddistributorCallerSession struct {
+	Contract *RewarddistributorCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts            // Call options to use throughout this session
+}
+
+// RewarddistributorTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type RewarddistributorTransactorSession struct {
+	Contract     *RewarddistributorTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts            // Transaction auth options to use throughout this session
+}
+
+// RewarddistributorRaw is an auto generated low-level Go binding around an Ethereum contract.
+type RewarddistributorRaw struct {
+	Contract *Rewarddistributor // Generic contract binding to access the raw methods on
+}
+
+// RewarddistributorCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type RewarddistributorCallerRaw struct {
+	Contract *RewarddistributorCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// RewarddistributorTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type RewarddistributorTransactorRaw struct {
+	Contract *RewarddistributorTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewRewarddistributor creates a new instance of Rewarddistributor, bound to a specific deployed contract.
+func NewRewarddistributor(address common.Address, backend bind.ContractBackend) (*Rewarddistributor, error) {
+	contract, err := bindRewarddistributor(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Rewarddistributor{RewarddistributorCaller: RewarddistributorCaller{contract: contract}, RewarddistributorTransactor: RewarddistributorTransactor{contract: contract}, RewarddistributorFilterer: RewarddistributorFilterer{contract: contract}}, nil
+}
+
+// NewRewarddistributorCaller creates a new read-only instance of Rewarddistributor, bound to a specific deployed contract.
+func NewRewarddistributorCaller(address common.Address, caller bind.ContractCaller) (*RewarddistributorCaller, error) {
+	contract, err := bindRewarddistributor(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorCaller{contract: contract}, nil
+}
+
+// NewRewarddistributorTransactor creates a new write-only instance of Rewarddistributor, bound to a specific deployed contract.
+func NewRewarddistributorTransactor(address common.Address, transactor bind.ContractTransactor) (*RewarddistributorTransactor, error) {
+	contract, err := bindRewarddistributor(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorTransactor{contract: contract}, nil
+}
+
+// NewRewarddistributorFilterer creates a new log filterer instance of Rewarddistributor, bound to a specific deployed contract.
+func NewRewarddistributorFilterer(address common.Address, filterer bind.ContractFilterer) (*RewarddistributorFilterer, error) {
+	contract, err := bindRewarddistributor(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorFilterer{contract: contract}, nil
+}
+
+// bindRewarddistributor binds a generic wrapper to an already deployed contract.
+func bindRewarddistributor(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := RewarddistributorMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Rewarddistributor *RewarddistributorRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Rewarddistributor.Contract.RewarddistributorCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Rewarddistributor *RewarddistributorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.RewarddistributorTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Rewarddistributor *RewarddistributorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.RewarddistributorTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Rewarddistributor *RewarddistributorCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Rewarddistributor.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Rewarddistributor *RewarddistributorTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Rewarddistributor *RewarddistributorTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.contract.Transact(opts, method, params...)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Rewarddistributor *RewarddistributorCaller) UPGRADEINTERFACEVERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "UPGRADE_INTERFACE_VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Rewarddistributor *RewarddistributorSession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _Rewarddistributor.Contract.UPGRADEINTERFACEVERSION(&_Rewarddistributor.CallOpts)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Rewarddistributor *RewarddistributorCallerSession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _Rewarddistributor.Contract.UPGRADEINTERFACEVERSION(&_Rewarddistributor.CallOpts)
+}
+
+// ClaimDelegate is a free data retrieval call binding the contract method 0x281fe909.
+//
+// Solidity: function claimDelegate(address operator, address recipient, address delegate) view returns(bool)
+func (_Rewarddistributor *RewarddistributorCaller) ClaimDelegate(opts *bind.CallOpts, operator common.Address, recipient common.Address, delegate common.Address) (bool, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "claimDelegate", operator, recipient, delegate)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ClaimDelegate is a free data retrieval call binding the contract method 0x281fe909.
+//
+// Solidity: function claimDelegate(address operator, address recipient, address delegate) view returns(bool)
+func (_Rewarddistributor *RewarddistributorSession) ClaimDelegate(operator common.Address, recipient common.Address, delegate common.Address) (bool, error) {
+	return _Rewarddistributor.Contract.ClaimDelegate(&_Rewarddistributor.CallOpts, operator, recipient, delegate)
+}
+
+// ClaimDelegate is a free data retrieval call binding the contract method 0x281fe909.
+//
+// Solidity: function claimDelegate(address operator, address recipient, address delegate) view returns(bool)
+func (_Rewarddistributor *RewarddistributorCallerSession) ClaimDelegate(operator common.Address, recipient common.Address, delegate common.Address) (bool, error) {
+	return _Rewarddistributor.Contract.ClaimDelegate(&_Rewarddistributor.CallOpts, operator, recipient, delegate)
+}
+
+// GetKeyRecipient is a free data retrieval call binding the contract method 0xa4529e70.
+//
+// Solidity: function getKeyRecipient(address operator, bytes pubkey) view returns(address)
+func (_Rewarddistributor *RewarddistributorCaller) GetKeyRecipient(opts *bind.CallOpts, operator common.Address, pubkey []byte) (common.Address, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "getKeyRecipient", operator, pubkey)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetKeyRecipient is a free data retrieval call binding the contract method 0xa4529e70.
+//
+// Solidity: function getKeyRecipient(address operator, bytes pubkey) view returns(address)
+func (_Rewarddistributor *RewarddistributorSession) GetKeyRecipient(operator common.Address, pubkey []byte) (common.Address, error) {
+	return _Rewarddistributor.Contract.GetKeyRecipient(&_Rewarddistributor.CallOpts, operator, pubkey)
+}
+
+// GetKeyRecipient is a free data retrieval call binding the contract method 0xa4529e70.
+//
+// Solidity: function getKeyRecipient(address operator, bytes pubkey) view returns(address)
+func (_Rewarddistributor *RewarddistributorCallerSession) GetKeyRecipient(operator common.Address, pubkey []byte) (common.Address, error) {
+	return _Rewarddistributor.Contract.GetKeyRecipient(&_Rewarddistributor.CallOpts, operator, pubkey)
+}
+
+// GetPendingRewards is a free data retrieval call binding the contract method 0x32d30141.
+//
+// Solidity: function getPendingRewards(address operator, address recipient, uint256 tokenID) view returns(uint128)
+func (_Rewarddistributor *RewarddistributorCaller) GetPendingRewards(opts *bind.CallOpts, operator common.Address, recipient common.Address, tokenID *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "getPendingRewards", operator, recipient, tokenID)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetPendingRewards is a free data retrieval call binding the contract method 0x32d30141.
+//
+// Solidity: function getPendingRewards(address operator, address recipient, uint256 tokenID) view returns(uint128)
+func (_Rewarddistributor *RewarddistributorSession) GetPendingRewards(operator common.Address, recipient common.Address, tokenID *big.Int) (*big.Int, error) {
+	return _Rewarddistributor.Contract.GetPendingRewards(&_Rewarddistributor.CallOpts, operator, recipient, tokenID)
+}
+
+// GetPendingRewards is a free data retrieval call binding the contract method 0x32d30141.
+//
+// Solidity: function getPendingRewards(address operator, address recipient, uint256 tokenID) view returns(uint128)
+func (_Rewarddistributor *RewarddistributorCallerSession) GetPendingRewards(operator common.Address, recipient common.Address, tokenID *big.Int) (*big.Int, error) {
+	return _Rewarddistributor.Contract.GetPendingRewards(&_Rewarddistributor.CallOpts, operator, recipient, tokenID)
+}
+
+// OperatorGlobalOverride is a free data retrieval call binding the contract method 0x60aa8706.
+//
+// Solidity: function operatorGlobalOverride(address operator) view returns(address recipient)
+func (_Rewarddistributor *RewarddistributorCaller) OperatorGlobalOverride(opts *bind.CallOpts, operator common.Address) (common.Address, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "operatorGlobalOverride", operator)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// OperatorGlobalOverride is a free data retrieval call binding the contract method 0x60aa8706.
+//
+// Solidity: function operatorGlobalOverride(address operator) view returns(address recipient)
+func (_Rewarddistributor *RewarddistributorSession) OperatorGlobalOverride(operator common.Address) (common.Address, error) {
+	return _Rewarddistributor.Contract.OperatorGlobalOverride(&_Rewarddistributor.CallOpts, operator)
+}
+
+// OperatorGlobalOverride is a free data retrieval call binding the contract method 0x60aa8706.
+//
+// Solidity: function operatorGlobalOverride(address operator) view returns(address recipient)
+func (_Rewarddistributor *RewarddistributorCallerSession) OperatorGlobalOverride(operator common.Address) (common.Address, error) {
+	return _Rewarddistributor.Contract.OperatorGlobalOverride(&_Rewarddistributor.CallOpts, operator)
+}
+
+// OperatorKeyOverrides is a free data retrieval call binding the contract method 0x27e53420.
+//
+// Solidity: function operatorKeyOverrides(address operator, bytes32 keyhash) view returns(address recipient)
+func (_Rewarddistributor *RewarddistributorCaller) OperatorKeyOverrides(opts *bind.CallOpts, operator common.Address, keyhash [32]byte) (common.Address, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "operatorKeyOverrides", operator, keyhash)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// OperatorKeyOverrides is a free data retrieval call binding the contract method 0x27e53420.
+//
+// Solidity: function operatorKeyOverrides(address operator, bytes32 keyhash) view returns(address recipient)
+func (_Rewarddistributor *RewarddistributorSession) OperatorKeyOverrides(operator common.Address, keyhash [32]byte) (common.Address, error) {
+	return _Rewarddistributor.Contract.OperatorKeyOverrides(&_Rewarddistributor.CallOpts, operator, keyhash)
+}
+
+// OperatorKeyOverrides is a free data retrieval call binding the contract method 0x27e53420.
+//
+// Solidity: function operatorKeyOverrides(address operator, bytes32 keyhash) view returns(address recipient)
+func (_Rewarddistributor *RewarddistributorCallerSession) OperatorKeyOverrides(operator common.Address, keyhash [32]byte) (common.Address, error) {
+	return _Rewarddistributor.Contract.OperatorKeyOverrides(&_Rewarddistributor.CallOpts, operator, keyhash)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Rewarddistributor *RewarddistributorCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Rewarddistributor *RewarddistributorSession) Owner() (common.Address, error) {
+	return _Rewarddistributor.Contract.Owner(&_Rewarddistributor.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Rewarddistributor *RewarddistributorCallerSession) Owner() (common.Address, error) {
+	return _Rewarddistributor.Contract.Owner(&_Rewarddistributor.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_Rewarddistributor *RewarddistributorCaller) Paused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "paused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_Rewarddistributor *RewarddistributorSession) Paused() (bool, error) {
+	return _Rewarddistributor.Contract.Paused(&_Rewarddistributor.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_Rewarddistributor *RewarddistributorCallerSession) Paused() (bool, error) {
+	return _Rewarddistributor.Contract.Paused(&_Rewarddistributor.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Rewarddistributor *RewarddistributorCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Rewarddistributor *RewarddistributorSession) PendingOwner() (common.Address, error) {
+	return _Rewarddistributor.Contract.PendingOwner(&_Rewarddistributor.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Rewarddistributor *RewarddistributorCallerSession) PendingOwner() (common.Address, error) {
+	return _Rewarddistributor.Contract.PendingOwner(&_Rewarddistributor.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Rewarddistributor *RewarddistributorCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "proxiableUUID")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Rewarddistributor *RewarddistributorSession) ProxiableUUID() ([32]byte, error) {
+	return _Rewarddistributor.Contract.ProxiableUUID(&_Rewarddistributor.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Rewarddistributor *RewarddistributorCallerSession) ProxiableUUID() ([32]byte, error) {
+	return _Rewarddistributor.Contract.ProxiableUUID(&_Rewarddistributor.CallOpts)
+}
+
+// RewardData is a free data retrieval call binding the contract method 0x68a99ef6.
+//
+// Solidity: function rewardData(address operator, address recipient, uint256 tokenID) view returns(uint128 accrued, uint128 claimed)
+func (_Rewarddistributor *RewarddistributorCaller) RewardData(opts *bind.CallOpts, operator common.Address, recipient common.Address, tokenID *big.Int) (struct {
+	Accrued *big.Int
+	Claimed *big.Int
+}, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "rewardData", operator, recipient, tokenID)
+
+	outstruct := new(struct {
+		Accrued *big.Int
+		Claimed *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Accrued = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Claimed = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// RewardData is a free data retrieval call binding the contract method 0x68a99ef6.
+//
+// Solidity: function rewardData(address operator, address recipient, uint256 tokenID) view returns(uint128 accrued, uint128 claimed)
+func (_Rewarddistributor *RewarddistributorSession) RewardData(operator common.Address, recipient common.Address, tokenID *big.Int) (struct {
+	Accrued *big.Int
+	Claimed *big.Int
+}, error) {
+	return _Rewarddistributor.Contract.RewardData(&_Rewarddistributor.CallOpts, operator, recipient, tokenID)
+}
+
+// RewardData is a free data retrieval call binding the contract method 0x68a99ef6.
+//
+// Solidity: function rewardData(address operator, address recipient, uint256 tokenID) view returns(uint128 accrued, uint128 claimed)
+func (_Rewarddistributor *RewarddistributorCallerSession) RewardData(operator common.Address, recipient common.Address, tokenID *big.Int) (struct {
+	Accrued *big.Int
+	Claimed *big.Int
+}, error) {
+	return _Rewarddistributor.Contract.RewardData(&_Rewarddistributor.CallOpts, operator, recipient, tokenID)
+}
+
+// RewardManager is a free data retrieval call binding the contract method 0x0f4ef8a6.
+//
+// Solidity: function rewardManager() view returns(address)
+func (_Rewarddistributor *RewarddistributorCaller) RewardManager(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "rewardManager")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// RewardManager is a free data retrieval call binding the contract method 0x0f4ef8a6.
+//
+// Solidity: function rewardManager() view returns(address)
+func (_Rewarddistributor *RewarddistributorSession) RewardManager() (common.Address, error) {
+	return _Rewarddistributor.Contract.RewardManager(&_Rewarddistributor.CallOpts)
+}
+
+// RewardManager is a free data retrieval call binding the contract method 0x0f4ef8a6.
+//
+// Solidity: function rewardManager() view returns(address)
+func (_Rewarddistributor *RewarddistributorCallerSession) RewardManager() (common.Address, error) {
+	return _Rewarddistributor.Contract.RewardManager(&_Rewarddistributor.CallOpts)
+}
+
+// RewardTokens is a free data retrieval call binding the contract method 0x7bb7bed1.
+//
+// Solidity: function rewardTokens(uint256 id) view returns(address token)
+func (_Rewarddistributor *RewarddistributorCaller) RewardTokens(opts *bind.CallOpts, id *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _Rewarddistributor.contract.Call(opts, &out, "rewardTokens", id)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// RewardTokens is a free data retrieval call binding the contract method 0x7bb7bed1.
+//
+// Solidity: function rewardTokens(uint256 id) view returns(address token)
+func (_Rewarddistributor *RewarddistributorSession) RewardTokens(id *big.Int) (common.Address, error) {
+	return _Rewarddistributor.Contract.RewardTokens(&_Rewarddistributor.CallOpts, id)
+}
+
+// RewardTokens is a free data retrieval call binding the contract method 0x7bb7bed1.
+//
+// Solidity: function rewardTokens(uint256 id) view returns(address token)
+func (_Rewarddistributor *RewarddistributorCallerSession) RewardTokens(id *big.Int) (common.Address, error) {
+	return _Rewarddistributor.Contract.RewardTokens(&_Rewarddistributor.CallOpts, id)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Rewarddistributor *RewarddistributorTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Rewarddistributor *RewarddistributorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.AcceptOwnership(&_Rewarddistributor.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.AcceptOwnership(&_Rewarddistributor.TransactOpts)
+}
+
+// ClaimOnbehalfOfOperator is a paid mutator transaction binding the contract method 0x61714a3b.
+//
+// Solidity: function claimOnbehalfOfOperator(address operator, address[] recipients, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) ClaimOnbehalfOfOperator(opts *bind.TransactOpts, operator common.Address, recipients []common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "claimOnbehalfOfOperator", operator, recipients, tokenID)
+}
+
+// ClaimOnbehalfOfOperator is a paid mutator transaction binding the contract method 0x61714a3b.
+//
+// Solidity: function claimOnbehalfOfOperator(address operator, address[] recipients, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorSession) ClaimOnbehalfOfOperator(operator common.Address, recipients []common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.ClaimOnbehalfOfOperator(&_Rewarddistributor.TransactOpts, operator, recipients, tokenID)
+}
+
+// ClaimOnbehalfOfOperator is a paid mutator transaction binding the contract method 0x61714a3b.
+//
+// Solidity: function claimOnbehalfOfOperator(address operator, address[] recipients, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) ClaimOnbehalfOfOperator(operator common.Address, recipients []common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.ClaimOnbehalfOfOperator(&_Rewarddistributor.TransactOpts, operator, recipients, tokenID)
+}
+
+// ClaimRewards is a paid mutator transaction binding the contract method 0xfad66604.
+//
+// Solidity: function claimRewards(address[] recipients, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) ClaimRewards(opts *bind.TransactOpts, recipients []common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "claimRewards", recipients, tokenID)
+}
+
+// ClaimRewards is a paid mutator transaction binding the contract method 0xfad66604.
+//
+// Solidity: function claimRewards(address[] recipients, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorSession) ClaimRewards(recipients []common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.ClaimRewards(&_Rewarddistributor.TransactOpts, recipients, tokenID)
+}
+
+// ClaimRewards is a paid mutator transaction binding the contract method 0xfad66604.
+//
+// Solidity: function claimRewards(address[] recipients, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) ClaimRewards(recipients []common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.ClaimRewards(&_Rewarddistributor.TransactOpts, recipients, tokenID)
+}
+
+// GrantETHRewards is a paid mutator transaction binding the contract method 0xa990eff1.
+//
+// Solidity: function grantETHRewards((address,address,uint128)[] rewardList) payable returns()
+func (_Rewarddistributor *RewarddistributorTransactor) GrantETHRewards(opts *bind.TransactOpts, rewardList []IRewardDistributorDistribution) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "grantETHRewards", rewardList)
+}
+
+// GrantETHRewards is a paid mutator transaction binding the contract method 0xa990eff1.
+//
+// Solidity: function grantETHRewards((address,address,uint128)[] rewardList) payable returns()
+func (_Rewarddistributor *RewarddistributorSession) GrantETHRewards(rewardList []IRewardDistributorDistribution) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.GrantETHRewards(&_Rewarddistributor.TransactOpts, rewardList)
+}
+
+// GrantETHRewards is a paid mutator transaction binding the contract method 0xa990eff1.
+//
+// Solidity: function grantETHRewards((address,address,uint128)[] rewardList) payable returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) GrantETHRewards(rewardList []IRewardDistributorDistribution) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.GrantETHRewards(&_Rewarddistributor.TransactOpts, rewardList)
+}
+
+// GrantTokenRewards is a paid mutator transaction binding the contract method 0x9bf6c9f5.
+//
+// Solidity: function grantTokenRewards((address,address,uint128)[] rewardList, uint256 tokenID) payable returns()
+func (_Rewarddistributor *RewarddistributorTransactor) GrantTokenRewards(opts *bind.TransactOpts, rewardList []IRewardDistributorDistribution, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "grantTokenRewards", rewardList, tokenID)
+}
+
+// GrantTokenRewards is a paid mutator transaction binding the contract method 0x9bf6c9f5.
+//
+// Solidity: function grantTokenRewards((address,address,uint128)[] rewardList, uint256 tokenID) payable returns()
+func (_Rewarddistributor *RewarddistributorSession) GrantTokenRewards(rewardList []IRewardDistributorDistribution, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.GrantTokenRewards(&_Rewarddistributor.TransactOpts, rewardList, tokenID)
+}
+
+// GrantTokenRewards is a paid mutator transaction binding the contract method 0x9bf6c9f5.
+//
+// Solidity: function grantTokenRewards((address,address,uint128)[] rewardList, uint256 tokenID) payable returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) GrantTokenRewards(rewardList []IRewardDistributorDistribution, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.GrantTokenRewards(&_Rewarddistributor.TransactOpts, rewardList, tokenID)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x485cc955.
+//
+// Solidity: function initialize(address _owner, address _rewardManager) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) Initialize(opts *bind.TransactOpts, _owner common.Address, _rewardManager common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "initialize", _owner, _rewardManager)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x485cc955.
+//
+// Solidity: function initialize(address _owner, address _rewardManager) returns()
+func (_Rewarddistributor *RewarddistributorSession) Initialize(_owner common.Address, _rewardManager common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.Initialize(&_Rewarddistributor.TransactOpts, _owner, _rewardManager)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x485cc955.
+//
+// Solidity: function initialize(address _owner, address _rewardManager) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) Initialize(_owner common.Address, _rewardManager common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.Initialize(&_Rewarddistributor.TransactOpts, _owner, _rewardManager)
+}
+
+// MigrateExistingRewards is a paid mutator transaction binding the contract method 0x4c7bf229.
+//
+// Solidity: function migrateExistingRewards(address from, address to, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) MigrateExistingRewards(opts *bind.TransactOpts, from common.Address, to common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "migrateExistingRewards", from, to, tokenID)
+}
+
+// MigrateExistingRewards is a paid mutator transaction binding the contract method 0x4c7bf229.
+//
+// Solidity: function migrateExistingRewards(address from, address to, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorSession) MigrateExistingRewards(from common.Address, to common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.MigrateExistingRewards(&_Rewarddistributor.TransactOpts, from, to, tokenID)
+}
+
+// MigrateExistingRewards is a paid mutator transaction binding the contract method 0x4c7bf229.
+//
+// Solidity: function migrateExistingRewards(address from, address to, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) MigrateExistingRewards(from common.Address, to common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.MigrateExistingRewards(&_Rewarddistributor.TransactOpts, from, to, tokenID)
+}
+
+// OverrideRecipientByPubkey is a paid mutator transaction binding the contract method 0xd5a2693e.
+//
+// Solidity: function overrideRecipientByPubkey(bytes[] pubkeys, address recipient) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) OverrideRecipientByPubkey(opts *bind.TransactOpts, pubkeys [][]byte, recipient common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "overrideRecipientByPubkey", pubkeys, recipient)
+}
+
+// OverrideRecipientByPubkey is a paid mutator transaction binding the contract method 0xd5a2693e.
+//
+// Solidity: function overrideRecipientByPubkey(bytes[] pubkeys, address recipient) returns()
+func (_Rewarddistributor *RewarddistributorSession) OverrideRecipientByPubkey(pubkeys [][]byte, recipient common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.OverrideRecipientByPubkey(&_Rewarddistributor.TransactOpts, pubkeys, recipient)
+}
+
+// OverrideRecipientByPubkey is a paid mutator transaction binding the contract method 0xd5a2693e.
+//
+// Solidity: function overrideRecipientByPubkey(bytes[] pubkeys, address recipient) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) OverrideRecipientByPubkey(pubkeys [][]byte, recipient common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.OverrideRecipientByPubkey(&_Rewarddistributor.TransactOpts, pubkeys, recipient)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_Rewarddistributor *RewarddistributorTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "pause")
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_Rewarddistributor *RewarddistributorSession) Pause() (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.Pause(&_Rewarddistributor.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) Pause() (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.Pause(&_Rewarddistributor.TransactOpts)
+}
+
+// ReclaimStipendsToOwner is a paid mutator transaction binding the contract method 0xcfb9a4f9.
+//
+// Solidity: function reclaimStipendsToOwner(address[] operators, address[] recipients, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) ReclaimStipendsToOwner(opts *bind.TransactOpts, operators []common.Address, recipients []common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "reclaimStipendsToOwner", operators, recipients, tokenID)
+}
+
+// ReclaimStipendsToOwner is a paid mutator transaction binding the contract method 0xcfb9a4f9.
+//
+// Solidity: function reclaimStipendsToOwner(address[] operators, address[] recipients, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorSession) ReclaimStipendsToOwner(operators []common.Address, recipients []common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.ReclaimStipendsToOwner(&_Rewarddistributor.TransactOpts, operators, recipients, tokenID)
+}
+
+// ReclaimStipendsToOwner is a paid mutator transaction binding the contract method 0xcfb9a4f9.
+//
+// Solidity: function reclaimStipendsToOwner(address[] operators, address[] recipients, uint256 tokenID) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) ReclaimStipendsToOwner(operators []common.Address, recipients []common.Address, tokenID *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.ReclaimStipendsToOwner(&_Rewarddistributor.TransactOpts, operators, recipients, tokenID)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Rewarddistributor *RewarddistributorTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Rewarddistributor *RewarddistributorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.RenounceOwnership(&_Rewarddistributor.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.RenounceOwnership(&_Rewarddistributor.TransactOpts)
+}
+
+// SetClaimDelegate is a paid mutator transaction binding the contract method 0x537d22fe.
+//
+// Solidity: function setClaimDelegate(address delegate, address recipient, bool status) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) SetClaimDelegate(opts *bind.TransactOpts, delegate common.Address, recipient common.Address, status bool) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "setClaimDelegate", delegate, recipient, status)
+}
+
+// SetClaimDelegate is a paid mutator transaction binding the contract method 0x537d22fe.
+//
+// Solidity: function setClaimDelegate(address delegate, address recipient, bool status) returns()
+func (_Rewarddistributor *RewarddistributorSession) SetClaimDelegate(delegate common.Address, recipient common.Address, status bool) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.SetClaimDelegate(&_Rewarddistributor.TransactOpts, delegate, recipient, status)
+}
+
+// SetClaimDelegate is a paid mutator transaction binding the contract method 0x537d22fe.
+//
+// Solidity: function setClaimDelegate(address delegate, address recipient, bool status) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) SetClaimDelegate(delegate common.Address, recipient common.Address, status bool) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.SetClaimDelegate(&_Rewarddistributor.TransactOpts, delegate, recipient, status)
+}
+
+// SetOperatorGlobalOverride is a paid mutator transaction binding the contract method 0x86ee57b7.
+//
+// Solidity: function setOperatorGlobalOverride(address recipient) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) SetOperatorGlobalOverride(opts *bind.TransactOpts, recipient common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "setOperatorGlobalOverride", recipient)
+}
+
+// SetOperatorGlobalOverride is a paid mutator transaction binding the contract method 0x86ee57b7.
+//
+// Solidity: function setOperatorGlobalOverride(address recipient) returns()
+func (_Rewarddistributor *RewarddistributorSession) SetOperatorGlobalOverride(recipient common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.SetOperatorGlobalOverride(&_Rewarddistributor.TransactOpts, recipient)
+}
+
+// SetOperatorGlobalOverride is a paid mutator transaction binding the contract method 0x86ee57b7.
+//
+// Solidity: function setOperatorGlobalOverride(address recipient) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) SetOperatorGlobalOverride(recipient common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.SetOperatorGlobalOverride(&_Rewarddistributor.TransactOpts, recipient)
+}
+
+// SetRewardManager is a paid mutator transaction binding the contract method 0x153ee554.
+//
+// Solidity: function setRewardManager(address _rewardManager) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) SetRewardManager(opts *bind.TransactOpts, _rewardManager common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "setRewardManager", _rewardManager)
+}
+
+// SetRewardManager is a paid mutator transaction binding the contract method 0x153ee554.
+//
+// Solidity: function setRewardManager(address _rewardManager) returns()
+func (_Rewarddistributor *RewarddistributorSession) SetRewardManager(_rewardManager common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.SetRewardManager(&_Rewarddistributor.TransactOpts, _rewardManager)
+}
+
+// SetRewardManager is a paid mutator transaction binding the contract method 0x153ee554.
+//
+// Solidity: function setRewardManager(address _rewardManager) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) SetRewardManager(_rewardManager common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.SetRewardManager(&_Rewarddistributor.TransactOpts, _rewardManager)
+}
+
+// SetRewardToken is a paid mutator transaction binding the contract method 0xf77a3fb9.
+//
+// Solidity: function setRewardToken(address _rewardToken, uint256 _id) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) SetRewardToken(opts *bind.TransactOpts, _rewardToken common.Address, _id *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "setRewardToken", _rewardToken, _id)
+}
+
+// SetRewardToken is a paid mutator transaction binding the contract method 0xf77a3fb9.
+//
+// Solidity: function setRewardToken(address _rewardToken, uint256 _id) returns()
+func (_Rewarddistributor *RewarddistributorSession) SetRewardToken(_rewardToken common.Address, _id *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.SetRewardToken(&_Rewarddistributor.TransactOpts, _rewardToken, _id)
+}
+
+// SetRewardToken is a paid mutator transaction binding the contract method 0xf77a3fb9.
+//
+// Solidity: function setRewardToken(address _rewardToken, uint256 _id) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) SetRewardToken(_rewardToken common.Address, _id *big.Int) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.SetRewardToken(&_Rewarddistributor.TransactOpts, _rewardToken, _id)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Rewarddistributor *RewarddistributorTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Rewarddistributor *RewarddistributorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.TransferOwnership(&_Rewarddistributor.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.TransferOwnership(&_Rewarddistributor.TransactOpts, newOwner)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_Rewarddistributor *RewarddistributorTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "unpause")
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_Rewarddistributor *RewarddistributorSession) Unpause() (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.Unpause(&_Rewarddistributor.TransactOpts)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) Unpause() (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.Unpause(&_Rewarddistributor.TransactOpts)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Rewarddistributor *RewarddistributorTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Rewarddistributor *RewarddistributorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.UpgradeToAndCall(&_Rewarddistributor.TransactOpts, newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.UpgradeToAndCall(&_Rewarddistributor.TransactOpts, newImplementation, data)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Rewarddistributor *RewarddistributorTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.RawTransact(opts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Rewarddistributor *RewarddistributorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.Fallback(&_Rewarddistributor.TransactOpts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.Fallback(&_Rewarddistributor.TransactOpts, calldata)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Rewarddistributor *RewarddistributorTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rewarddistributor.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Rewarddistributor *RewarddistributorSession) Receive() (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.Receive(&_Rewarddistributor.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Rewarddistributor *RewarddistributorTransactorSession) Receive() (*types.Transaction, error) {
+	return _Rewarddistributor.Contract.Receive(&_Rewarddistributor.TransactOpts)
+}
+
+// RewarddistributorClaimDelegateSetIterator is returned from FilterClaimDelegateSet and is used to iterate over the raw logs and unpacked data for ClaimDelegateSet events raised by the Rewarddistributor contract.
+type RewarddistributorClaimDelegateSetIterator struct {
+	Event *RewarddistributorClaimDelegateSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorClaimDelegateSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorClaimDelegateSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorClaimDelegateSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorClaimDelegateSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorClaimDelegateSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorClaimDelegateSet represents a ClaimDelegateSet event raised by the Rewarddistributor contract.
+type RewarddistributorClaimDelegateSet struct {
+	Operator  common.Address
+	Recipient common.Address
+	Delegate  common.Address
+	Status    bool
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterClaimDelegateSet is a free log retrieval operation binding the contract event 0x678890bc989aa73fd3b36ff01efad3e0a551d088550af66284a3b876cafc1fd2.
+//
+// Solidity: event ClaimDelegateSet(address indexed operator, address indexed recipient, address indexed delegate, bool status)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterClaimDelegateSet(opts *bind.FilterOpts, operator []common.Address, recipient []common.Address, delegate []common.Address) (*RewarddistributorClaimDelegateSetIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+	var delegateRule []interface{}
+	for _, delegateItem := range delegate {
+		delegateRule = append(delegateRule, delegateItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "ClaimDelegateSet", operatorRule, recipientRule, delegateRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorClaimDelegateSetIterator{contract: _Rewarddistributor.contract, event: "ClaimDelegateSet", logs: logs, sub: sub}, nil
+}
+
+// WatchClaimDelegateSet is a free log subscription operation binding the contract event 0x678890bc989aa73fd3b36ff01efad3e0a551d088550af66284a3b876cafc1fd2.
+//
+// Solidity: event ClaimDelegateSet(address indexed operator, address indexed recipient, address indexed delegate, bool status)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchClaimDelegateSet(opts *bind.WatchOpts, sink chan<- *RewarddistributorClaimDelegateSet, operator []common.Address, recipient []common.Address, delegate []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+	var delegateRule []interface{}
+	for _, delegateItem := range delegate {
+		delegateRule = append(delegateRule, delegateItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "ClaimDelegateSet", operatorRule, recipientRule, delegateRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorClaimDelegateSet)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "ClaimDelegateSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseClaimDelegateSet is a log parse operation binding the contract event 0x678890bc989aa73fd3b36ff01efad3e0a551d088550af66284a3b876cafc1fd2.
+//
+// Solidity: event ClaimDelegateSet(address indexed operator, address indexed recipient, address indexed delegate, bool status)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseClaimDelegateSet(log types.Log) (*RewarddistributorClaimDelegateSet, error) {
+	event := new(RewarddistributorClaimDelegateSet)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "ClaimDelegateSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorETHGrantedIterator is returned from FilterETHGranted and is used to iterate over the raw logs and unpacked data for ETHGranted events raised by the Rewarddistributor contract.
+type RewarddistributorETHGrantedIterator struct {
+	Event *RewarddistributorETHGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorETHGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorETHGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorETHGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorETHGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorETHGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorETHGranted represents a ETHGranted event raised by the Rewarddistributor contract.
+type RewarddistributorETHGranted struct {
+	Operator  common.Address
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterETHGranted is a free log retrieval operation binding the contract event 0x4633f6e8264d8c05cba97be33e0f1eaae97dbf81597c4da193d52da4b7b4d1f1.
+//
+// Solidity: event ETHGranted(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterETHGranted(opts *bind.FilterOpts, operator []common.Address, recipient []common.Address, amount []*big.Int) (*RewarddistributorETHGrantedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "ETHGranted", operatorRule, recipientRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorETHGrantedIterator{contract: _Rewarddistributor.contract, event: "ETHGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchETHGranted is a free log subscription operation binding the contract event 0x4633f6e8264d8c05cba97be33e0f1eaae97dbf81597c4da193d52da4b7b4d1f1.
+//
+// Solidity: event ETHGranted(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchETHGranted(opts *bind.WatchOpts, sink chan<- *RewarddistributorETHGranted, operator []common.Address, recipient []common.Address, amount []*big.Int) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "ETHGranted", operatorRule, recipientRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorETHGranted)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "ETHGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseETHGranted is a log parse operation binding the contract event 0x4633f6e8264d8c05cba97be33e0f1eaae97dbf81597c4da193d52da4b7b4d1f1.
+//
+// Solidity: event ETHGranted(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseETHGranted(log types.Log) (*RewarddistributorETHGranted, error) {
+	event := new(RewarddistributorETHGranted)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "ETHGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorETHRewardsClaimedIterator is returned from FilterETHRewardsClaimed and is used to iterate over the raw logs and unpacked data for ETHRewardsClaimed events raised by the Rewarddistributor contract.
+type RewarddistributorETHRewardsClaimedIterator struct {
+	Event *RewarddistributorETHRewardsClaimed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorETHRewardsClaimedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorETHRewardsClaimed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorETHRewardsClaimed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorETHRewardsClaimedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorETHRewardsClaimedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorETHRewardsClaimed represents a ETHRewardsClaimed event raised by the Rewarddistributor contract.
+type RewarddistributorETHRewardsClaimed struct {
+	Operator  common.Address
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterETHRewardsClaimed is a free log retrieval operation binding the contract event 0xd74da12fa2c485462374064b211802914920859a34df550f95c1c5d5f811fe42.
+//
+// Solidity: event ETHRewardsClaimed(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterETHRewardsClaimed(opts *bind.FilterOpts, operator []common.Address, recipient []common.Address, amount []*big.Int) (*RewarddistributorETHRewardsClaimedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "ETHRewardsClaimed", operatorRule, recipientRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorETHRewardsClaimedIterator{contract: _Rewarddistributor.contract, event: "ETHRewardsClaimed", logs: logs, sub: sub}, nil
+}
+
+// WatchETHRewardsClaimed is a free log subscription operation binding the contract event 0xd74da12fa2c485462374064b211802914920859a34df550f95c1c5d5f811fe42.
+//
+// Solidity: event ETHRewardsClaimed(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchETHRewardsClaimed(opts *bind.WatchOpts, sink chan<- *RewarddistributorETHRewardsClaimed, operator []common.Address, recipient []common.Address, amount []*big.Int) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "ETHRewardsClaimed", operatorRule, recipientRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorETHRewardsClaimed)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "ETHRewardsClaimed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseETHRewardsClaimed is a log parse operation binding the contract event 0xd74da12fa2c485462374064b211802914920859a34df550f95c1c5d5f811fe42.
+//
+// Solidity: event ETHRewardsClaimed(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseETHRewardsClaimed(log types.Log) (*RewarddistributorETHRewardsClaimed, error) {
+	event := new(RewarddistributorETHRewardsClaimed)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "ETHRewardsClaimed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Rewarddistributor contract.
+type RewarddistributorInitializedIterator struct {
+	Event *RewarddistributorInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorInitialized represents a Initialized event raised by the Rewarddistributor contract.
+type RewarddistributorInitialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterInitialized(opts *bind.FilterOpts) (*RewarddistributorInitializedIterator, error) {
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorInitializedIterator{contract: _Rewarddistributor.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *RewarddistributorInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorInitialized)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseInitialized(log types.Log) (*RewarddistributorInitialized, error) {
+	event := new(RewarddistributorInitialized)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorOperatorGlobalOverrideSetIterator is returned from FilterOperatorGlobalOverrideSet and is used to iterate over the raw logs and unpacked data for OperatorGlobalOverrideSet events raised by the Rewarddistributor contract.
+type RewarddistributorOperatorGlobalOverrideSetIterator struct {
+	Event *RewarddistributorOperatorGlobalOverrideSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorOperatorGlobalOverrideSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorOperatorGlobalOverrideSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorOperatorGlobalOverrideSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorOperatorGlobalOverrideSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorOperatorGlobalOverrideSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorOperatorGlobalOverrideSet represents a OperatorGlobalOverrideSet event raised by the Rewarddistributor contract.
+type RewarddistributorOperatorGlobalOverrideSet struct {
+	Operator  common.Address
+	Recipient common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorGlobalOverrideSet is a free log retrieval operation binding the contract event 0x8fd2f6227c705a2e4c9af87a9c9e974f7c2b5c124ce9f4c418881e2de432f41f.
+//
+// Solidity: event OperatorGlobalOverrideSet(address indexed operator, address indexed recipient)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterOperatorGlobalOverrideSet(opts *bind.FilterOpts, operator []common.Address, recipient []common.Address) (*RewarddistributorOperatorGlobalOverrideSetIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "OperatorGlobalOverrideSet", operatorRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorOperatorGlobalOverrideSetIterator{contract: _Rewarddistributor.contract, event: "OperatorGlobalOverrideSet", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorGlobalOverrideSet is a free log subscription operation binding the contract event 0x8fd2f6227c705a2e4c9af87a9c9e974f7c2b5c124ce9f4c418881e2de432f41f.
+//
+// Solidity: event OperatorGlobalOverrideSet(address indexed operator, address indexed recipient)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchOperatorGlobalOverrideSet(opts *bind.WatchOpts, sink chan<- *RewarddistributorOperatorGlobalOverrideSet, operator []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "OperatorGlobalOverrideSet", operatorRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorOperatorGlobalOverrideSet)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "OperatorGlobalOverrideSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorGlobalOverrideSet is a log parse operation binding the contract event 0x8fd2f6227c705a2e4c9af87a9c9e974f7c2b5c124ce9f4c418881e2de432f41f.
+//
+// Solidity: event OperatorGlobalOverrideSet(address indexed operator, address indexed recipient)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseOperatorGlobalOverrideSet(log types.Log) (*RewarddistributorOperatorGlobalOverrideSet, error) {
+	event := new(RewarddistributorOperatorGlobalOverrideSet)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "OperatorGlobalOverrideSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the Rewarddistributor contract.
+type RewarddistributorOwnershipTransferStartedIterator struct {
+	Event *RewarddistributorOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the Rewarddistributor contract.
+type RewarddistributorOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*RewarddistributorOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorOwnershipTransferStartedIterator{contract: _Rewarddistributor.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *RewarddistributorOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorOwnershipTransferStarted)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseOwnershipTransferStarted(log types.Log) (*RewarddistributorOwnershipTransferStarted, error) {
+	event := new(RewarddistributorOwnershipTransferStarted)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Rewarddistributor contract.
+type RewarddistributorOwnershipTransferredIterator struct {
+	Event *RewarddistributorOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorOwnershipTransferred represents a OwnershipTransferred event raised by the Rewarddistributor contract.
+type RewarddistributorOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*RewarddistributorOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorOwnershipTransferredIterator{contract: _Rewarddistributor.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *RewarddistributorOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorOwnershipTransferred)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseOwnershipTransferred(log types.Log) (*RewarddistributorOwnershipTransferred, error) {
+	event := new(RewarddistributorOwnershipTransferred)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the Rewarddistributor contract.
+type RewarddistributorPausedIterator struct {
+	Event *RewarddistributorPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorPaused represents a Paused event raised by the Rewarddistributor contract.
+type RewarddistributorPaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterPaused(opts *bind.FilterOpts) (*RewarddistributorPausedIterator, error) {
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorPausedIterator{contract: _Rewarddistributor.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *RewarddistributorPaused) (event.Subscription, error) {
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorPaused)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_Rewarddistributor *RewarddistributorFilterer) ParsePaused(log types.Log) (*RewarddistributorPaused, error) {
+	event := new(RewarddistributorPaused)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorRecipientSetIterator is returned from FilterRecipientSet and is used to iterate over the raw logs and unpacked data for RecipientSet events raised by the Rewarddistributor contract.
+type RewarddistributorRecipientSetIterator struct {
+	Event *RewarddistributorRecipientSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorRecipientSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorRecipientSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorRecipientSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorRecipientSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorRecipientSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorRecipientSet represents a RecipientSet event raised by the Rewarddistributor contract.
+type RewarddistributorRecipientSet struct {
+	Operator  common.Address
+	Pubkey    []byte
+	Recipient common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterRecipientSet is a free log retrieval operation binding the contract event 0xdd1c6108b84f1dfef6f5b45484370f1a270fad78f335e45b376a351f489b5460.
+//
+// Solidity: event RecipientSet(address indexed operator, bytes pubkey, address indexed recipient)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterRecipientSet(opts *bind.FilterOpts, operator []common.Address, recipient []common.Address) (*RewarddistributorRecipientSetIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "RecipientSet", operatorRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorRecipientSetIterator{contract: _Rewarddistributor.contract, event: "RecipientSet", logs: logs, sub: sub}, nil
+}
+
+// WatchRecipientSet is a free log subscription operation binding the contract event 0xdd1c6108b84f1dfef6f5b45484370f1a270fad78f335e45b376a351f489b5460.
+//
+// Solidity: event RecipientSet(address indexed operator, bytes pubkey, address indexed recipient)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchRecipientSet(opts *bind.WatchOpts, sink chan<- *RewarddistributorRecipientSet, operator []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "RecipientSet", operatorRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorRecipientSet)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "RecipientSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRecipientSet is a log parse operation binding the contract event 0xdd1c6108b84f1dfef6f5b45484370f1a270fad78f335e45b376a351f489b5460.
+//
+// Solidity: event RecipientSet(address indexed operator, bytes pubkey, address indexed recipient)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseRecipientSet(log types.Log) (*RewarddistributorRecipientSet, error) {
+	event := new(RewarddistributorRecipientSet)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "RecipientSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorRewardManagerSetIterator is returned from FilterRewardManagerSet and is used to iterate over the raw logs and unpacked data for RewardManagerSet events raised by the Rewarddistributor contract.
+type RewarddistributorRewardManagerSetIterator struct {
+	Event *RewarddistributorRewardManagerSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorRewardManagerSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorRewardManagerSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorRewardManagerSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorRewardManagerSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorRewardManagerSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorRewardManagerSet represents a RewardManagerSet event raised by the Rewarddistributor contract.
+type RewarddistributorRewardManagerSet struct {
+	RewardManager common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardManagerSet is a free log retrieval operation binding the contract event 0x4b722357462a92ae2776fce05f39902ac96cb04d2fe661eb688f4a72ab069cff.
+//
+// Solidity: event RewardManagerSet(address indexed rewardManager)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterRewardManagerSet(opts *bind.FilterOpts, rewardManager []common.Address) (*RewarddistributorRewardManagerSetIterator, error) {
+
+	var rewardManagerRule []interface{}
+	for _, rewardManagerItem := range rewardManager {
+		rewardManagerRule = append(rewardManagerRule, rewardManagerItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "RewardManagerSet", rewardManagerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorRewardManagerSetIterator{contract: _Rewarddistributor.contract, event: "RewardManagerSet", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardManagerSet is a free log subscription operation binding the contract event 0x4b722357462a92ae2776fce05f39902ac96cb04d2fe661eb688f4a72ab069cff.
+//
+// Solidity: event RewardManagerSet(address indexed rewardManager)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchRewardManagerSet(opts *bind.WatchOpts, sink chan<- *RewarddistributorRewardManagerSet, rewardManager []common.Address) (event.Subscription, error) {
+
+	var rewardManagerRule []interface{}
+	for _, rewardManagerItem := range rewardManager {
+		rewardManagerRule = append(rewardManagerRule, rewardManagerItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "RewardManagerSet", rewardManagerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorRewardManagerSet)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "RewardManagerSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardManagerSet is a log parse operation binding the contract event 0x4b722357462a92ae2776fce05f39902ac96cb04d2fe661eb688f4a72ab069cff.
+//
+// Solidity: event RewardManagerSet(address indexed rewardManager)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseRewardManagerSet(log types.Log) (*RewarddistributorRewardManagerSet, error) {
+	event := new(RewarddistributorRewardManagerSet)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "RewardManagerSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorRewardTokenSetIterator is returned from FilterRewardTokenSet and is used to iterate over the raw logs and unpacked data for RewardTokenSet events raised by the Rewarddistributor contract.
+type RewarddistributorRewardTokenSetIterator struct {
+	Event *RewarddistributorRewardTokenSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorRewardTokenSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorRewardTokenSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorRewardTokenSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorRewardTokenSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorRewardTokenSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorRewardTokenSet represents a RewardTokenSet event raised by the Rewarddistributor contract.
+type RewarddistributorRewardTokenSet struct {
+	RewardToken common.Address
+	TokenID     *big.Int
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardTokenSet is a free log retrieval operation binding the contract event 0x699da1ad32a331acc89644abfd5a2d9960170bd81cde59bda93fe7f53d3c1f31.
+//
+// Solidity: event RewardTokenSet(address indexed rewardToken, uint256 indexed tokenID)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterRewardTokenSet(opts *bind.FilterOpts, rewardToken []common.Address, tokenID []*big.Int) (*RewarddistributorRewardTokenSetIterator, error) {
+
+	var rewardTokenRule []interface{}
+	for _, rewardTokenItem := range rewardToken {
+		rewardTokenRule = append(rewardTokenRule, rewardTokenItem)
+	}
+	var tokenIDRule []interface{}
+	for _, tokenIDItem := range tokenID {
+		tokenIDRule = append(tokenIDRule, tokenIDItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "RewardTokenSet", rewardTokenRule, tokenIDRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorRewardTokenSetIterator{contract: _Rewarddistributor.contract, event: "RewardTokenSet", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardTokenSet is a free log subscription operation binding the contract event 0x699da1ad32a331acc89644abfd5a2d9960170bd81cde59bda93fe7f53d3c1f31.
+//
+// Solidity: event RewardTokenSet(address indexed rewardToken, uint256 indexed tokenID)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchRewardTokenSet(opts *bind.WatchOpts, sink chan<- *RewarddistributorRewardTokenSet, rewardToken []common.Address, tokenID []*big.Int) (event.Subscription, error) {
+
+	var rewardTokenRule []interface{}
+	for _, rewardTokenItem := range rewardToken {
+		rewardTokenRule = append(rewardTokenRule, rewardTokenItem)
+	}
+	var tokenIDRule []interface{}
+	for _, tokenIDItem := range tokenID {
+		tokenIDRule = append(tokenIDRule, tokenIDItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "RewardTokenSet", rewardTokenRule, tokenIDRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorRewardTokenSet)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "RewardTokenSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardTokenSet is a log parse operation binding the contract event 0x699da1ad32a331acc89644abfd5a2d9960170bd81cde59bda93fe7f53d3c1f31.
+//
+// Solidity: event RewardTokenSet(address indexed rewardToken, uint256 indexed tokenID)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseRewardTokenSet(log types.Log) (*RewarddistributorRewardTokenSet, error) {
+	event := new(RewarddistributorRewardTokenSet)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "RewardTokenSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorRewardsBatchGrantedIterator is returned from FilterRewardsBatchGranted and is used to iterate over the raw logs and unpacked data for RewardsBatchGranted events raised by the Rewarddistributor contract.
+type RewarddistributorRewardsBatchGrantedIterator struct {
+	Event *RewarddistributorRewardsBatchGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorRewardsBatchGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorRewardsBatchGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorRewardsBatchGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorRewardsBatchGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorRewardsBatchGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorRewardsBatchGranted represents a RewardsBatchGranted event raised by the Rewarddistributor contract.
+type RewarddistributorRewardsBatchGranted struct {
+	TokenID *big.Int
+	Amount  *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardsBatchGranted is a free log retrieval operation binding the contract event 0x5a560578c2a2576a22870a295e55da0d824316461ca74857c685b7ab72391658.
+//
+// Solidity: event RewardsBatchGranted(uint256 indexed tokenID, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterRewardsBatchGranted(opts *bind.FilterOpts, tokenID []*big.Int, amount []*big.Int) (*RewarddistributorRewardsBatchGrantedIterator, error) {
+
+	var tokenIDRule []interface{}
+	for _, tokenIDItem := range tokenID {
+		tokenIDRule = append(tokenIDRule, tokenIDItem)
+	}
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "RewardsBatchGranted", tokenIDRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorRewardsBatchGrantedIterator{contract: _Rewarddistributor.contract, event: "RewardsBatchGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardsBatchGranted is a free log subscription operation binding the contract event 0x5a560578c2a2576a22870a295e55da0d824316461ca74857c685b7ab72391658.
+//
+// Solidity: event RewardsBatchGranted(uint256 indexed tokenID, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchRewardsBatchGranted(opts *bind.WatchOpts, sink chan<- *RewarddistributorRewardsBatchGranted, tokenID []*big.Int, amount []*big.Int) (event.Subscription, error) {
+
+	var tokenIDRule []interface{}
+	for _, tokenIDItem := range tokenID {
+		tokenIDRule = append(tokenIDRule, tokenIDItem)
+	}
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "RewardsBatchGranted", tokenIDRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorRewardsBatchGranted)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "RewardsBatchGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardsBatchGranted is a log parse operation binding the contract event 0x5a560578c2a2576a22870a295e55da0d824316461ca74857c685b7ab72391658.
+//
+// Solidity: event RewardsBatchGranted(uint256 indexed tokenID, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseRewardsBatchGranted(log types.Log) (*RewarddistributorRewardsBatchGranted, error) {
+	event := new(RewarddistributorRewardsBatchGranted)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "RewardsBatchGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorRewardsMigratedIterator is returned from FilterRewardsMigrated and is used to iterate over the raw logs and unpacked data for RewardsMigrated events raised by the Rewarddistributor contract.
+type RewarddistributorRewardsMigratedIterator struct {
+	Event *RewarddistributorRewardsMigrated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorRewardsMigratedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorRewardsMigrated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorRewardsMigrated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorRewardsMigratedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorRewardsMigratedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorRewardsMigrated represents a RewardsMigrated event raised by the Rewarddistributor contract.
+type RewarddistributorRewardsMigrated struct {
+	TokenID  *big.Int
+	Operator common.Address
+	From     common.Address
+	To       common.Address
+	Amount   *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardsMigrated is a free log retrieval operation binding the contract event 0x74103144248cb03c4a8398b58ebd933e52aad3e743dc6d25c7e566d6129d2e05.
+//
+// Solidity: event RewardsMigrated(uint256 tokenID, address indexed operator, address indexed from, address indexed to, uint128 amount)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterRewardsMigrated(opts *bind.FilterOpts, operator []common.Address, from []common.Address, to []common.Address) (*RewarddistributorRewardsMigratedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "RewardsMigrated", operatorRule, fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorRewardsMigratedIterator{contract: _Rewarddistributor.contract, event: "RewardsMigrated", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardsMigrated is a free log subscription operation binding the contract event 0x74103144248cb03c4a8398b58ebd933e52aad3e743dc6d25c7e566d6129d2e05.
+//
+// Solidity: event RewardsMigrated(uint256 tokenID, address indexed operator, address indexed from, address indexed to, uint128 amount)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchRewardsMigrated(opts *bind.WatchOpts, sink chan<- *RewarddistributorRewardsMigrated, operator []common.Address, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "RewardsMigrated", operatorRule, fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorRewardsMigrated)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "RewardsMigrated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardsMigrated is a log parse operation binding the contract event 0x74103144248cb03c4a8398b58ebd933e52aad3e743dc6d25c7e566d6129d2e05.
+//
+// Solidity: event RewardsMigrated(uint256 tokenID, address indexed operator, address indexed from, address indexed to, uint128 amount)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseRewardsMigrated(log types.Log) (*RewarddistributorRewardsMigrated, error) {
+	event := new(RewarddistributorRewardsMigrated)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "RewardsMigrated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorRewardsReclaimedIterator is returned from FilterRewardsReclaimed and is used to iterate over the raw logs and unpacked data for RewardsReclaimed events raised by the Rewarddistributor contract.
+type RewarddistributorRewardsReclaimedIterator struct {
+	Event *RewarddistributorRewardsReclaimed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorRewardsReclaimedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorRewardsReclaimed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorRewardsReclaimed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorRewardsReclaimedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorRewardsReclaimedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorRewardsReclaimed represents a RewardsReclaimed event raised by the Rewarddistributor contract.
+type RewarddistributorRewardsReclaimed struct {
+	TokenID   *big.Int
+	Operator  common.Address
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardsReclaimed is a free log retrieval operation binding the contract event 0xc541b4439a9af87e81276e3d4782683d5ec3ac36e3f806c4d8b6de9eba5acd85.
+//
+// Solidity: event RewardsReclaimed(uint256 indexed tokenID, address indexed operator, address indexed recipient, uint256 amount)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterRewardsReclaimed(opts *bind.FilterOpts, tokenID []*big.Int, operator []common.Address, recipient []common.Address) (*RewarddistributorRewardsReclaimedIterator, error) {
+
+	var tokenIDRule []interface{}
+	for _, tokenIDItem := range tokenID {
+		tokenIDRule = append(tokenIDRule, tokenIDItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "RewardsReclaimed", tokenIDRule, operatorRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorRewardsReclaimedIterator{contract: _Rewarddistributor.contract, event: "RewardsReclaimed", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardsReclaimed is a free log subscription operation binding the contract event 0xc541b4439a9af87e81276e3d4782683d5ec3ac36e3f806c4d8b6de9eba5acd85.
+//
+// Solidity: event RewardsReclaimed(uint256 indexed tokenID, address indexed operator, address indexed recipient, uint256 amount)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchRewardsReclaimed(opts *bind.WatchOpts, sink chan<- *RewarddistributorRewardsReclaimed, tokenID []*big.Int, operator []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var tokenIDRule []interface{}
+	for _, tokenIDItem := range tokenID {
+		tokenIDRule = append(tokenIDRule, tokenIDItem)
+	}
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "RewardsReclaimed", tokenIDRule, operatorRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorRewardsReclaimed)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "RewardsReclaimed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardsReclaimed is a log parse operation binding the contract event 0xc541b4439a9af87e81276e3d4782683d5ec3ac36e3f806c4d8b6de9eba5acd85.
+//
+// Solidity: event RewardsReclaimed(uint256 indexed tokenID, address indexed operator, address indexed recipient, uint256 amount)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseRewardsReclaimed(log types.Log) (*RewarddistributorRewardsReclaimed, error) {
+	event := new(RewarddistributorRewardsReclaimed)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "RewardsReclaimed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorTokenRewardsClaimedIterator is returned from FilterTokenRewardsClaimed and is used to iterate over the raw logs and unpacked data for TokenRewardsClaimed events raised by the Rewarddistributor contract.
+type RewarddistributorTokenRewardsClaimedIterator struct {
+	Event *RewarddistributorTokenRewardsClaimed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorTokenRewardsClaimedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorTokenRewardsClaimed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorTokenRewardsClaimed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorTokenRewardsClaimedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorTokenRewardsClaimedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorTokenRewardsClaimed represents a TokenRewardsClaimed event raised by the Rewarddistributor contract.
+type RewarddistributorTokenRewardsClaimed struct {
+	Operator  common.Address
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterTokenRewardsClaimed is a free log retrieval operation binding the contract event 0x2ecbbad36dfb8af92a78e491dd8a3a195a314c9e3d7262dd303ae70bf6378e26.
+//
+// Solidity: event TokenRewardsClaimed(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterTokenRewardsClaimed(opts *bind.FilterOpts, operator []common.Address, recipient []common.Address, amount []*big.Int) (*RewarddistributorTokenRewardsClaimedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "TokenRewardsClaimed", operatorRule, recipientRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorTokenRewardsClaimedIterator{contract: _Rewarddistributor.contract, event: "TokenRewardsClaimed", logs: logs, sub: sub}, nil
+}
+
+// WatchTokenRewardsClaimed is a free log subscription operation binding the contract event 0x2ecbbad36dfb8af92a78e491dd8a3a195a314c9e3d7262dd303ae70bf6378e26.
+//
+// Solidity: event TokenRewardsClaimed(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchTokenRewardsClaimed(opts *bind.WatchOpts, sink chan<- *RewarddistributorTokenRewardsClaimed, operator []common.Address, recipient []common.Address, amount []*big.Int) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "TokenRewardsClaimed", operatorRule, recipientRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorTokenRewardsClaimed)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "TokenRewardsClaimed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTokenRewardsClaimed is a log parse operation binding the contract event 0x2ecbbad36dfb8af92a78e491dd8a3a195a314c9e3d7262dd303ae70bf6378e26.
+//
+// Solidity: event TokenRewardsClaimed(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseTokenRewardsClaimed(log types.Log) (*RewarddistributorTokenRewardsClaimed, error) {
+	event := new(RewarddistributorTokenRewardsClaimed)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "TokenRewardsClaimed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorTokensGrantedIterator is returned from FilterTokensGranted and is used to iterate over the raw logs and unpacked data for TokensGranted events raised by the Rewarddistributor contract.
+type RewarddistributorTokensGrantedIterator struct {
+	Event *RewarddistributorTokensGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorTokensGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorTokensGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorTokensGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorTokensGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorTokensGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorTokensGranted represents a TokensGranted event raised by the Rewarddistributor contract.
+type RewarddistributorTokensGranted struct {
+	Operator  common.Address
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterTokensGranted is a free log retrieval operation binding the contract event 0x4b1544c19293e59b936b0280f49423a62bdf27ffa57af6fdabe8e7a4a454d80e.
+//
+// Solidity: event TokensGranted(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterTokensGranted(opts *bind.FilterOpts, operator []common.Address, recipient []common.Address, amount []*big.Int) (*RewarddistributorTokensGrantedIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "TokensGranted", operatorRule, recipientRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorTokensGrantedIterator{contract: _Rewarddistributor.contract, event: "TokensGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchTokensGranted is a free log subscription operation binding the contract event 0x4b1544c19293e59b936b0280f49423a62bdf27ffa57af6fdabe8e7a4a454d80e.
+//
+// Solidity: event TokensGranted(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchTokensGranted(opts *bind.WatchOpts, sink chan<- *RewarddistributorTokensGranted, operator []common.Address, recipient []common.Address, amount []*big.Int) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "TokensGranted", operatorRule, recipientRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorTokensGranted)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "TokensGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTokensGranted is a log parse operation binding the contract event 0x4b1544c19293e59b936b0280f49423a62bdf27ffa57af6fdabe8e7a4a454d80e.
+//
+// Solidity: event TokensGranted(address indexed operator, address indexed recipient, uint256 indexed amount)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseTokensGranted(log types.Log) (*RewarddistributorTokensGranted, error) {
+	event := new(RewarddistributorTokensGranted)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "TokensGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the Rewarddistributor contract.
+type RewarddistributorUnpausedIterator struct {
+	Event *RewarddistributorUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorUnpaused represents a Unpaused event raised by the Rewarddistributor contract.
+type RewarddistributorUnpaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterUnpaused(opts *bind.FilterOpts) (*RewarddistributorUnpausedIterator, error) {
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorUnpausedIterator{contract: _Rewarddistributor.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *RewarddistributorUnpaused) (event.Subscription, error) {
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorUnpaused)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseUnpaused(log types.Log) (*RewarddistributorUnpaused, error) {
+	event := new(RewarddistributorUnpaused)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RewarddistributorUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the Rewarddistributor contract.
+type RewarddistributorUpgradedIterator struct {
+	Event *RewarddistributorUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RewarddistributorUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RewarddistributorUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RewarddistributorUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RewarddistributorUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RewarddistributorUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RewarddistributorUpgraded represents a Upgraded event raised by the Rewarddistributor contract.
+type RewarddistributorUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Rewarddistributor *RewarddistributorFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*RewarddistributorUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RewarddistributorUpgradedIterator{contract: _Rewarddistributor.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Rewarddistributor *RewarddistributorFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *RewarddistributorUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _Rewarddistributor.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RewarddistributorUpgraded)
+				if err := _Rewarddistributor.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Rewarddistributor *RewarddistributorFilterer) ParseUpgraded(log types.Log) (*RewarddistributorUpgraded, error) {
+	event := new(RewarddistributorUpgraded)
+	if err := _Rewarddistributor.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts-abi/clients/RocketMinipoolRegistry/RocketMinipoolRegistry.go
+++ b/contracts-abi/clients/RocketMinipoolRegistry/RocketMinipoolRegistry.go
@@ -38,7 +38,7 @@ type IRocketMinipoolRegistryValidatorRegistration struct {
 
 // RocketminipoolregistryMetaData contains all meta data concerning the Rocketminipoolregistry contract.
 var RocketminipoolregistryMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregisterValidators\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregistrationPeriod\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"freeze\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"freezeOracle\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getEligibleTimeForDeregistration\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getMinipoolFromPubkey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNodeAddressFromMinipool\",\"inputs\":[{\"name\":\"minipool\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNodeAddressFromPubkey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getValidOperatorsForKey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getValidatorRegInfo\",\"inputs\":[{\"name\":\"valPubKey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIRocketMinipoolRegistry.ValidatorRegistration\",\"components\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"deregTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"freezeTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"freezeOracle\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"unfreezeReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"rocketStorage\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"unfreezeFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deregistrationPeriod\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isMinipoolActive\",\"inputs\":[{\"name\":\"minipool\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isOperatorValidForKey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorOptedIn\",\"inputs\":[{\"name\":\"valPubKey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorRegistered\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"ownerUnfreeze\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"registerValidators\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestValidatorDeregistration\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"rocketStorage\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractRocketStorageInterface\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setDeregistrationPeriod\",\"inputs\":[{\"name\":\"newDeregistrationPeriod\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setFreezeOracle\",\"inputs\":[{\"name\":\"newFreezeOracle\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRocketStorage\",\"inputs\":[{\"name\":\"newRocketStorage\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setUnfreezeFee\",\"inputs\":[{\"name\":\"newUnfreezeFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setUnfreezeReceiver\",\"inputs\":[{\"name\":\"newUnfreezeReceiver\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unfreeze\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"unfreezeFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unfreezeReceiver\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"validatorRegistrations\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"deregTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"freezeTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorDeregistered\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"nodeAddress\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorDeregistrationRequested\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"nodeAddress\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorFrozen\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorRegistered\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"nodeAddress\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorUnfrozen\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"DeregRequestAlreadyExists\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"DeregRequestDoesNotExist\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"DeregistrationTooSoon\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FrozenValidatorCannotDeregister\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"InvalidBLSPubKeyLength\",\"inputs\":[{\"name\":\"expectedLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"actualLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReceive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MinipoolNotActive\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"NoMinipoolForKey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotMinipoolOperator\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"OnlyFreezeOracle\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"RefundFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnfreezeFeeRequired\",\"inputs\":[{\"name\":\"requiredFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UnfreezeTransferFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ValidatorAlreadyFrozen\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorAlreadyRegistered\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorDeregistrationNotExpired\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotFrozen\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotRegistered\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregisterValidators\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregistrationPeriod\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"freeze\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"freezeOracle\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getEligibleTimeForDeregistration\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getMinipoolFromPubkey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNodeAddressFromMinipool\",\"inputs\":[{\"name\":\"minipool\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNodeAddressFromPubkey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getValidOperatorsForKey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getValidatorRegInfo\",\"inputs\":[{\"name\":\"valPubKey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIRocketMinipoolRegistry.ValidatorRegistration\",\"components\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"deregTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"freezeTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"freezeOracle\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"unfreezeReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"rocketStorage\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"unfreezeFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deregistrationPeriod\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isMinipoolActive\",\"inputs\":[{\"name\":\"minipool\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isOperatorValidForKey\",\"inputs\":[{\"name\":\"operator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorOptedIn\",\"inputs\":[{\"name\":\"valPubKey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorRegistered\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"ownerUnfreeze\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"registerValidators\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestValidatorDeregistration\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"rocketStorage\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractRocketStorageInterface\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setDeregistrationPeriod\",\"inputs\":[{\"name\":\"newDeregistrationPeriod\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setFreezeOracle\",\"inputs\":[{\"name\":\"newFreezeOracle\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRocketStorage\",\"inputs\":[{\"name\":\"newRocketStorage\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setUnfreezeFee\",\"inputs\":[{\"name\":\"newUnfreezeFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setUnfreezeReceiver\",\"inputs\":[{\"name\":\"newUnfreezeReceiver\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unfreeze\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"unfreezeFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unfreezeReceiver\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"validatorRegistrations\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"deregTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"freezeTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorDeregistered\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"},{\"name\":\"nodeAddress\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorDeregistrationRequested\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"},{\"name\":\"nodeAddress\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorFrozen\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorRegistered\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"},{\"name\":\"nodeAddress\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorUnfrozen\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":true,\"internalType\":\"bytes\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"DeregRequestAlreadyExists\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"DeregRequestDoesNotExist\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"DeregistrationTooSoon\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FrozenValidatorCannotDeregister\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"InvalidBLSPubKeyLength\",\"inputs\":[{\"name\":\"expectedLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"actualLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReceive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MinipoolNotActive\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"NoMinipoolForKey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotMinipoolOperator\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"OnlyFreezeOracle\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RefundFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnfreezeFeeRequired\",\"inputs\":[{\"name\":\"requiredFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UnfreezeTransferFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ValidatorAlreadyFrozen\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorAlreadyRegistered\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorDeregistrationNotExpired\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotFrozen\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotRegistered\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ZeroParam\",\"inputs\":[]}]",
 }
 
 // RocketminipoolregistryABI is the input ABI used to generate the binding from.
@@ -498,12 +498,12 @@ func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) IsMinipoolAc
 	return _Rocketminipoolregistry.Contract.IsMinipoolActive(&_Rocketminipoolregistry.CallOpts, minipool)
 }
 
-// IsOperatorValidForKey is a free data retrieval call binding the contract method 0x527300f3.
+// IsOperatorValidForKey is a free data retrieval call binding the contract method 0x5ac0191f.
 //
-// Solidity: function isOperatorValidForKey(bytes validatorPubkey) view returns(bool)
-func (_Rocketminipoolregistry *RocketminipoolregistryCaller) IsOperatorValidForKey(opts *bind.CallOpts, validatorPubkey []byte) (bool, error) {
+// Solidity: function isOperatorValidForKey(address operator, bytes validatorPubkey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) IsOperatorValidForKey(opts *bind.CallOpts, operator common.Address, validatorPubkey []byte) (bool, error) {
 	var out []interface{}
-	err := _Rocketminipoolregistry.contract.Call(opts, &out, "isOperatorValidForKey", validatorPubkey)
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "isOperatorValidForKey", operator, validatorPubkey)
 
 	if err != nil {
 		return *new(bool), err
@@ -515,18 +515,18 @@ func (_Rocketminipoolregistry *RocketminipoolregistryCaller) IsOperatorValidForK
 
 }
 
-// IsOperatorValidForKey is a free data retrieval call binding the contract method 0x527300f3.
+// IsOperatorValidForKey is a free data retrieval call binding the contract method 0x5ac0191f.
 //
-// Solidity: function isOperatorValidForKey(bytes validatorPubkey) view returns(bool)
-func (_Rocketminipoolregistry *RocketminipoolregistrySession) IsOperatorValidForKey(validatorPubkey []byte) (bool, error) {
-	return _Rocketminipoolregistry.Contract.IsOperatorValidForKey(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+// Solidity: function isOperatorValidForKey(address operator, bytes validatorPubkey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) IsOperatorValidForKey(operator common.Address, validatorPubkey []byte) (bool, error) {
+	return _Rocketminipoolregistry.Contract.IsOperatorValidForKey(&_Rocketminipoolregistry.CallOpts, operator, validatorPubkey)
 }
 
-// IsOperatorValidForKey is a free data retrieval call binding the contract method 0x527300f3.
+// IsOperatorValidForKey is a free data retrieval call binding the contract method 0x5ac0191f.
 //
-// Solidity: function isOperatorValidForKey(bytes validatorPubkey) view returns(bool)
-func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) IsOperatorValidForKey(validatorPubkey []byte) (bool, error) {
-	return _Rocketminipoolregistry.Contract.IsOperatorValidForKey(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+// Solidity: function isOperatorValidForKey(address operator, bytes validatorPubkey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) IsOperatorValidForKey(operator common.Address, validatorPubkey []byte) (bool, error) {
+	return _Rocketminipoolregistry.Contract.IsOperatorValidForKey(&_Rocketminipoolregistry.CallOpts, operator, validatorPubkey)
 }
 
 // IsValidatorOptedIn is a free data retrieval call binding the contract method 0x470b690f.
@@ -2199,22 +2199,26 @@ func (it *RocketminipoolregistryValidatorDeregisteredIterator) Close() error {
 
 // RocketminipoolregistryValidatorDeregistered represents a ValidatorDeregistered event raised by the Rocketminipoolregistry contract.
 type RocketminipoolregistryValidatorDeregistered struct {
-	ValidatorPubKey []byte
+	ValidatorPubKey common.Hash
 	NodeAddress     common.Address
 	Raw             types.Log // Blockchain specific contextual infos
 }
 
 // FilterValidatorDeregistered is a free log retrieval operation binding the contract event 0x10ec0bb1533e599e504516d6b49226d8a637ea19cbadfc6f7ff14a01bede3170.
 //
-// Solidity: event ValidatorDeregistered(bytes validatorPubKey, address indexed nodeAddress)
-func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorDeregistered(opts *bind.FilterOpts, nodeAddress []common.Address) (*RocketminipoolregistryValidatorDeregisteredIterator, error) {
+// Solidity: event ValidatorDeregistered(bytes indexed validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorDeregistered(opts *bind.FilterOpts, validatorPubKey [][]byte, nodeAddress []common.Address) (*RocketminipoolregistryValidatorDeregisteredIterator, error) {
 
+	var validatorPubKeyRule []interface{}
+	for _, validatorPubKeyItem := range validatorPubKey {
+		validatorPubKeyRule = append(validatorPubKeyRule, validatorPubKeyItem)
+	}
 	var nodeAddressRule []interface{}
 	for _, nodeAddressItem := range nodeAddress {
 		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
 	}
 
-	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorDeregistered", nodeAddressRule)
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorDeregistered", validatorPubKeyRule, nodeAddressRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2223,15 +2227,19 @@ func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorDe
 
 // WatchValidatorDeregistered is a free log subscription operation binding the contract event 0x10ec0bb1533e599e504516d6b49226d8a637ea19cbadfc6f7ff14a01bede3170.
 //
-// Solidity: event ValidatorDeregistered(bytes validatorPubKey, address indexed nodeAddress)
-func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorDeregistered(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorDeregistered, nodeAddress []common.Address) (event.Subscription, error) {
+// Solidity: event ValidatorDeregistered(bytes indexed validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorDeregistered(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorDeregistered, validatorPubKey [][]byte, nodeAddress []common.Address) (event.Subscription, error) {
 
+	var validatorPubKeyRule []interface{}
+	for _, validatorPubKeyItem := range validatorPubKey {
+		validatorPubKeyRule = append(validatorPubKeyRule, validatorPubKeyItem)
+	}
 	var nodeAddressRule []interface{}
 	for _, nodeAddressItem := range nodeAddress {
 		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
 	}
 
-	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorDeregistered", nodeAddressRule)
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorDeregistered", validatorPubKeyRule, nodeAddressRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2265,7 +2273,7 @@ func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorDer
 
 // ParseValidatorDeregistered is a log parse operation binding the contract event 0x10ec0bb1533e599e504516d6b49226d8a637ea19cbadfc6f7ff14a01bede3170.
 //
-// Solidity: event ValidatorDeregistered(bytes validatorPubKey, address indexed nodeAddress)
+// Solidity: event ValidatorDeregistered(bytes indexed validatorPubKey, address indexed nodeAddress)
 func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseValidatorDeregistered(log types.Log) (*RocketminipoolregistryValidatorDeregistered, error) {
 	event := new(RocketminipoolregistryValidatorDeregistered)
 	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorDeregistered", log); err != nil {
@@ -2344,22 +2352,26 @@ func (it *RocketminipoolregistryValidatorDeregistrationRequestedIterator) Close(
 
 // RocketminipoolregistryValidatorDeregistrationRequested represents a ValidatorDeregistrationRequested event raised by the Rocketminipoolregistry contract.
 type RocketminipoolregistryValidatorDeregistrationRequested struct {
-	ValidatorPubKey []byte
+	ValidatorPubKey common.Hash
 	NodeAddress     common.Address
 	Raw             types.Log // Blockchain specific contextual infos
 }
 
 // FilterValidatorDeregistrationRequested is a free log retrieval operation binding the contract event 0x13b70fd48d462f71863cae24350d77b0dc4115a7e928b39dd0f0f60b701ffed3.
 //
-// Solidity: event ValidatorDeregistrationRequested(bytes validatorPubKey, address indexed nodeAddress)
-func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorDeregistrationRequested(opts *bind.FilterOpts, nodeAddress []common.Address) (*RocketminipoolregistryValidatorDeregistrationRequestedIterator, error) {
+// Solidity: event ValidatorDeregistrationRequested(bytes indexed validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorDeregistrationRequested(opts *bind.FilterOpts, validatorPubKey [][]byte, nodeAddress []common.Address) (*RocketminipoolregistryValidatorDeregistrationRequestedIterator, error) {
 
+	var validatorPubKeyRule []interface{}
+	for _, validatorPubKeyItem := range validatorPubKey {
+		validatorPubKeyRule = append(validatorPubKeyRule, validatorPubKeyItem)
+	}
 	var nodeAddressRule []interface{}
 	for _, nodeAddressItem := range nodeAddress {
 		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
 	}
 
-	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorDeregistrationRequested", nodeAddressRule)
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorDeregistrationRequested", validatorPubKeyRule, nodeAddressRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2368,15 +2380,19 @@ func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorDe
 
 // WatchValidatorDeregistrationRequested is a free log subscription operation binding the contract event 0x13b70fd48d462f71863cae24350d77b0dc4115a7e928b39dd0f0f60b701ffed3.
 //
-// Solidity: event ValidatorDeregistrationRequested(bytes validatorPubKey, address indexed nodeAddress)
-func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorDeregistrationRequested(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorDeregistrationRequested, nodeAddress []common.Address) (event.Subscription, error) {
+// Solidity: event ValidatorDeregistrationRequested(bytes indexed validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorDeregistrationRequested(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorDeregistrationRequested, validatorPubKey [][]byte, nodeAddress []common.Address) (event.Subscription, error) {
 
+	var validatorPubKeyRule []interface{}
+	for _, validatorPubKeyItem := range validatorPubKey {
+		validatorPubKeyRule = append(validatorPubKeyRule, validatorPubKeyItem)
+	}
 	var nodeAddressRule []interface{}
 	for _, nodeAddressItem := range nodeAddress {
 		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
 	}
 
-	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorDeregistrationRequested", nodeAddressRule)
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorDeregistrationRequested", validatorPubKeyRule, nodeAddressRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2410,7 +2426,7 @@ func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorDer
 
 // ParseValidatorDeregistrationRequested is a log parse operation binding the contract event 0x13b70fd48d462f71863cae24350d77b0dc4115a7e928b39dd0f0f60b701ffed3.
 //
-// Solidity: event ValidatorDeregistrationRequested(bytes validatorPubKey, address indexed nodeAddress)
+// Solidity: event ValidatorDeregistrationRequested(bytes indexed validatorPubKey, address indexed nodeAddress)
 func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseValidatorDeregistrationRequested(log types.Log) (*RocketminipoolregistryValidatorDeregistrationRequested, error) {
 	event := new(RocketminipoolregistryValidatorDeregistrationRequested)
 	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorDeregistrationRequested", log); err != nil {
@@ -2489,16 +2505,21 @@ func (it *RocketminipoolregistryValidatorFrozenIterator) Close() error {
 
 // RocketminipoolregistryValidatorFrozen represents a ValidatorFrozen event raised by the Rocketminipoolregistry contract.
 type RocketminipoolregistryValidatorFrozen struct {
-	ValidatorPubKey []byte
+	ValidatorPubKey common.Hash
 	Raw             types.Log // Blockchain specific contextual infos
 }
 
 // FilterValidatorFrozen is a free log retrieval operation binding the contract event 0xfa1d47945b5949504666dd8477bbfc00a77b976fb2119961c96adf939e53e876.
 //
-// Solidity: event ValidatorFrozen(bytes validatorPubKey)
-func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorFrozen(opts *bind.FilterOpts) (*RocketminipoolregistryValidatorFrozenIterator, error) {
+// Solidity: event ValidatorFrozen(bytes indexed validatorPubKey)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorFrozen(opts *bind.FilterOpts, validatorPubKey [][]byte) (*RocketminipoolregistryValidatorFrozenIterator, error) {
 
-	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorFrozen")
+	var validatorPubKeyRule []interface{}
+	for _, validatorPubKeyItem := range validatorPubKey {
+		validatorPubKeyRule = append(validatorPubKeyRule, validatorPubKeyItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorFrozen", validatorPubKeyRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2507,10 +2528,15 @@ func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorFr
 
 // WatchValidatorFrozen is a free log subscription operation binding the contract event 0xfa1d47945b5949504666dd8477bbfc00a77b976fb2119961c96adf939e53e876.
 //
-// Solidity: event ValidatorFrozen(bytes validatorPubKey)
-func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorFrozen(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorFrozen) (event.Subscription, error) {
+// Solidity: event ValidatorFrozen(bytes indexed validatorPubKey)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorFrozen(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorFrozen, validatorPubKey [][]byte) (event.Subscription, error) {
 
-	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorFrozen")
+	var validatorPubKeyRule []interface{}
+	for _, validatorPubKeyItem := range validatorPubKey {
+		validatorPubKeyRule = append(validatorPubKeyRule, validatorPubKeyItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorFrozen", validatorPubKeyRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2544,7 +2570,7 @@ func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorFro
 
 // ParseValidatorFrozen is a log parse operation binding the contract event 0xfa1d47945b5949504666dd8477bbfc00a77b976fb2119961c96adf939e53e876.
 //
-// Solidity: event ValidatorFrozen(bytes validatorPubKey)
+// Solidity: event ValidatorFrozen(bytes indexed validatorPubKey)
 func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseValidatorFrozen(log types.Log) (*RocketminipoolregistryValidatorFrozen, error) {
 	event := new(RocketminipoolregistryValidatorFrozen)
 	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorFrozen", log); err != nil {
@@ -2623,22 +2649,26 @@ func (it *RocketminipoolregistryValidatorRegisteredIterator) Close() error {
 
 // RocketminipoolregistryValidatorRegistered represents a ValidatorRegistered event raised by the Rocketminipoolregistry contract.
 type RocketminipoolregistryValidatorRegistered struct {
-	ValidatorPubKey []byte
+	ValidatorPubKey common.Hash
 	NodeAddress     common.Address
 	Raw             types.Log // Blockchain specific contextual infos
 }
 
 // FilterValidatorRegistered is a free log retrieval operation binding the contract event 0x7cb7aef9bd2e5ee3f6073019691bb332fe3ef290465065aca1b9983f3dc66c56.
 //
-// Solidity: event ValidatorRegistered(bytes validatorPubKey, address indexed nodeAddress)
-func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorRegistered(opts *bind.FilterOpts, nodeAddress []common.Address) (*RocketminipoolregistryValidatorRegisteredIterator, error) {
+// Solidity: event ValidatorRegistered(bytes indexed validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorRegistered(opts *bind.FilterOpts, validatorPubKey [][]byte, nodeAddress []common.Address) (*RocketminipoolregistryValidatorRegisteredIterator, error) {
 
+	var validatorPubKeyRule []interface{}
+	for _, validatorPubKeyItem := range validatorPubKey {
+		validatorPubKeyRule = append(validatorPubKeyRule, validatorPubKeyItem)
+	}
 	var nodeAddressRule []interface{}
 	for _, nodeAddressItem := range nodeAddress {
 		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
 	}
 
-	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorRegistered", nodeAddressRule)
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorRegistered", validatorPubKeyRule, nodeAddressRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2647,15 +2677,19 @@ func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorRe
 
 // WatchValidatorRegistered is a free log subscription operation binding the contract event 0x7cb7aef9bd2e5ee3f6073019691bb332fe3ef290465065aca1b9983f3dc66c56.
 //
-// Solidity: event ValidatorRegistered(bytes validatorPubKey, address indexed nodeAddress)
-func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorRegistered(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorRegistered, nodeAddress []common.Address) (event.Subscription, error) {
+// Solidity: event ValidatorRegistered(bytes indexed validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorRegistered(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorRegistered, validatorPubKey [][]byte, nodeAddress []common.Address) (event.Subscription, error) {
 
+	var validatorPubKeyRule []interface{}
+	for _, validatorPubKeyItem := range validatorPubKey {
+		validatorPubKeyRule = append(validatorPubKeyRule, validatorPubKeyItem)
+	}
 	var nodeAddressRule []interface{}
 	for _, nodeAddressItem := range nodeAddress {
 		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
 	}
 
-	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorRegistered", nodeAddressRule)
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorRegistered", validatorPubKeyRule, nodeAddressRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2689,7 +2723,7 @@ func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorReg
 
 // ParseValidatorRegistered is a log parse operation binding the contract event 0x7cb7aef9bd2e5ee3f6073019691bb332fe3ef290465065aca1b9983f3dc66c56.
 //
-// Solidity: event ValidatorRegistered(bytes validatorPubKey, address indexed nodeAddress)
+// Solidity: event ValidatorRegistered(bytes indexed validatorPubKey, address indexed nodeAddress)
 func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseValidatorRegistered(log types.Log) (*RocketminipoolregistryValidatorRegistered, error) {
 	event := new(RocketminipoolregistryValidatorRegistered)
 	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorRegistered", log); err != nil {
@@ -2768,16 +2802,21 @@ func (it *RocketminipoolregistryValidatorUnfrozenIterator) Close() error {
 
 // RocketminipoolregistryValidatorUnfrozen represents a ValidatorUnfrozen event raised by the Rocketminipoolregistry contract.
 type RocketminipoolregistryValidatorUnfrozen struct {
-	ValidatorPubKey []byte
+	ValidatorPubKey common.Hash
 	Raw             types.Log // Blockchain specific contextual infos
 }
 
 // FilterValidatorUnfrozen is a free log retrieval operation binding the contract event 0x83f1169418932171cc1b130d2c1e543ace8af55b47e4a1341b39b9c71d491392.
 //
-// Solidity: event ValidatorUnfrozen(bytes validatorPubKey)
-func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorUnfrozen(opts *bind.FilterOpts) (*RocketminipoolregistryValidatorUnfrozenIterator, error) {
+// Solidity: event ValidatorUnfrozen(bytes indexed validatorPubKey)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorUnfrozen(opts *bind.FilterOpts, validatorPubKey [][]byte) (*RocketminipoolregistryValidatorUnfrozenIterator, error) {
 
-	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorUnfrozen")
+	var validatorPubKeyRule []interface{}
+	for _, validatorPubKeyItem := range validatorPubKey {
+		validatorPubKeyRule = append(validatorPubKeyRule, validatorPubKeyItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorUnfrozen", validatorPubKeyRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2786,10 +2825,15 @@ func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorUn
 
 // WatchValidatorUnfrozen is a free log subscription operation binding the contract event 0x83f1169418932171cc1b130d2c1e543ace8af55b47e4a1341b39b9c71d491392.
 //
-// Solidity: event ValidatorUnfrozen(bytes validatorPubKey)
-func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorUnfrozen(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorUnfrozen) (event.Subscription, error) {
+// Solidity: event ValidatorUnfrozen(bytes indexed validatorPubKey)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorUnfrozen(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorUnfrozen, validatorPubKey [][]byte) (event.Subscription, error) {
 
-	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorUnfrozen")
+	var validatorPubKeyRule []interface{}
+	for _, validatorPubKeyItem := range validatorPubKey {
+		validatorPubKeyRule = append(validatorPubKeyRule, validatorPubKeyItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorUnfrozen", validatorPubKeyRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2823,7 +2867,7 @@ func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorUnf
 
 // ParseValidatorUnfrozen is a log parse operation binding the contract event 0x83f1169418932171cc1b130d2c1e543ace8af55b47e4a1341b39b9c71d491392.
 //
-// Solidity: event ValidatorUnfrozen(bytes validatorPubKey)
+// Solidity: event ValidatorUnfrozen(bytes indexed validatorPubKey)
 func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseValidatorUnfrozen(log types.Log) (*RocketminipoolregistryValidatorUnfrozen, error) {
 	event := new(RocketminipoolregistryValidatorUnfrozen)
 	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorUnfrozen", log); err != nil {

--- a/contracts-abi/clients/RocketMinipoolRegistry/RocketMinipoolRegistry.go
+++ b/contracts-abi/clients/RocketMinipoolRegistry/RocketMinipoolRegistry.go
@@ -1,0 +1,2834 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package rocketminipoolregistry
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IRocketMinipoolRegistryValidatorRegistration is an auto generated low-level Go binding around an user-defined struct.
+type IRocketMinipoolRegistryValidatorRegistration struct {
+	Exists          bool
+	DeregTimestamp  uint64
+	FreezeTimestamp uint64
+}
+
+// RocketminipoolregistryMetaData contains all meta data concerning the Rocketminipoolregistry contract.
+var RocketminipoolregistryMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregisterValidators\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"deregistrationPeriod\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"freeze\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"freezeOracle\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getEligibleTimeForDeregistration\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getMinipoolFromPubkey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNodeAddressFromMinipool\",\"inputs\":[{\"name\":\"minipool\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNodeAddressFromPubkey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getValidOperatorsForKey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getValidatorRegInfo\",\"inputs\":[{\"name\":\"valPubKey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIRocketMinipoolRegistry.ValidatorRegistration\",\"components\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"deregTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"freezeTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"freezeOracle\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"unfreezeReceiver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"rocketStorage\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"unfreezeFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deregistrationPeriod\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isMinipoolActive\",\"inputs\":[{\"name\":\"minipool\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isOperatorValidForKey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorOptedIn\",\"inputs\":[{\"name\":\"valPubKey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorRegistered\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"ownerUnfreeze\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"registerValidators\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestValidatorDeregistration\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"rocketStorage\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractRocketStorageInterface\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setDeregistrationPeriod\",\"inputs\":[{\"name\":\"newDeregistrationPeriod\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setFreezeOracle\",\"inputs\":[{\"name\":\"newFreezeOracle\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRocketStorage\",\"inputs\":[{\"name\":\"newRocketStorage\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setUnfreezeFee\",\"inputs\":[{\"name\":\"newUnfreezeFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setUnfreezeReceiver\",\"inputs\":[{\"name\":\"newUnfreezeReceiver\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unfreeze\",\"inputs\":[{\"name\":\"valPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"unfreezeFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unfreezeReceiver\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"validatorRegistrations\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"deregTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"freezeTimestamp\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorDeregistered\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"nodeAddress\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorDeregistrationRequested\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"nodeAddress\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorFrozen\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorRegistered\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"},{\"name\":\"nodeAddress\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ValidatorUnfrozen\",\"inputs\":[{\"name\":\"validatorPubKey\",\"type\":\"bytes\",\"indexed\":false,\"internalType\":\"bytes\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"DeregRequestAlreadyExists\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"DeregRequestDoesNotExist\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"DeregistrationTooSoon\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FrozenValidatorCannotDeregister\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"InvalidBLSPubKeyLength\",\"inputs\":[{\"name\":\"expectedLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"actualLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReceive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MinipoolNotActive\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"NoMinipoolForKey\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotMinipoolOperator\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"OnlyFreezeOracle\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"RefundFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnfreezeFeeRequired\",\"inputs\":[{\"name\":\"requiredFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UnfreezeTransferFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ValidatorAlreadyFrozen\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorAlreadyRegistered\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorDeregistrationNotExpired\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotFrozen\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"type\":\"error\",\"name\":\"ValidatorNotRegistered\",\"inputs\":[{\"name\":\"validatorPubkey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}]",
+}
+
+// RocketminipoolregistryABI is the input ABI used to generate the binding from.
+// Deprecated: Use RocketminipoolregistryMetaData.ABI instead.
+var RocketminipoolregistryABI = RocketminipoolregistryMetaData.ABI
+
+// Rocketminipoolregistry is an auto generated Go binding around an Ethereum contract.
+type Rocketminipoolregistry struct {
+	RocketminipoolregistryCaller     // Read-only binding to the contract
+	RocketminipoolregistryTransactor // Write-only binding to the contract
+	RocketminipoolregistryFilterer   // Log filterer for contract events
+}
+
+// RocketminipoolregistryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type RocketminipoolregistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RocketminipoolregistryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type RocketminipoolregistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RocketminipoolregistryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type RocketminipoolregistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RocketminipoolregistrySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type RocketminipoolregistrySession struct {
+	Contract     *Rocketminipoolregistry // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts           // Call options to use throughout this session
+	TransactOpts bind.TransactOpts       // Transaction auth options to use throughout this session
+}
+
+// RocketminipoolregistryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type RocketminipoolregistryCallerSession struct {
+	Contract *RocketminipoolregistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts                 // Call options to use throughout this session
+}
+
+// RocketminipoolregistryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type RocketminipoolregistryTransactorSession struct {
+	Contract     *RocketminipoolregistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts                 // Transaction auth options to use throughout this session
+}
+
+// RocketminipoolregistryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type RocketminipoolregistryRaw struct {
+	Contract *Rocketminipoolregistry // Generic contract binding to access the raw methods on
+}
+
+// RocketminipoolregistryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type RocketminipoolregistryCallerRaw struct {
+	Contract *RocketminipoolregistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// RocketminipoolregistryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type RocketminipoolregistryTransactorRaw struct {
+	Contract *RocketminipoolregistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewRocketminipoolregistry creates a new instance of Rocketminipoolregistry, bound to a specific deployed contract.
+func NewRocketminipoolregistry(address common.Address, backend bind.ContractBackend) (*Rocketminipoolregistry, error) {
+	contract, err := bindRocketminipoolregistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Rocketminipoolregistry{RocketminipoolregistryCaller: RocketminipoolregistryCaller{contract: contract}, RocketminipoolregistryTransactor: RocketminipoolregistryTransactor{contract: contract}, RocketminipoolregistryFilterer: RocketminipoolregistryFilterer{contract: contract}}, nil
+}
+
+// NewRocketminipoolregistryCaller creates a new read-only instance of Rocketminipoolregistry, bound to a specific deployed contract.
+func NewRocketminipoolregistryCaller(address common.Address, caller bind.ContractCaller) (*RocketminipoolregistryCaller, error) {
+	contract, err := bindRocketminipoolregistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryCaller{contract: contract}, nil
+}
+
+// NewRocketminipoolregistryTransactor creates a new write-only instance of Rocketminipoolregistry, bound to a specific deployed contract.
+func NewRocketminipoolregistryTransactor(address common.Address, transactor bind.ContractTransactor) (*RocketminipoolregistryTransactor, error) {
+	contract, err := bindRocketminipoolregistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryTransactor{contract: contract}, nil
+}
+
+// NewRocketminipoolregistryFilterer creates a new log filterer instance of Rocketminipoolregistry, bound to a specific deployed contract.
+func NewRocketminipoolregistryFilterer(address common.Address, filterer bind.ContractFilterer) (*RocketminipoolregistryFilterer, error) {
+	contract, err := bindRocketminipoolregistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryFilterer{contract: contract}, nil
+}
+
+// bindRocketminipoolregistry binds a generic wrapper to an already deployed contract.
+func bindRocketminipoolregistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := RocketminipoolregistryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Rocketminipoolregistry *RocketminipoolregistryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Rocketminipoolregistry.Contract.RocketminipoolregistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Rocketminipoolregistry *RocketminipoolregistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.RocketminipoolregistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Rocketminipoolregistry *RocketminipoolregistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.RocketminipoolregistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Rocketminipoolregistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) UPGRADEINTERFACEVERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "UPGRADE_INTERFACE_VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _Rocketminipoolregistry.Contract.UPGRADEINTERFACEVERSION(&_Rocketminipoolregistry.CallOpts)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _Rocketminipoolregistry.Contract.UPGRADEINTERFACEVERSION(&_Rocketminipoolregistry.CallOpts)
+}
+
+// DeregistrationPeriod is a free data retrieval call binding the contract method 0x1667a3b6.
+//
+// Solidity: function deregistrationPeriod() view returns(uint64)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) DeregistrationPeriod(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "deregistrationPeriod")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// DeregistrationPeriod is a free data retrieval call binding the contract method 0x1667a3b6.
+//
+// Solidity: function deregistrationPeriod() view returns(uint64)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) DeregistrationPeriod() (uint64, error) {
+	return _Rocketminipoolregistry.Contract.DeregistrationPeriod(&_Rocketminipoolregistry.CallOpts)
+}
+
+// DeregistrationPeriod is a free data retrieval call binding the contract method 0x1667a3b6.
+//
+// Solidity: function deregistrationPeriod() view returns(uint64)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) DeregistrationPeriod() (uint64, error) {
+	return _Rocketminipoolregistry.Contract.DeregistrationPeriod(&_Rocketminipoolregistry.CallOpts)
+}
+
+// FreezeOracle is a free data retrieval call binding the contract method 0xaf91e0bf.
+//
+// Solidity: function freezeOracle() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) FreezeOracle(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "freezeOracle")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// FreezeOracle is a free data retrieval call binding the contract method 0xaf91e0bf.
+//
+// Solidity: function freezeOracle() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) FreezeOracle() (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.FreezeOracle(&_Rocketminipoolregistry.CallOpts)
+}
+
+// FreezeOracle is a free data retrieval call binding the contract method 0xaf91e0bf.
+//
+// Solidity: function freezeOracle() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) FreezeOracle() (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.FreezeOracle(&_Rocketminipoolregistry.CallOpts)
+}
+
+// GetEligibleTimeForDeregistration is a free data retrieval call binding the contract method 0x371a83ad.
+//
+// Solidity: function getEligibleTimeForDeregistration(bytes validatorPubkey) view returns(uint64)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) GetEligibleTimeForDeregistration(opts *bind.CallOpts, validatorPubkey []byte) (uint64, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "getEligibleTimeForDeregistration", validatorPubkey)
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// GetEligibleTimeForDeregistration is a free data retrieval call binding the contract method 0x371a83ad.
+//
+// Solidity: function getEligibleTimeForDeregistration(bytes validatorPubkey) view returns(uint64)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) GetEligibleTimeForDeregistration(validatorPubkey []byte) (uint64, error) {
+	return _Rocketminipoolregistry.Contract.GetEligibleTimeForDeregistration(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// GetEligibleTimeForDeregistration is a free data retrieval call binding the contract method 0x371a83ad.
+//
+// Solidity: function getEligibleTimeForDeregistration(bytes validatorPubkey) view returns(uint64)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) GetEligibleTimeForDeregistration(validatorPubkey []byte) (uint64, error) {
+	return _Rocketminipoolregistry.Contract.GetEligibleTimeForDeregistration(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// GetMinipoolFromPubkey is a free data retrieval call binding the contract method 0x6dc6b1ec.
+//
+// Solidity: function getMinipoolFromPubkey(bytes validatorPubkey) view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) GetMinipoolFromPubkey(opts *bind.CallOpts, validatorPubkey []byte) (common.Address, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "getMinipoolFromPubkey", validatorPubkey)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetMinipoolFromPubkey is a free data retrieval call binding the contract method 0x6dc6b1ec.
+//
+// Solidity: function getMinipoolFromPubkey(bytes validatorPubkey) view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) GetMinipoolFromPubkey(validatorPubkey []byte) (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.GetMinipoolFromPubkey(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// GetMinipoolFromPubkey is a free data retrieval call binding the contract method 0x6dc6b1ec.
+//
+// Solidity: function getMinipoolFromPubkey(bytes validatorPubkey) view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) GetMinipoolFromPubkey(validatorPubkey []byte) (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.GetMinipoolFromPubkey(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// GetNodeAddressFromMinipool is a free data retrieval call binding the contract method 0x1dc14943.
+//
+// Solidity: function getNodeAddressFromMinipool(address minipool) view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) GetNodeAddressFromMinipool(opts *bind.CallOpts, minipool common.Address) (common.Address, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "getNodeAddressFromMinipool", minipool)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetNodeAddressFromMinipool is a free data retrieval call binding the contract method 0x1dc14943.
+//
+// Solidity: function getNodeAddressFromMinipool(address minipool) view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) GetNodeAddressFromMinipool(minipool common.Address) (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.GetNodeAddressFromMinipool(&_Rocketminipoolregistry.CallOpts, minipool)
+}
+
+// GetNodeAddressFromMinipool is a free data retrieval call binding the contract method 0x1dc14943.
+//
+// Solidity: function getNodeAddressFromMinipool(address minipool) view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) GetNodeAddressFromMinipool(minipool common.Address) (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.GetNodeAddressFromMinipool(&_Rocketminipoolregistry.CallOpts, minipool)
+}
+
+// GetNodeAddressFromPubkey is a free data retrieval call binding the contract method 0x8eabd1ee.
+//
+// Solidity: function getNodeAddressFromPubkey(bytes validatorPubkey) view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) GetNodeAddressFromPubkey(opts *bind.CallOpts, validatorPubkey []byte) (common.Address, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "getNodeAddressFromPubkey", validatorPubkey)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetNodeAddressFromPubkey is a free data retrieval call binding the contract method 0x8eabd1ee.
+//
+// Solidity: function getNodeAddressFromPubkey(bytes validatorPubkey) view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) GetNodeAddressFromPubkey(validatorPubkey []byte) (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.GetNodeAddressFromPubkey(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// GetNodeAddressFromPubkey is a free data retrieval call binding the contract method 0x8eabd1ee.
+//
+// Solidity: function getNodeAddressFromPubkey(bytes validatorPubkey) view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) GetNodeAddressFromPubkey(validatorPubkey []byte) (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.GetNodeAddressFromPubkey(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// GetValidOperatorsForKey is a free data retrieval call binding the contract method 0xa259a713.
+//
+// Solidity: function getValidOperatorsForKey(bytes validatorPubkey) view returns(address, address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) GetValidOperatorsForKey(opts *bind.CallOpts, validatorPubkey []byte) (common.Address, common.Address, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "getValidOperatorsForKey", validatorPubkey)
+
+	if err != nil {
+		return *new(common.Address), *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	out1 := *abi.ConvertType(out[1], new(common.Address)).(*common.Address)
+
+	return out0, out1, err
+
+}
+
+// GetValidOperatorsForKey is a free data retrieval call binding the contract method 0xa259a713.
+//
+// Solidity: function getValidOperatorsForKey(bytes validatorPubkey) view returns(address, address)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) GetValidOperatorsForKey(validatorPubkey []byte) (common.Address, common.Address, error) {
+	return _Rocketminipoolregistry.Contract.GetValidOperatorsForKey(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// GetValidOperatorsForKey is a free data retrieval call binding the contract method 0xa259a713.
+//
+// Solidity: function getValidOperatorsForKey(bytes validatorPubkey) view returns(address, address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) GetValidOperatorsForKey(validatorPubkey []byte) (common.Address, common.Address, error) {
+	return _Rocketminipoolregistry.Contract.GetValidOperatorsForKey(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// GetValidatorRegInfo is a free data retrieval call binding the contract method 0x972ac83c.
+//
+// Solidity: function getValidatorRegInfo(bytes valPubKey) view returns((bool,uint64,uint64))
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) GetValidatorRegInfo(opts *bind.CallOpts, valPubKey []byte) (IRocketMinipoolRegistryValidatorRegistration, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "getValidatorRegInfo", valPubKey)
+
+	if err != nil {
+		return *new(IRocketMinipoolRegistryValidatorRegistration), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(IRocketMinipoolRegistryValidatorRegistration)).(*IRocketMinipoolRegistryValidatorRegistration)
+
+	return out0, err
+
+}
+
+// GetValidatorRegInfo is a free data retrieval call binding the contract method 0x972ac83c.
+//
+// Solidity: function getValidatorRegInfo(bytes valPubKey) view returns((bool,uint64,uint64))
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) GetValidatorRegInfo(valPubKey []byte) (IRocketMinipoolRegistryValidatorRegistration, error) {
+	return _Rocketminipoolregistry.Contract.GetValidatorRegInfo(&_Rocketminipoolregistry.CallOpts, valPubKey)
+}
+
+// GetValidatorRegInfo is a free data retrieval call binding the contract method 0x972ac83c.
+//
+// Solidity: function getValidatorRegInfo(bytes valPubKey) view returns((bool,uint64,uint64))
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) GetValidatorRegInfo(valPubKey []byte) (IRocketMinipoolRegistryValidatorRegistration, error) {
+	return _Rocketminipoolregistry.Contract.GetValidatorRegInfo(&_Rocketminipoolregistry.CallOpts, valPubKey)
+}
+
+// IsMinipoolActive is a free data retrieval call binding the contract method 0x59d48d83.
+//
+// Solidity: function isMinipoolActive(address minipool) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) IsMinipoolActive(opts *bind.CallOpts, minipool common.Address) (bool, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "isMinipoolActive", minipool)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsMinipoolActive is a free data retrieval call binding the contract method 0x59d48d83.
+//
+// Solidity: function isMinipoolActive(address minipool) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) IsMinipoolActive(minipool common.Address) (bool, error) {
+	return _Rocketminipoolregistry.Contract.IsMinipoolActive(&_Rocketminipoolregistry.CallOpts, minipool)
+}
+
+// IsMinipoolActive is a free data retrieval call binding the contract method 0x59d48d83.
+//
+// Solidity: function isMinipoolActive(address minipool) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) IsMinipoolActive(minipool common.Address) (bool, error) {
+	return _Rocketminipoolregistry.Contract.IsMinipoolActive(&_Rocketminipoolregistry.CallOpts, minipool)
+}
+
+// IsOperatorValidForKey is a free data retrieval call binding the contract method 0x527300f3.
+//
+// Solidity: function isOperatorValidForKey(bytes validatorPubkey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) IsOperatorValidForKey(opts *bind.CallOpts, validatorPubkey []byte) (bool, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "isOperatorValidForKey", validatorPubkey)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsOperatorValidForKey is a free data retrieval call binding the contract method 0x527300f3.
+//
+// Solidity: function isOperatorValidForKey(bytes validatorPubkey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) IsOperatorValidForKey(validatorPubkey []byte) (bool, error) {
+	return _Rocketminipoolregistry.Contract.IsOperatorValidForKey(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// IsOperatorValidForKey is a free data retrieval call binding the contract method 0x527300f3.
+//
+// Solidity: function isOperatorValidForKey(bytes validatorPubkey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) IsOperatorValidForKey(validatorPubkey []byte) (bool, error) {
+	return _Rocketminipoolregistry.Contract.IsOperatorValidForKey(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// IsValidatorOptedIn is a free data retrieval call binding the contract method 0x470b690f.
+//
+// Solidity: function isValidatorOptedIn(bytes valPubKey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) IsValidatorOptedIn(opts *bind.CallOpts, valPubKey []byte) (bool, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "isValidatorOptedIn", valPubKey)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsValidatorOptedIn is a free data retrieval call binding the contract method 0x470b690f.
+//
+// Solidity: function isValidatorOptedIn(bytes valPubKey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) IsValidatorOptedIn(valPubKey []byte) (bool, error) {
+	return _Rocketminipoolregistry.Contract.IsValidatorOptedIn(&_Rocketminipoolregistry.CallOpts, valPubKey)
+}
+
+// IsValidatorOptedIn is a free data retrieval call binding the contract method 0x470b690f.
+//
+// Solidity: function isValidatorOptedIn(bytes valPubKey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) IsValidatorOptedIn(valPubKey []byte) (bool, error) {
+	return _Rocketminipoolregistry.Contract.IsValidatorOptedIn(&_Rocketminipoolregistry.CallOpts, valPubKey)
+}
+
+// IsValidatorRegistered is a free data retrieval call binding the contract method 0x0c5642d3.
+//
+// Solidity: function isValidatorRegistered(bytes validatorPubkey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) IsValidatorRegistered(opts *bind.CallOpts, validatorPubkey []byte) (bool, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "isValidatorRegistered", validatorPubkey)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsValidatorRegistered is a free data retrieval call binding the contract method 0x0c5642d3.
+//
+// Solidity: function isValidatorRegistered(bytes validatorPubkey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) IsValidatorRegistered(validatorPubkey []byte) (bool, error) {
+	return _Rocketminipoolregistry.Contract.IsValidatorRegistered(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// IsValidatorRegistered is a free data retrieval call binding the contract method 0x0c5642d3.
+//
+// Solidity: function isValidatorRegistered(bytes validatorPubkey) view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) IsValidatorRegistered(validatorPubkey []byte) (bool, error) {
+	return _Rocketminipoolregistry.Contract.IsValidatorRegistered(&_Rocketminipoolregistry.CallOpts, validatorPubkey)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) Owner() (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.Owner(&_Rocketminipoolregistry.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) Owner() (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.Owner(&_Rocketminipoolregistry.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) Paused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "paused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) Paused() (bool, error) {
+	return _Rocketminipoolregistry.Contract.Paused(&_Rocketminipoolregistry.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) Paused() (bool, error) {
+	return _Rocketminipoolregistry.Contract.Paused(&_Rocketminipoolregistry.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) PendingOwner() (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.PendingOwner(&_Rocketminipoolregistry.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) PendingOwner() (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.PendingOwner(&_Rocketminipoolregistry.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "proxiableUUID")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) ProxiableUUID() ([32]byte, error) {
+	return _Rocketminipoolregistry.Contract.ProxiableUUID(&_Rocketminipoolregistry.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) ProxiableUUID() ([32]byte, error) {
+	return _Rocketminipoolregistry.Contract.ProxiableUUID(&_Rocketminipoolregistry.CallOpts)
+}
+
+// RocketStorage is a free data retrieval call binding the contract method 0x67601a8e.
+//
+// Solidity: function rocketStorage() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) RocketStorage(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "rocketStorage")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// RocketStorage is a free data retrieval call binding the contract method 0x67601a8e.
+//
+// Solidity: function rocketStorage() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) RocketStorage() (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.RocketStorage(&_Rocketminipoolregistry.CallOpts)
+}
+
+// RocketStorage is a free data retrieval call binding the contract method 0x67601a8e.
+//
+// Solidity: function rocketStorage() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) RocketStorage() (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.RocketStorage(&_Rocketminipoolregistry.CallOpts)
+}
+
+// UnfreezeFee is a free data retrieval call binding the contract method 0x90d0c8c2.
+//
+// Solidity: function unfreezeFee() view returns(uint256)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) UnfreezeFee(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "unfreezeFee")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// UnfreezeFee is a free data retrieval call binding the contract method 0x90d0c8c2.
+//
+// Solidity: function unfreezeFee() view returns(uint256)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) UnfreezeFee() (*big.Int, error) {
+	return _Rocketminipoolregistry.Contract.UnfreezeFee(&_Rocketminipoolregistry.CallOpts)
+}
+
+// UnfreezeFee is a free data retrieval call binding the contract method 0x90d0c8c2.
+//
+// Solidity: function unfreezeFee() view returns(uint256)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) UnfreezeFee() (*big.Int, error) {
+	return _Rocketminipoolregistry.Contract.UnfreezeFee(&_Rocketminipoolregistry.CallOpts)
+}
+
+// UnfreezeReceiver is a free data retrieval call binding the contract method 0xc9207afb.
+//
+// Solidity: function unfreezeReceiver() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) UnfreezeReceiver(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "unfreezeReceiver")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// UnfreezeReceiver is a free data retrieval call binding the contract method 0xc9207afb.
+//
+// Solidity: function unfreezeReceiver() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) UnfreezeReceiver() (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.UnfreezeReceiver(&_Rocketminipoolregistry.CallOpts)
+}
+
+// UnfreezeReceiver is a free data retrieval call binding the contract method 0xc9207afb.
+//
+// Solidity: function unfreezeReceiver() view returns(address)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) UnfreezeReceiver() (common.Address, error) {
+	return _Rocketminipoolregistry.Contract.UnfreezeReceiver(&_Rocketminipoolregistry.CallOpts)
+}
+
+// ValidatorRegistrations is a free data retrieval call binding the contract method 0x8cdaf000.
+//
+// Solidity: function validatorRegistrations(bytes ) view returns(bool exists, uint64 deregTimestamp, uint64 freezeTimestamp)
+func (_Rocketminipoolregistry *RocketminipoolregistryCaller) ValidatorRegistrations(opts *bind.CallOpts, arg0 []byte) (struct {
+	Exists          bool
+	DeregTimestamp  uint64
+	FreezeTimestamp uint64
+}, error) {
+	var out []interface{}
+	err := _Rocketminipoolregistry.contract.Call(opts, &out, "validatorRegistrations", arg0)
+
+	outstruct := new(struct {
+		Exists          bool
+		DeregTimestamp  uint64
+		FreezeTimestamp uint64
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Exists = *abi.ConvertType(out[0], new(bool)).(*bool)
+	outstruct.DeregTimestamp = *abi.ConvertType(out[1], new(uint64)).(*uint64)
+	outstruct.FreezeTimestamp = *abi.ConvertType(out[2], new(uint64)).(*uint64)
+
+	return *outstruct, err
+
+}
+
+// ValidatorRegistrations is a free data retrieval call binding the contract method 0x8cdaf000.
+//
+// Solidity: function validatorRegistrations(bytes ) view returns(bool exists, uint64 deregTimestamp, uint64 freezeTimestamp)
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) ValidatorRegistrations(arg0 []byte) (struct {
+	Exists          bool
+	DeregTimestamp  uint64
+	FreezeTimestamp uint64
+}, error) {
+	return _Rocketminipoolregistry.Contract.ValidatorRegistrations(&_Rocketminipoolregistry.CallOpts, arg0)
+}
+
+// ValidatorRegistrations is a free data retrieval call binding the contract method 0x8cdaf000.
+//
+// Solidity: function validatorRegistrations(bytes ) view returns(bool exists, uint64 deregTimestamp, uint64 freezeTimestamp)
+func (_Rocketminipoolregistry *RocketminipoolregistryCallerSession) ValidatorRegistrations(arg0 []byte) (struct {
+	Exists          bool
+	DeregTimestamp  uint64
+	FreezeTimestamp uint64
+}, error) {
+	return _Rocketminipoolregistry.Contract.ValidatorRegistrations(&_Rocketminipoolregistry.CallOpts, arg0)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) AcceptOwnership() (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.AcceptOwnership(&_Rocketminipoolregistry.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.AcceptOwnership(&_Rocketminipoolregistry.TransactOpts)
+}
+
+// DeregisterValidators is a paid mutator transaction binding the contract method 0xc6c6a657.
+//
+// Solidity: function deregisterValidators(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) DeregisterValidators(opts *bind.TransactOpts, valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "deregisterValidators", valPubKeys)
+}
+
+// DeregisterValidators is a paid mutator transaction binding the contract method 0xc6c6a657.
+//
+// Solidity: function deregisterValidators(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) DeregisterValidators(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.DeregisterValidators(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// DeregisterValidators is a paid mutator transaction binding the contract method 0xc6c6a657.
+//
+// Solidity: function deregisterValidators(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) DeregisterValidators(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.DeregisterValidators(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// Freeze is a paid mutator transaction binding the contract method 0xa694d33f.
+//
+// Solidity: function freeze(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) Freeze(opts *bind.TransactOpts, valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "freeze", valPubKeys)
+}
+
+// Freeze is a paid mutator transaction binding the contract method 0xa694d33f.
+//
+// Solidity: function freeze(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) Freeze(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Freeze(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// Freeze is a paid mutator transaction binding the contract method 0xa694d33f.
+//
+// Solidity: function freeze(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) Freeze(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Freeze(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x3de2598c.
+//
+// Solidity: function initialize(address owner, address freezeOracle, address unfreezeReceiver, address rocketStorage, uint256 unfreezeFee, uint64 deregistrationPeriod) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) Initialize(opts *bind.TransactOpts, owner common.Address, freezeOracle common.Address, unfreezeReceiver common.Address, rocketStorage common.Address, unfreezeFee *big.Int, deregistrationPeriod uint64) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "initialize", owner, freezeOracle, unfreezeReceiver, rocketStorage, unfreezeFee, deregistrationPeriod)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x3de2598c.
+//
+// Solidity: function initialize(address owner, address freezeOracle, address unfreezeReceiver, address rocketStorage, uint256 unfreezeFee, uint64 deregistrationPeriod) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) Initialize(owner common.Address, freezeOracle common.Address, unfreezeReceiver common.Address, rocketStorage common.Address, unfreezeFee *big.Int, deregistrationPeriod uint64) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Initialize(&_Rocketminipoolregistry.TransactOpts, owner, freezeOracle, unfreezeReceiver, rocketStorage, unfreezeFee, deregistrationPeriod)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x3de2598c.
+//
+// Solidity: function initialize(address owner, address freezeOracle, address unfreezeReceiver, address rocketStorage, uint256 unfreezeFee, uint64 deregistrationPeriod) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) Initialize(owner common.Address, freezeOracle common.Address, unfreezeReceiver common.Address, rocketStorage common.Address, unfreezeFee *big.Int, deregistrationPeriod uint64) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Initialize(&_Rocketminipoolregistry.TransactOpts, owner, freezeOracle, unfreezeReceiver, rocketStorage, unfreezeFee, deregistrationPeriod)
+}
+
+// OwnerUnfreeze is a paid mutator transaction binding the contract method 0x3ba2b274.
+//
+// Solidity: function ownerUnfreeze(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) OwnerUnfreeze(opts *bind.TransactOpts, valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "ownerUnfreeze", valPubKeys)
+}
+
+// OwnerUnfreeze is a paid mutator transaction binding the contract method 0x3ba2b274.
+//
+// Solidity: function ownerUnfreeze(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) OwnerUnfreeze(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.OwnerUnfreeze(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// OwnerUnfreeze is a paid mutator transaction binding the contract method 0x3ba2b274.
+//
+// Solidity: function ownerUnfreeze(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) OwnerUnfreeze(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.OwnerUnfreeze(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "pause")
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) Pause() (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Pause(&_Rocketminipoolregistry.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) Pause() (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Pause(&_Rocketminipoolregistry.TransactOpts)
+}
+
+// RegisterValidators is a paid mutator transaction binding the contract method 0xdbd739ad.
+//
+// Solidity: function registerValidators(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) RegisterValidators(opts *bind.TransactOpts, valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "registerValidators", valPubKeys)
+}
+
+// RegisterValidators is a paid mutator transaction binding the contract method 0xdbd739ad.
+//
+// Solidity: function registerValidators(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) RegisterValidators(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.RegisterValidators(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// RegisterValidators is a paid mutator transaction binding the contract method 0xdbd739ad.
+//
+// Solidity: function registerValidators(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) RegisterValidators(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.RegisterValidators(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) RenounceOwnership() (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.RenounceOwnership(&_Rocketminipoolregistry.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.RenounceOwnership(&_Rocketminipoolregistry.TransactOpts)
+}
+
+// RequestValidatorDeregistration is a paid mutator transaction binding the contract method 0xb0d5445c.
+//
+// Solidity: function requestValidatorDeregistration(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) RequestValidatorDeregistration(opts *bind.TransactOpts, valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "requestValidatorDeregistration", valPubKeys)
+}
+
+// RequestValidatorDeregistration is a paid mutator transaction binding the contract method 0xb0d5445c.
+//
+// Solidity: function requestValidatorDeregistration(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) RequestValidatorDeregistration(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.RequestValidatorDeregistration(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// RequestValidatorDeregistration is a paid mutator transaction binding the contract method 0xb0d5445c.
+//
+// Solidity: function requestValidatorDeregistration(bytes[] valPubKeys) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) RequestValidatorDeregistration(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.RequestValidatorDeregistration(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// SetDeregistrationPeriod is a paid mutator transaction binding the contract method 0xaaa47b39.
+//
+// Solidity: function setDeregistrationPeriod(uint64 newDeregistrationPeriod) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) SetDeregistrationPeriod(opts *bind.TransactOpts, newDeregistrationPeriod uint64) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "setDeregistrationPeriod", newDeregistrationPeriod)
+}
+
+// SetDeregistrationPeriod is a paid mutator transaction binding the contract method 0xaaa47b39.
+//
+// Solidity: function setDeregistrationPeriod(uint64 newDeregistrationPeriod) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) SetDeregistrationPeriod(newDeregistrationPeriod uint64) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.SetDeregistrationPeriod(&_Rocketminipoolregistry.TransactOpts, newDeregistrationPeriod)
+}
+
+// SetDeregistrationPeriod is a paid mutator transaction binding the contract method 0xaaa47b39.
+//
+// Solidity: function setDeregistrationPeriod(uint64 newDeregistrationPeriod) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) SetDeregistrationPeriod(newDeregistrationPeriod uint64) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.SetDeregistrationPeriod(&_Rocketminipoolregistry.TransactOpts, newDeregistrationPeriod)
+}
+
+// SetFreezeOracle is a paid mutator transaction binding the contract method 0x65a49071.
+//
+// Solidity: function setFreezeOracle(address newFreezeOracle) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) SetFreezeOracle(opts *bind.TransactOpts, newFreezeOracle common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "setFreezeOracle", newFreezeOracle)
+}
+
+// SetFreezeOracle is a paid mutator transaction binding the contract method 0x65a49071.
+//
+// Solidity: function setFreezeOracle(address newFreezeOracle) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) SetFreezeOracle(newFreezeOracle common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.SetFreezeOracle(&_Rocketminipoolregistry.TransactOpts, newFreezeOracle)
+}
+
+// SetFreezeOracle is a paid mutator transaction binding the contract method 0x65a49071.
+//
+// Solidity: function setFreezeOracle(address newFreezeOracle) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) SetFreezeOracle(newFreezeOracle common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.SetFreezeOracle(&_Rocketminipoolregistry.TransactOpts, newFreezeOracle)
+}
+
+// SetRocketStorage is a paid mutator transaction binding the contract method 0x3af9b8ff.
+//
+// Solidity: function setRocketStorage(address newRocketStorage) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) SetRocketStorage(opts *bind.TransactOpts, newRocketStorage common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "setRocketStorage", newRocketStorage)
+}
+
+// SetRocketStorage is a paid mutator transaction binding the contract method 0x3af9b8ff.
+//
+// Solidity: function setRocketStorage(address newRocketStorage) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) SetRocketStorage(newRocketStorage common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.SetRocketStorage(&_Rocketminipoolregistry.TransactOpts, newRocketStorage)
+}
+
+// SetRocketStorage is a paid mutator transaction binding the contract method 0x3af9b8ff.
+//
+// Solidity: function setRocketStorage(address newRocketStorage) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) SetRocketStorage(newRocketStorage common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.SetRocketStorage(&_Rocketminipoolregistry.TransactOpts, newRocketStorage)
+}
+
+// SetUnfreezeFee is a paid mutator transaction binding the contract method 0x80e7751c.
+//
+// Solidity: function setUnfreezeFee(uint256 newUnfreezeFee) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) SetUnfreezeFee(opts *bind.TransactOpts, newUnfreezeFee *big.Int) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "setUnfreezeFee", newUnfreezeFee)
+}
+
+// SetUnfreezeFee is a paid mutator transaction binding the contract method 0x80e7751c.
+//
+// Solidity: function setUnfreezeFee(uint256 newUnfreezeFee) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) SetUnfreezeFee(newUnfreezeFee *big.Int) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.SetUnfreezeFee(&_Rocketminipoolregistry.TransactOpts, newUnfreezeFee)
+}
+
+// SetUnfreezeFee is a paid mutator transaction binding the contract method 0x80e7751c.
+//
+// Solidity: function setUnfreezeFee(uint256 newUnfreezeFee) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) SetUnfreezeFee(newUnfreezeFee *big.Int) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.SetUnfreezeFee(&_Rocketminipoolregistry.TransactOpts, newUnfreezeFee)
+}
+
+// SetUnfreezeReceiver is a paid mutator transaction binding the contract method 0x7d0b802d.
+//
+// Solidity: function setUnfreezeReceiver(address newUnfreezeReceiver) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) SetUnfreezeReceiver(opts *bind.TransactOpts, newUnfreezeReceiver common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "setUnfreezeReceiver", newUnfreezeReceiver)
+}
+
+// SetUnfreezeReceiver is a paid mutator transaction binding the contract method 0x7d0b802d.
+//
+// Solidity: function setUnfreezeReceiver(address newUnfreezeReceiver) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) SetUnfreezeReceiver(newUnfreezeReceiver common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.SetUnfreezeReceiver(&_Rocketminipoolregistry.TransactOpts, newUnfreezeReceiver)
+}
+
+// SetUnfreezeReceiver is a paid mutator transaction binding the contract method 0x7d0b802d.
+//
+// Solidity: function setUnfreezeReceiver(address newUnfreezeReceiver) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) SetUnfreezeReceiver(newUnfreezeReceiver common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.SetUnfreezeReceiver(&_Rocketminipoolregistry.TransactOpts, newUnfreezeReceiver)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.TransferOwnership(&_Rocketminipoolregistry.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.TransferOwnership(&_Rocketminipoolregistry.TransactOpts, newOwner)
+}
+
+// Unfreeze is a paid mutator transaction binding the contract method 0xb764d33c.
+//
+// Solidity: function unfreeze(bytes[] valPubKeys) payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) Unfreeze(opts *bind.TransactOpts, valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "unfreeze", valPubKeys)
+}
+
+// Unfreeze is a paid mutator transaction binding the contract method 0xb764d33c.
+//
+// Solidity: function unfreeze(bytes[] valPubKeys) payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) Unfreeze(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Unfreeze(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// Unfreeze is a paid mutator transaction binding the contract method 0xb764d33c.
+//
+// Solidity: function unfreeze(bytes[] valPubKeys) payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) Unfreeze(valPubKeys [][]byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Unfreeze(&_Rocketminipoolregistry.TransactOpts, valPubKeys)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "unpause")
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) Unpause() (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Unpause(&_Rocketminipoolregistry.TransactOpts)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) Unpause() (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Unpause(&_Rocketminipoolregistry.TransactOpts)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.UpgradeToAndCall(&_Rocketminipoolregistry.TransactOpts, newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.UpgradeToAndCall(&_Rocketminipoolregistry.TransactOpts, newImplementation, data)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.RawTransact(opts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Fallback(&_Rocketminipoolregistry.TransactOpts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Fallback(&_Rocketminipoolregistry.TransactOpts, calldata)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Rocketminipoolregistry.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistrySession) Receive() (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Receive(&_Rocketminipoolregistry.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Rocketminipoolregistry *RocketminipoolregistryTransactorSession) Receive() (*types.Transaction, error) {
+	return _Rocketminipoolregistry.Contract.Receive(&_Rocketminipoolregistry.TransactOpts)
+}
+
+// RocketminipoolregistryInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryInitializedIterator struct {
+	Event *RocketminipoolregistryInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryInitialized represents a Initialized event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryInitialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterInitialized(opts *bind.FilterOpts) (*RocketminipoolregistryInitializedIterator, error) {
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryInitializedIterator{contract: _Rocketminipoolregistry.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryInitialized)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseInitialized(log types.Log) (*RocketminipoolregistryInitialized, error) {
+	event := new(RocketminipoolregistryInitialized)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RocketminipoolregistryOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryOwnershipTransferStartedIterator struct {
+	Event *RocketminipoolregistryOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*RocketminipoolregistryOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryOwnershipTransferStartedIterator{contract: _Rocketminipoolregistry.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryOwnershipTransferStarted)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseOwnershipTransferStarted(log types.Log) (*RocketminipoolregistryOwnershipTransferStarted, error) {
+	event := new(RocketminipoolregistryOwnershipTransferStarted)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RocketminipoolregistryOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryOwnershipTransferredIterator struct {
+	Event *RocketminipoolregistryOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryOwnershipTransferred represents a OwnershipTransferred event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*RocketminipoolregistryOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryOwnershipTransferredIterator{contract: _Rocketminipoolregistry.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryOwnershipTransferred)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseOwnershipTransferred(log types.Log) (*RocketminipoolregistryOwnershipTransferred, error) {
+	event := new(RocketminipoolregistryOwnershipTransferred)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RocketminipoolregistryPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryPausedIterator struct {
+	Event *RocketminipoolregistryPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryPaused represents a Paused event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryPaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterPaused(opts *bind.FilterOpts) (*RocketminipoolregistryPausedIterator, error) {
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryPausedIterator{contract: _Rocketminipoolregistry.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryPaused) (event.Subscription, error) {
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryPaused)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParsePaused(log types.Log) (*RocketminipoolregistryPaused, error) {
+	event := new(RocketminipoolregistryPaused)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RocketminipoolregistryUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryUnpausedIterator struct {
+	Event *RocketminipoolregistryUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryUnpaused represents a Unpaused event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryUnpaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterUnpaused(opts *bind.FilterOpts) (*RocketminipoolregistryUnpausedIterator, error) {
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryUnpausedIterator{contract: _Rocketminipoolregistry.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryUnpaused) (event.Subscription, error) {
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryUnpaused)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseUnpaused(log types.Log) (*RocketminipoolregistryUnpaused, error) {
+	event := new(RocketminipoolregistryUnpaused)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RocketminipoolregistryUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryUpgradedIterator struct {
+	Event *RocketminipoolregistryUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryUpgraded represents a Upgraded event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*RocketminipoolregistryUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryUpgradedIterator{contract: _Rocketminipoolregistry.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryUpgraded)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseUpgraded(log types.Log) (*RocketminipoolregistryUpgraded, error) {
+	event := new(RocketminipoolregistryUpgraded)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RocketminipoolregistryValidatorDeregisteredIterator is returned from FilterValidatorDeregistered and is used to iterate over the raw logs and unpacked data for ValidatorDeregistered events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryValidatorDeregisteredIterator struct {
+	Event *RocketminipoolregistryValidatorDeregistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryValidatorDeregisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryValidatorDeregistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryValidatorDeregistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryValidatorDeregisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryValidatorDeregisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryValidatorDeregistered represents a ValidatorDeregistered event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryValidatorDeregistered struct {
+	ValidatorPubKey []byte
+	NodeAddress     common.Address
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorDeregistered is a free log retrieval operation binding the contract event 0x10ec0bb1533e599e504516d6b49226d8a637ea19cbadfc6f7ff14a01bede3170.
+//
+// Solidity: event ValidatorDeregistered(bytes validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorDeregistered(opts *bind.FilterOpts, nodeAddress []common.Address) (*RocketminipoolregistryValidatorDeregisteredIterator, error) {
+
+	var nodeAddressRule []interface{}
+	for _, nodeAddressItem := range nodeAddress {
+		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorDeregistered", nodeAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryValidatorDeregisteredIterator{contract: _Rocketminipoolregistry.contract, event: "ValidatorDeregistered", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorDeregistered is a free log subscription operation binding the contract event 0x10ec0bb1533e599e504516d6b49226d8a637ea19cbadfc6f7ff14a01bede3170.
+//
+// Solidity: event ValidatorDeregistered(bytes validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorDeregistered(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorDeregistered, nodeAddress []common.Address) (event.Subscription, error) {
+
+	var nodeAddressRule []interface{}
+	for _, nodeAddressItem := range nodeAddress {
+		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorDeregistered", nodeAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryValidatorDeregistered)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorDeregistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorDeregistered is a log parse operation binding the contract event 0x10ec0bb1533e599e504516d6b49226d8a637ea19cbadfc6f7ff14a01bede3170.
+//
+// Solidity: event ValidatorDeregistered(bytes validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseValidatorDeregistered(log types.Log) (*RocketminipoolregistryValidatorDeregistered, error) {
+	event := new(RocketminipoolregistryValidatorDeregistered)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorDeregistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RocketminipoolregistryValidatorDeregistrationRequestedIterator is returned from FilterValidatorDeregistrationRequested and is used to iterate over the raw logs and unpacked data for ValidatorDeregistrationRequested events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryValidatorDeregistrationRequestedIterator struct {
+	Event *RocketminipoolregistryValidatorDeregistrationRequested // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryValidatorDeregistrationRequestedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryValidatorDeregistrationRequested)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryValidatorDeregistrationRequested)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryValidatorDeregistrationRequestedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryValidatorDeregistrationRequestedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryValidatorDeregistrationRequested represents a ValidatorDeregistrationRequested event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryValidatorDeregistrationRequested struct {
+	ValidatorPubKey []byte
+	NodeAddress     common.Address
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorDeregistrationRequested is a free log retrieval operation binding the contract event 0x13b70fd48d462f71863cae24350d77b0dc4115a7e928b39dd0f0f60b701ffed3.
+//
+// Solidity: event ValidatorDeregistrationRequested(bytes validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorDeregistrationRequested(opts *bind.FilterOpts, nodeAddress []common.Address) (*RocketminipoolregistryValidatorDeregistrationRequestedIterator, error) {
+
+	var nodeAddressRule []interface{}
+	for _, nodeAddressItem := range nodeAddress {
+		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorDeregistrationRequested", nodeAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryValidatorDeregistrationRequestedIterator{contract: _Rocketminipoolregistry.contract, event: "ValidatorDeregistrationRequested", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorDeregistrationRequested is a free log subscription operation binding the contract event 0x13b70fd48d462f71863cae24350d77b0dc4115a7e928b39dd0f0f60b701ffed3.
+//
+// Solidity: event ValidatorDeregistrationRequested(bytes validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorDeregistrationRequested(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorDeregistrationRequested, nodeAddress []common.Address) (event.Subscription, error) {
+
+	var nodeAddressRule []interface{}
+	for _, nodeAddressItem := range nodeAddress {
+		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorDeregistrationRequested", nodeAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryValidatorDeregistrationRequested)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorDeregistrationRequested", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorDeregistrationRequested is a log parse operation binding the contract event 0x13b70fd48d462f71863cae24350d77b0dc4115a7e928b39dd0f0f60b701ffed3.
+//
+// Solidity: event ValidatorDeregistrationRequested(bytes validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseValidatorDeregistrationRequested(log types.Log) (*RocketminipoolregistryValidatorDeregistrationRequested, error) {
+	event := new(RocketminipoolregistryValidatorDeregistrationRequested)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorDeregistrationRequested", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RocketminipoolregistryValidatorFrozenIterator is returned from FilterValidatorFrozen and is used to iterate over the raw logs and unpacked data for ValidatorFrozen events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryValidatorFrozenIterator struct {
+	Event *RocketminipoolregistryValidatorFrozen // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryValidatorFrozenIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryValidatorFrozen)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryValidatorFrozen)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryValidatorFrozenIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryValidatorFrozenIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryValidatorFrozen represents a ValidatorFrozen event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryValidatorFrozen struct {
+	ValidatorPubKey []byte
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorFrozen is a free log retrieval operation binding the contract event 0xfa1d47945b5949504666dd8477bbfc00a77b976fb2119961c96adf939e53e876.
+//
+// Solidity: event ValidatorFrozen(bytes validatorPubKey)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorFrozen(opts *bind.FilterOpts) (*RocketminipoolregistryValidatorFrozenIterator, error) {
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorFrozen")
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryValidatorFrozenIterator{contract: _Rocketminipoolregistry.contract, event: "ValidatorFrozen", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorFrozen is a free log subscription operation binding the contract event 0xfa1d47945b5949504666dd8477bbfc00a77b976fb2119961c96adf939e53e876.
+//
+// Solidity: event ValidatorFrozen(bytes validatorPubKey)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorFrozen(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorFrozen) (event.Subscription, error) {
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorFrozen")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryValidatorFrozen)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorFrozen", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorFrozen is a log parse operation binding the contract event 0xfa1d47945b5949504666dd8477bbfc00a77b976fb2119961c96adf939e53e876.
+//
+// Solidity: event ValidatorFrozen(bytes validatorPubKey)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseValidatorFrozen(log types.Log) (*RocketminipoolregistryValidatorFrozen, error) {
+	event := new(RocketminipoolregistryValidatorFrozen)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorFrozen", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RocketminipoolregistryValidatorRegisteredIterator is returned from FilterValidatorRegistered and is used to iterate over the raw logs and unpacked data for ValidatorRegistered events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryValidatorRegisteredIterator struct {
+	Event *RocketminipoolregistryValidatorRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryValidatorRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryValidatorRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryValidatorRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryValidatorRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryValidatorRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryValidatorRegistered represents a ValidatorRegistered event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryValidatorRegistered struct {
+	ValidatorPubKey []byte
+	NodeAddress     common.Address
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorRegistered is a free log retrieval operation binding the contract event 0x7cb7aef9bd2e5ee3f6073019691bb332fe3ef290465065aca1b9983f3dc66c56.
+//
+// Solidity: event ValidatorRegistered(bytes validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorRegistered(opts *bind.FilterOpts, nodeAddress []common.Address) (*RocketminipoolregistryValidatorRegisteredIterator, error) {
+
+	var nodeAddressRule []interface{}
+	for _, nodeAddressItem := range nodeAddress {
+		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorRegistered", nodeAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryValidatorRegisteredIterator{contract: _Rocketminipoolregistry.contract, event: "ValidatorRegistered", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorRegistered is a free log subscription operation binding the contract event 0x7cb7aef9bd2e5ee3f6073019691bb332fe3ef290465065aca1b9983f3dc66c56.
+//
+// Solidity: event ValidatorRegistered(bytes validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorRegistered(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorRegistered, nodeAddress []common.Address) (event.Subscription, error) {
+
+	var nodeAddressRule []interface{}
+	for _, nodeAddressItem := range nodeAddress {
+		nodeAddressRule = append(nodeAddressRule, nodeAddressItem)
+	}
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorRegistered", nodeAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryValidatorRegistered)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorRegistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorRegistered is a log parse operation binding the contract event 0x7cb7aef9bd2e5ee3f6073019691bb332fe3ef290465065aca1b9983f3dc66c56.
+//
+// Solidity: event ValidatorRegistered(bytes validatorPubKey, address indexed nodeAddress)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseValidatorRegistered(log types.Log) (*RocketminipoolregistryValidatorRegistered, error) {
+	event := new(RocketminipoolregistryValidatorRegistered)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorRegistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// RocketminipoolregistryValidatorUnfrozenIterator is returned from FilterValidatorUnfrozen and is used to iterate over the raw logs and unpacked data for ValidatorUnfrozen events raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryValidatorUnfrozenIterator struct {
+	Event *RocketminipoolregistryValidatorUnfrozen // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RocketminipoolregistryValidatorUnfrozenIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RocketminipoolregistryValidatorUnfrozen)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RocketminipoolregistryValidatorUnfrozen)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RocketminipoolregistryValidatorUnfrozenIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RocketminipoolregistryValidatorUnfrozenIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RocketminipoolregistryValidatorUnfrozen represents a ValidatorUnfrozen event raised by the Rocketminipoolregistry contract.
+type RocketminipoolregistryValidatorUnfrozen struct {
+	ValidatorPubKey []byte
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorUnfrozen is a free log retrieval operation binding the contract event 0x83f1169418932171cc1b130d2c1e543ace8af55b47e4a1341b39b9c71d491392.
+//
+// Solidity: event ValidatorUnfrozen(bytes validatorPubKey)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) FilterValidatorUnfrozen(opts *bind.FilterOpts) (*RocketminipoolregistryValidatorUnfrozenIterator, error) {
+
+	logs, sub, err := _Rocketminipoolregistry.contract.FilterLogs(opts, "ValidatorUnfrozen")
+	if err != nil {
+		return nil, err
+	}
+	return &RocketminipoolregistryValidatorUnfrozenIterator{contract: _Rocketminipoolregistry.contract, event: "ValidatorUnfrozen", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorUnfrozen is a free log subscription operation binding the contract event 0x83f1169418932171cc1b130d2c1e543ace8af55b47e4a1341b39b9c71d491392.
+//
+// Solidity: event ValidatorUnfrozen(bytes validatorPubKey)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) WatchValidatorUnfrozen(opts *bind.WatchOpts, sink chan<- *RocketminipoolregistryValidatorUnfrozen) (event.Subscription, error) {
+
+	logs, sub, err := _Rocketminipoolregistry.contract.WatchLogs(opts, "ValidatorUnfrozen")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RocketminipoolregistryValidatorUnfrozen)
+				if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorUnfrozen", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorUnfrozen is a log parse operation binding the contract event 0x83f1169418932171cc1b130d2c1e543ace8af55b47e4a1341b39b9c71d491392.
+//
+// Solidity: event ValidatorUnfrozen(bytes validatorPubKey)
+func (_Rocketminipoolregistry *RocketminipoolregistryFilterer) ParseValidatorUnfrozen(log types.Log) (*RocketminipoolregistryValidatorUnfrozen, error) {
+	event := new(RocketminipoolregistryValidatorUnfrozen)
+	if err := _Rocketminipoolregistry.contract.UnpackLog(event, "ValidatorUnfrozen", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts-abi/clients/ValidatorOptInHub/ValidatorOptInHub.go
+++ b/contracts-abi/clients/ValidatorOptInHub/ValidatorOptInHub.go
@@ -1,0 +1,1722 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package validatoroptinhub
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// ValidatoroptinhubMetaData contains all meta data concerning the Validatoroptinhub contract.
+var ValidatoroptinhubMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"fallback\",\"stateMutability\":\"payable\"},{\"type\":\"receive\",\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"addRegistry\",\"inputs\":[{\"name\":\"registry\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"areValidatorsOptedIn\",\"inputs\":[{\"name\":\"valBLSPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool[]\",\"internalType\":\"bool[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"areValidatorsOptedInList\",\"inputs\":[{\"name\":\"valBLSPubKeys\",\"type\":\"bytes[]\",\"internalType\":\"bytes[]\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool[][]\",\"internalType\":\"bool[][]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_registries\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isValidatorOptedIn\",\"inputs\":[{\"name\":\"valPubKey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorOptedInList\",\"inputs\":[{\"name\":\"valPubKey\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool[]\",\"internalType\":\"bool[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"registries\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"removeRegistry\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"registry\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"updateRegistry\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"oldRegistry\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"newRegistry\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RegistryAdded\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"registry\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RegistryRemoved\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"registry\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RegistryReplaced\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"oldRegistry\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newRegistry\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedInnerCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IndexRegistryMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidFallback\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidIndex\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReceive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidRegistry\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]}]",
+}
+
+// ValidatoroptinhubABI is the input ABI used to generate the binding from.
+// Deprecated: Use ValidatoroptinhubMetaData.ABI instead.
+var ValidatoroptinhubABI = ValidatoroptinhubMetaData.ABI
+
+// Validatoroptinhub is an auto generated Go binding around an Ethereum contract.
+type Validatoroptinhub struct {
+	ValidatoroptinhubCaller     // Read-only binding to the contract
+	ValidatoroptinhubTransactor // Write-only binding to the contract
+	ValidatoroptinhubFilterer   // Log filterer for contract events
+}
+
+// ValidatoroptinhubCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ValidatoroptinhubCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ValidatoroptinhubTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ValidatoroptinhubTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ValidatoroptinhubFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ValidatoroptinhubFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ValidatoroptinhubSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ValidatoroptinhubSession struct {
+	Contract     *Validatoroptinhub // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts      // Call options to use throughout this session
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// ValidatoroptinhubCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ValidatoroptinhubCallerSession struct {
+	Contract *ValidatoroptinhubCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts            // Call options to use throughout this session
+}
+
+// ValidatoroptinhubTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ValidatoroptinhubTransactorSession struct {
+	Contract     *ValidatoroptinhubTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts            // Transaction auth options to use throughout this session
+}
+
+// ValidatoroptinhubRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ValidatoroptinhubRaw struct {
+	Contract *Validatoroptinhub // Generic contract binding to access the raw methods on
+}
+
+// ValidatoroptinhubCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ValidatoroptinhubCallerRaw struct {
+	Contract *ValidatoroptinhubCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ValidatoroptinhubTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ValidatoroptinhubTransactorRaw struct {
+	Contract *ValidatoroptinhubTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewValidatoroptinhub creates a new instance of Validatoroptinhub, bound to a specific deployed contract.
+func NewValidatoroptinhub(address common.Address, backend bind.ContractBackend) (*Validatoroptinhub, error) {
+	contract, err := bindValidatoroptinhub(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Validatoroptinhub{ValidatoroptinhubCaller: ValidatoroptinhubCaller{contract: contract}, ValidatoroptinhubTransactor: ValidatoroptinhubTransactor{contract: contract}, ValidatoroptinhubFilterer: ValidatoroptinhubFilterer{contract: contract}}, nil
+}
+
+// NewValidatoroptinhubCaller creates a new read-only instance of Validatoroptinhub, bound to a specific deployed contract.
+func NewValidatoroptinhubCaller(address common.Address, caller bind.ContractCaller) (*ValidatoroptinhubCaller, error) {
+	contract, err := bindValidatoroptinhub(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatoroptinhubCaller{contract: contract}, nil
+}
+
+// NewValidatoroptinhubTransactor creates a new write-only instance of Validatoroptinhub, bound to a specific deployed contract.
+func NewValidatoroptinhubTransactor(address common.Address, transactor bind.ContractTransactor) (*ValidatoroptinhubTransactor, error) {
+	contract, err := bindValidatoroptinhub(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatoroptinhubTransactor{contract: contract}, nil
+}
+
+// NewValidatoroptinhubFilterer creates a new log filterer instance of Validatoroptinhub, bound to a specific deployed contract.
+func NewValidatoroptinhubFilterer(address common.Address, filterer bind.ContractFilterer) (*ValidatoroptinhubFilterer, error) {
+	contract, err := bindValidatoroptinhub(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatoroptinhubFilterer{contract: contract}, nil
+}
+
+// bindValidatoroptinhub binds a generic wrapper to an already deployed contract.
+func bindValidatoroptinhub(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := ValidatoroptinhubMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Validatoroptinhub *ValidatoroptinhubRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Validatoroptinhub.Contract.ValidatoroptinhubCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Validatoroptinhub *ValidatoroptinhubRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.ValidatoroptinhubTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Validatoroptinhub *ValidatoroptinhubRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.ValidatoroptinhubTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Validatoroptinhub *ValidatoroptinhubCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Validatoroptinhub.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Validatoroptinhub *ValidatoroptinhubTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Validatoroptinhub *ValidatoroptinhubTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.contract.Transact(opts, method, params...)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Validatoroptinhub *ValidatoroptinhubCaller) UPGRADEINTERFACEVERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _Validatoroptinhub.contract.Call(opts, &out, "UPGRADE_INTERFACE_VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Validatoroptinhub *ValidatoroptinhubSession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _Validatoroptinhub.Contract.UPGRADEINTERFACEVERSION(&_Validatoroptinhub.CallOpts)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_Validatoroptinhub *ValidatoroptinhubCallerSession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _Validatoroptinhub.Contract.UPGRADEINTERFACEVERSION(&_Validatoroptinhub.CallOpts)
+}
+
+// AreValidatorsOptedIn is a free data retrieval call binding the contract method 0x5b88b173.
+//
+// Solidity: function areValidatorsOptedIn(bytes[] valBLSPubKeys) view returns(bool[])
+func (_Validatoroptinhub *ValidatoroptinhubCaller) AreValidatorsOptedIn(opts *bind.CallOpts, valBLSPubKeys [][]byte) ([]bool, error) {
+	var out []interface{}
+	err := _Validatoroptinhub.contract.Call(opts, &out, "areValidatorsOptedIn", valBLSPubKeys)
+
+	if err != nil {
+		return *new([]bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]bool)).(*[]bool)
+
+	return out0, err
+
+}
+
+// AreValidatorsOptedIn is a free data retrieval call binding the contract method 0x5b88b173.
+//
+// Solidity: function areValidatorsOptedIn(bytes[] valBLSPubKeys) view returns(bool[])
+func (_Validatoroptinhub *ValidatoroptinhubSession) AreValidatorsOptedIn(valBLSPubKeys [][]byte) ([]bool, error) {
+	return _Validatoroptinhub.Contract.AreValidatorsOptedIn(&_Validatoroptinhub.CallOpts, valBLSPubKeys)
+}
+
+// AreValidatorsOptedIn is a free data retrieval call binding the contract method 0x5b88b173.
+//
+// Solidity: function areValidatorsOptedIn(bytes[] valBLSPubKeys) view returns(bool[])
+func (_Validatoroptinhub *ValidatoroptinhubCallerSession) AreValidatorsOptedIn(valBLSPubKeys [][]byte) ([]bool, error) {
+	return _Validatoroptinhub.Contract.AreValidatorsOptedIn(&_Validatoroptinhub.CallOpts, valBLSPubKeys)
+}
+
+// AreValidatorsOptedInList is a free data retrieval call binding the contract method 0xc9384003.
+//
+// Solidity: function areValidatorsOptedInList(bytes[] valBLSPubKeys) view returns(bool[][])
+func (_Validatoroptinhub *ValidatoroptinhubCaller) AreValidatorsOptedInList(opts *bind.CallOpts, valBLSPubKeys [][]byte) ([][]bool, error) {
+	var out []interface{}
+	err := _Validatoroptinhub.contract.Call(opts, &out, "areValidatorsOptedInList", valBLSPubKeys)
+
+	if err != nil {
+		return *new([][]bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([][]bool)).(*[][]bool)
+
+	return out0, err
+
+}
+
+// AreValidatorsOptedInList is a free data retrieval call binding the contract method 0xc9384003.
+//
+// Solidity: function areValidatorsOptedInList(bytes[] valBLSPubKeys) view returns(bool[][])
+func (_Validatoroptinhub *ValidatoroptinhubSession) AreValidatorsOptedInList(valBLSPubKeys [][]byte) ([][]bool, error) {
+	return _Validatoroptinhub.Contract.AreValidatorsOptedInList(&_Validatoroptinhub.CallOpts, valBLSPubKeys)
+}
+
+// AreValidatorsOptedInList is a free data retrieval call binding the contract method 0xc9384003.
+//
+// Solidity: function areValidatorsOptedInList(bytes[] valBLSPubKeys) view returns(bool[][])
+func (_Validatoroptinhub *ValidatoroptinhubCallerSession) AreValidatorsOptedInList(valBLSPubKeys [][]byte) ([][]bool, error) {
+	return _Validatoroptinhub.Contract.AreValidatorsOptedInList(&_Validatoroptinhub.CallOpts, valBLSPubKeys)
+}
+
+// IsValidatorOptedIn is a free data retrieval call binding the contract method 0x470b690f.
+//
+// Solidity: function isValidatorOptedIn(bytes valPubKey) view returns(bool)
+func (_Validatoroptinhub *ValidatoroptinhubCaller) IsValidatorOptedIn(opts *bind.CallOpts, valPubKey []byte) (bool, error) {
+	var out []interface{}
+	err := _Validatoroptinhub.contract.Call(opts, &out, "isValidatorOptedIn", valPubKey)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsValidatorOptedIn is a free data retrieval call binding the contract method 0x470b690f.
+//
+// Solidity: function isValidatorOptedIn(bytes valPubKey) view returns(bool)
+func (_Validatoroptinhub *ValidatoroptinhubSession) IsValidatorOptedIn(valPubKey []byte) (bool, error) {
+	return _Validatoroptinhub.Contract.IsValidatorOptedIn(&_Validatoroptinhub.CallOpts, valPubKey)
+}
+
+// IsValidatorOptedIn is a free data retrieval call binding the contract method 0x470b690f.
+//
+// Solidity: function isValidatorOptedIn(bytes valPubKey) view returns(bool)
+func (_Validatoroptinhub *ValidatoroptinhubCallerSession) IsValidatorOptedIn(valPubKey []byte) (bool, error) {
+	return _Validatoroptinhub.Contract.IsValidatorOptedIn(&_Validatoroptinhub.CallOpts, valPubKey)
+}
+
+// IsValidatorOptedInList is a free data retrieval call binding the contract method 0x374876f2.
+//
+// Solidity: function isValidatorOptedInList(bytes valPubKey) view returns(bool[])
+func (_Validatoroptinhub *ValidatoroptinhubCaller) IsValidatorOptedInList(opts *bind.CallOpts, valPubKey []byte) ([]bool, error) {
+	var out []interface{}
+	err := _Validatoroptinhub.contract.Call(opts, &out, "isValidatorOptedInList", valPubKey)
+
+	if err != nil {
+		return *new([]bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]bool)).(*[]bool)
+
+	return out0, err
+
+}
+
+// IsValidatorOptedInList is a free data retrieval call binding the contract method 0x374876f2.
+//
+// Solidity: function isValidatorOptedInList(bytes valPubKey) view returns(bool[])
+func (_Validatoroptinhub *ValidatoroptinhubSession) IsValidatorOptedInList(valPubKey []byte) ([]bool, error) {
+	return _Validatoroptinhub.Contract.IsValidatorOptedInList(&_Validatoroptinhub.CallOpts, valPubKey)
+}
+
+// IsValidatorOptedInList is a free data retrieval call binding the contract method 0x374876f2.
+//
+// Solidity: function isValidatorOptedInList(bytes valPubKey) view returns(bool[])
+func (_Validatoroptinhub *ValidatoroptinhubCallerSession) IsValidatorOptedInList(valPubKey []byte) ([]bool, error) {
+	return _Validatoroptinhub.Contract.IsValidatorOptedInList(&_Validatoroptinhub.CallOpts, valPubKey)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Validatoroptinhub *ValidatoroptinhubCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Validatoroptinhub.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Validatoroptinhub *ValidatoroptinhubSession) Owner() (common.Address, error) {
+	return _Validatoroptinhub.Contract.Owner(&_Validatoroptinhub.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Validatoroptinhub *ValidatoroptinhubCallerSession) Owner() (common.Address, error) {
+	return _Validatoroptinhub.Contract.Owner(&_Validatoroptinhub.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Validatoroptinhub *ValidatoroptinhubCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Validatoroptinhub.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Validatoroptinhub *ValidatoroptinhubSession) PendingOwner() (common.Address, error) {
+	return _Validatoroptinhub.Contract.PendingOwner(&_Validatoroptinhub.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Validatoroptinhub *ValidatoroptinhubCallerSession) PendingOwner() (common.Address, error) {
+	return _Validatoroptinhub.Contract.PendingOwner(&_Validatoroptinhub.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Validatoroptinhub *ValidatoroptinhubCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Validatoroptinhub.contract.Call(opts, &out, "proxiableUUID")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Validatoroptinhub *ValidatoroptinhubSession) ProxiableUUID() ([32]byte, error) {
+	return _Validatoroptinhub.Contract.ProxiableUUID(&_Validatoroptinhub.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Validatoroptinhub *ValidatoroptinhubCallerSession) ProxiableUUID() ([32]byte, error) {
+	return _Validatoroptinhub.Contract.ProxiableUUID(&_Validatoroptinhub.CallOpts)
+}
+
+// Registries is a free data retrieval call binding the contract method 0x6347c900.
+//
+// Solidity: function registries(uint256 ) view returns(address)
+func (_Validatoroptinhub *ValidatoroptinhubCaller) Registries(opts *bind.CallOpts, arg0 *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _Validatoroptinhub.contract.Call(opts, &out, "registries", arg0)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Registries is a free data retrieval call binding the contract method 0x6347c900.
+//
+// Solidity: function registries(uint256 ) view returns(address)
+func (_Validatoroptinhub *ValidatoroptinhubSession) Registries(arg0 *big.Int) (common.Address, error) {
+	return _Validatoroptinhub.Contract.Registries(&_Validatoroptinhub.CallOpts, arg0)
+}
+
+// Registries is a free data retrieval call binding the contract method 0x6347c900.
+//
+// Solidity: function registries(uint256 ) view returns(address)
+func (_Validatoroptinhub *ValidatoroptinhubCallerSession) Registries(arg0 *big.Int) (common.Address, error) {
+	return _Validatoroptinhub.Contract.Registries(&_Validatoroptinhub.CallOpts, arg0)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Validatoroptinhub.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Validatoroptinhub *ValidatoroptinhubSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.AcceptOwnership(&_Validatoroptinhub.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.AcceptOwnership(&_Validatoroptinhub.TransactOpts)
+}
+
+// AddRegistry is a paid mutator transaction binding the contract method 0xf6b11a23.
+//
+// Solidity: function addRegistry(address registry) returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactor) AddRegistry(opts *bind.TransactOpts, registry common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.contract.Transact(opts, "addRegistry", registry)
+}
+
+// AddRegistry is a paid mutator transaction binding the contract method 0xf6b11a23.
+//
+// Solidity: function addRegistry(address registry) returns()
+func (_Validatoroptinhub *ValidatoroptinhubSession) AddRegistry(registry common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.AddRegistry(&_Validatoroptinhub.TransactOpts, registry)
+}
+
+// AddRegistry is a paid mutator transaction binding the contract method 0xf6b11a23.
+//
+// Solidity: function addRegistry(address registry) returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactorSession) AddRegistry(registry common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.AddRegistry(&_Validatoroptinhub.TransactOpts, registry)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x462d0b2e.
+//
+// Solidity: function initialize(address[] _registries, address _owner) returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactor) Initialize(opts *bind.TransactOpts, _registries []common.Address, _owner common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.contract.Transact(opts, "initialize", _registries, _owner)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x462d0b2e.
+//
+// Solidity: function initialize(address[] _registries, address _owner) returns()
+func (_Validatoroptinhub *ValidatoroptinhubSession) Initialize(_registries []common.Address, _owner common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.Initialize(&_Validatoroptinhub.TransactOpts, _registries, _owner)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x462d0b2e.
+//
+// Solidity: function initialize(address[] _registries, address _owner) returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactorSession) Initialize(_registries []common.Address, _owner common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.Initialize(&_Validatoroptinhub.TransactOpts, _registries, _owner)
+}
+
+// RemoveRegistry is a paid mutator transaction binding the contract method 0x151c5f27.
+//
+// Solidity: function removeRegistry(uint256 index, address registry) returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactor) RemoveRegistry(opts *bind.TransactOpts, index *big.Int, registry common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.contract.Transact(opts, "removeRegistry", index, registry)
+}
+
+// RemoveRegistry is a paid mutator transaction binding the contract method 0x151c5f27.
+//
+// Solidity: function removeRegistry(uint256 index, address registry) returns()
+func (_Validatoroptinhub *ValidatoroptinhubSession) RemoveRegistry(index *big.Int, registry common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.RemoveRegistry(&_Validatoroptinhub.TransactOpts, index, registry)
+}
+
+// RemoveRegistry is a paid mutator transaction binding the contract method 0x151c5f27.
+//
+// Solidity: function removeRegistry(uint256 index, address registry) returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactorSession) RemoveRegistry(index *big.Int, registry common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.RemoveRegistry(&_Validatoroptinhub.TransactOpts, index, registry)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Validatoroptinhub.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Validatoroptinhub *ValidatoroptinhubSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.RenounceOwnership(&_Validatoroptinhub.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.RenounceOwnership(&_Validatoroptinhub.TransactOpts)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Validatoroptinhub *ValidatoroptinhubSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.TransferOwnership(&_Validatoroptinhub.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.TransferOwnership(&_Validatoroptinhub.TransactOpts, newOwner)
+}
+
+// UpdateRegistry is a paid mutator transaction binding the contract method 0x28b4c446.
+//
+// Solidity: function updateRegistry(uint256 index, address oldRegistry, address newRegistry) returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactor) UpdateRegistry(opts *bind.TransactOpts, index *big.Int, oldRegistry common.Address, newRegistry common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.contract.Transact(opts, "updateRegistry", index, oldRegistry, newRegistry)
+}
+
+// UpdateRegistry is a paid mutator transaction binding the contract method 0x28b4c446.
+//
+// Solidity: function updateRegistry(uint256 index, address oldRegistry, address newRegistry) returns()
+func (_Validatoroptinhub *ValidatoroptinhubSession) UpdateRegistry(index *big.Int, oldRegistry common.Address, newRegistry common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.UpdateRegistry(&_Validatoroptinhub.TransactOpts, index, oldRegistry, newRegistry)
+}
+
+// UpdateRegistry is a paid mutator transaction binding the contract method 0x28b4c446.
+//
+// Solidity: function updateRegistry(uint256 index, address oldRegistry, address newRegistry) returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactorSession) UpdateRegistry(index *big.Int, oldRegistry common.Address, newRegistry common.Address) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.UpdateRegistry(&_Validatoroptinhub.TransactOpts, index, oldRegistry, newRegistry)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Validatoroptinhub.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Validatoroptinhub *ValidatoroptinhubSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.UpgradeToAndCall(&_Validatoroptinhub.TransactOpts, newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.UpgradeToAndCall(&_Validatoroptinhub.TransactOpts, newImplementation, data)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
+	return _Validatoroptinhub.contract.RawTransact(opts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Validatoroptinhub *ValidatoroptinhubSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.Fallback(&_Validatoroptinhub.TransactOpts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.Fallback(&_Validatoroptinhub.TransactOpts, calldata)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Validatoroptinhub.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Validatoroptinhub *ValidatoroptinhubSession) Receive() (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.Receive(&_Validatoroptinhub.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Validatoroptinhub *ValidatoroptinhubTransactorSession) Receive() (*types.Transaction, error) {
+	return _Validatoroptinhub.Contract.Receive(&_Validatoroptinhub.TransactOpts)
+}
+
+// ValidatoroptinhubInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Validatoroptinhub contract.
+type ValidatoroptinhubInitializedIterator struct {
+	Event *ValidatoroptinhubInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ValidatoroptinhubInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ValidatoroptinhubInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ValidatoroptinhubInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ValidatoroptinhubInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ValidatoroptinhubInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ValidatoroptinhubInitialized represents a Initialized event raised by the Validatoroptinhub contract.
+type ValidatoroptinhubInitialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) FilterInitialized(opts *bind.FilterOpts) (*ValidatoroptinhubInitializedIterator, error) {
+
+	logs, sub, err := _Validatoroptinhub.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatoroptinhubInitializedIterator{contract: _Validatoroptinhub.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *ValidatoroptinhubInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _Validatoroptinhub.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ValidatoroptinhubInitialized)
+				if err := _Validatoroptinhub.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) ParseInitialized(log types.Log) (*ValidatoroptinhubInitialized, error) {
+	event := new(ValidatoroptinhubInitialized)
+	if err := _Validatoroptinhub.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ValidatoroptinhubOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the Validatoroptinhub contract.
+type ValidatoroptinhubOwnershipTransferStartedIterator struct {
+	Event *ValidatoroptinhubOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ValidatoroptinhubOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ValidatoroptinhubOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ValidatoroptinhubOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ValidatoroptinhubOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ValidatoroptinhubOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ValidatoroptinhubOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the Validatoroptinhub contract.
+type ValidatoroptinhubOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ValidatoroptinhubOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatoroptinhubOwnershipTransferStartedIterator{contract: _Validatoroptinhub.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *ValidatoroptinhubOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ValidatoroptinhubOwnershipTransferStarted)
+				if err := _Validatoroptinhub.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) ParseOwnershipTransferStarted(log types.Log) (*ValidatoroptinhubOwnershipTransferStarted, error) {
+	event := new(ValidatoroptinhubOwnershipTransferStarted)
+	if err := _Validatoroptinhub.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ValidatoroptinhubOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Validatoroptinhub contract.
+type ValidatoroptinhubOwnershipTransferredIterator struct {
+	Event *ValidatoroptinhubOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ValidatoroptinhubOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ValidatoroptinhubOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ValidatoroptinhubOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ValidatoroptinhubOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ValidatoroptinhubOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ValidatoroptinhubOwnershipTransferred represents a OwnershipTransferred event raised by the Validatoroptinhub contract.
+type ValidatoroptinhubOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ValidatoroptinhubOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatoroptinhubOwnershipTransferredIterator{contract: _Validatoroptinhub.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *ValidatoroptinhubOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ValidatoroptinhubOwnershipTransferred)
+				if err := _Validatoroptinhub.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) ParseOwnershipTransferred(log types.Log) (*ValidatoroptinhubOwnershipTransferred, error) {
+	event := new(ValidatoroptinhubOwnershipTransferred)
+	if err := _Validatoroptinhub.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ValidatoroptinhubRegistryAddedIterator is returned from FilterRegistryAdded and is used to iterate over the raw logs and unpacked data for RegistryAdded events raised by the Validatoroptinhub contract.
+type ValidatoroptinhubRegistryAddedIterator struct {
+	Event *ValidatoroptinhubRegistryAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ValidatoroptinhubRegistryAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ValidatoroptinhubRegistryAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ValidatoroptinhubRegistryAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ValidatoroptinhubRegistryAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ValidatoroptinhubRegistryAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ValidatoroptinhubRegistryAdded represents a RegistryAdded event raised by the Validatoroptinhub contract.
+type ValidatoroptinhubRegistryAdded struct {
+	Index    *big.Int
+	Registry common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterRegistryAdded is a free log retrieval operation binding the contract event 0x08d8a372b87adbf98c2b19281866b69031c8e54ae5fa823510d19b803b11382a.
+//
+// Solidity: event RegistryAdded(uint256 indexed index, address indexed registry)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) FilterRegistryAdded(opts *bind.FilterOpts, index []*big.Int, registry []common.Address) (*ValidatoroptinhubRegistryAddedIterator, error) {
+
+	var indexRule []interface{}
+	for _, indexItem := range index {
+		indexRule = append(indexRule, indexItem)
+	}
+	var registryRule []interface{}
+	for _, registryItem := range registry {
+		registryRule = append(registryRule, registryItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.FilterLogs(opts, "RegistryAdded", indexRule, registryRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatoroptinhubRegistryAddedIterator{contract: _Validatoroptinhub.contract, event: "RegistryAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchRegistryAdded is a free log subscription operation binding the contract event 0x08d8a372b87adbf98c2b19281866b69031c8e54ae5fa823510d19b803b11382a.
+//
+// Solidity: event RegistryAdded(uint256 indexed index, address indexed registry)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) WatchRegistryAdded(opts *bind.WatchOpts, sink chan<- *ValidatoroptinhubRegistryAdded, index []*big.Int, registry []common.Address) (event.Subscription, error) {
+
+	var indexRule []interface{}
+	for _, indexItem := range index {
+		indexRule = append(indexRule, indexItem)
+	}
+	var registryRule []interface{}
+	for _, registryItem := range registry {
+		registryRule = append(registryRule, registryItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.WatchLogs(opts, "RegistryAdded", indexRule, registryRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ValidatoroptinhubRegistryAdded)
+				if err := _Validatoroptinhub.contract.UnpackLog(event, "RegistryAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRegistryAdded is a log parse operation binding the contract event 0x08d8a372b87adbf98c2b19281866b69031c8e54ae5fa823510d19b803b11382a.
+//
+// Solidity: event RegistryAdded(uint256 indexed index, address indexed registry)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) ParseRegistryAdded(log types.Log) (*ValidatoroptinhubRegistryAdded, error) {
+	event := new(ValidatoroptinhubRegistryAdded)
+	if err := _Validatoroptinhub.contract.UnpackLog(event, "RegistryAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ValidatoroptinhubRegistryRemovedIterator is returned from FilterRegistryRemoved and is used to iterate over the raw logs and unpacked data for RegistryRemoved events raised by the Validatoroptinhub contract.
+type ValidatoroptinhubRegistryRemovedIterator struct {
+	Event *ValidatoroptinhubRegistryRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ValidatoroptinhubRegistryRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ValidatoroptinhubRegistryRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ValidatoroptinhubRegistryRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ValidatoroptinhubRegistryRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ValidatoroptinhubRegistryRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ValidatoroptinhubRegistryRemoved represents a RegistryRemoved event raised by the Validatoroptinhub contract.
+type ValidatoroptinhubRegistryRemoved struct {
+	Index    *big.Int
+	Registry common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterRegistryRemoved is a free log retrieval operation binding the contract event 0xabeeaf793e0f2bff8bb9ceb901ea839147a1c0282fb908f6f18142bc05ffcd1d.
+//
+// Solidity: event RegistryRemoved(uint256 indexed index, address indexed registry)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) FilterRegistryRemoved(opts *bind.FilterOpts, index []*big.Int, registry []common.Address) (*ValidatoroptinhubRegistryRemovedIterator, error) {
+
+	var indexRule []interface{}
+	for _, indexItem := range index {
+		indexRule = append(indexRule, indexItem)
+	}
+	var registryRule []interface{}
+	for _, registryItem := range registry {
+		registryRule = append(registryRule, registryItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.FilterLogs(opts, "RegistryRemoved", indexRule, registryRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatoroptinhubRegistryRemovedIterator{contract: _Validatoroptinhub.contract, event: "RegistryRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchRegistryRemoved is a free log subscription operation binding the contract event 0xabeeaf793e0f2bff8bb9ceb901ea839147a1c0282fb908f6f18142bc05ffcd1d.
+//
+// Solidity: event RegistryRemoved(uint256 indexed index, address indexed registry)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) WatchRegistryRemoved(opts *bind.WatchOpts, sink chan<- *ValidatoroptinhubRegistryRemoved, index []*big.Int, registry []common.Address) (event.Subscription, error) {
+
+	var indexRule []interface{}
+	for _, indexItem := range index {
+		indexRule = append(indexRule, indexItem)
+	}
+	var registryRule []interface{}
+	for _, registryItem := range registry {
+		registryRule = append(registryRule, registryItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.WatchLogs(opts, "RegistryRemoved", indexRule, registryRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ValidatoroptinhubRegistryRemoved)
+				if err := _Validatoroptinhub.contract.UnpackLog(event, "RegistryRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRegistryRemoved is a log parse operation binding the contract event 0xabeeaf793e0f2bff8bb9ceb901ea839147a1c0282fb908f6f18142bc05ffcd1d.
+//
+// Solidity: event RegistryRemoved(uint256 indexed index, address indexed registry)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) ParseRegistryRemoved(log types.Log) (*ValidatoroptinhubRegistryRemoved, error) {
+	event := new(ValidatoroptinhubRegistryRemoved)
+	if err := _Validatoroptinhub.contract.UnpackLog(event, "RegistryRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ValidatoroptinhubRegistryReplacedIterator is returned from FilterRegistryReplaced and is used to iterate over the raw logs and unpacked data for RegistryReplaced events raised by the Validatoroptinhub contract.
+type ValidatoroptinhubRegistryReplacedIterator struct {
+	Event *ValidatoroptinhubRegistryReplaced // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ValidatoroptinhubRegistryReplacedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ValidatoroptinhubRegistryReplaced)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ValidatoroptinhubRegistryReplaced)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ValidatoroptinhubRegistryReplacedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ValidatoroptinhubRegistryReplacedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ValidatoroptinhubRegistryReplaced represents a RegistryReplaced event raised by the Validatoroptinhub contract.
+type ValidatoroptinhubRegistryReplaced struct {
+	Index       *big.Int
+	OldRegistry common.Address
+	NewRegistry common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterRegistryReplaced is a free log retrieval operation binding the contract event 0x7d7b26f7fb2a6f76146f4e2ae8c5168da44eab44cd4fbecd3dc72ad3bafe03fe.
+//
+// Solidity: event RegistryReplaced(uint256 indexed index, address indexed oldRegistry, address indexed newRegistry)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) FilterRegistryReplaced(opts *bind.FilterOpts, index []*big.Int, oldRegistry []common.Address, newRegistry []common.Address) (*ValidatoroptinhubRegistryReplacedIterator, error) {
+
+	var indexRule []interface{}
+	for _, indexItem := range index {
+		indexRule = append(indexRule, indexItem)
+	}
+	var oldRegistryRule []interface{}
+	for _, oldRegistryItem := range oldRegistry {
+		oldRegistryRule = append(oldRegistryRule, oldRegistryItem)
+	}
+	var newRegistryRule []interface{}
+	for _, newRegistryItem := range newRegistry {
+		newRegistryRule = append(newRegistryRule, newRegistryItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.FilterLogs(opts, "RegistryReplaced", indexRule, oldRegistryRule, newRegistryRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatoroptinhubRegistryReplacedIterator{contract: _Validatoroptinhub.contract, event: "RegistryReplaced", logs: logs, sub: sub}, nil
+}
+
+// WatchRegistryReplaced is a free log subscription operation binding the contract event 0x7d7b26f7fb2a6f76146f4e2ae8c5168da44eab44cd4fbecd3dc72ad3bafe03fe.
+//
+// Solidity: event RegistryReplaced(uint256 indexed index, address indexed oldRegistry, address indexed newRegistry)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) WatchRegistryReplaced(opts *bind.WatchOpts, sink chan<- *ValidatoroptinhubRegistryReplaced, index []*big.Int, oldRegistry []common.Address, newRegistry []common.Address) (event.Subscription, error) {
+
+	var indexRule []interface{}
+	for _, indexItem := range index {
+		indexRule = append(indexRule, indexItem)
+	}
+	var oldRegistryRule []interface{}
+	for _, oldRegistryItem := range oldRegistry {
+		oldRegistryRule = append(oldRegistryRule, oldRegistryItem)
+	}
+	var newRegistryRule []interface{}
+	for _, newRegistryItem := range newRegistry {
+		newRegistryRule = append(newRegistryRule, newRegistryItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.WatchLogs(opts, "RegistryReplaced", indexRule, oldRegistryRule, newRegistryRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ValidatoroptinhubRegistryReplaced)
+				if err := _Validatoroptinhub.contract.UnpackLog(event, "RegistryReplaced", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRegistryReplaced is a log parse operation binding the contract event 0x7d7b26f7fb2a6f76146f4e2ae8c5168da44eab44cd4fbecd3dc72ad3bafe03fe.
+//
+// Solidity: event RegistryReplaced(uint256 indexed index, address indexed oldRegistry, address indexed newRegistry)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) ParseRegistryReplaced(log types.Log) (*ValidatoroptinhubRegistryReplaced, error) {
+	event := new(ValidatoroptinhubRegistryReplaced)
+	if err := _Validatoroptinhub.contract.UnpackLog(event, "RegistryReplaced", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ValidatoroptinhubUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the Validatoroptinhub contract.
+type ValidatoroptinhubUpgradedIterator struct {
+	Event *ValidatoroptinhubUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ValidatoroptinhubUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ValidatoroptinhubUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ValidatoroptinhubUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ValidatoroptinhubUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ValidatoroptinhubUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ValidatoroptinhubUpgraded represents a Upgraded event raised by the Validatoroptinhub contract.
+type ValidatoroptinhubUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*ValidatoroptinhubUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatoroptinhubUpgradedIterator{contract: _Validatoroptinhub.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *ValidatoroptinhubUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _Validatoroptinhub.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ValidatoroptinhubUpgraded)
+				if err := _Validatoroptinhub.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Validatoroptinhub *ValidatoroptinhubFilterer) ParseUpgraded(log types.Log) (*ValidatoroptinhubUpgraded, error) {
+	event := new(ValidatoroptinhubUpgraded)
+	if err := _Validatoroptinhub.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts-abi/script.sh
+++ b/contracts-abi/script.sh
@@ -56,6 +56,8 @@ extract_and_save_abi "$BASE_DIR/out/ValidatorOptInHub.sol/ValidatorOptInHub.json
 
 extract_and_save_abi "$BASE_DIR/out/AlwaysFalseRegistry.sol/AlwaysFalseRegistry.json" "$ABI_DIR/AlwaysFalseRegistry.abi"
 
+extract_and_save_abi "$BASE_DIR/out/RocketMinipoolRegistry.sol/RocketMinipoolRegistry.json" "$ABI_DIR/RocketMinipoolRegistry.abi"
+
 echo "ABI files extracted successfully."
 
 GO_CODE_BASE_DIR="./clients"
@@ -130,6 +132,8 @@ generate_go_code "$ABI_DIR/BlockRewardManager.abi" "BlockRewardManager" "blockre
 generate_go_code "$ABI_DIR/ValidatorOptInHub.abi" "ValidatorOptInHub" "validatoroptinhub"
 
 generate_go_code "$ABI_DIR/AlwaysFalseRegistry.abi" "AlwaysFalseRegistry" "alwaysfalseregistry"
+
+generate_go_code "$ABI_DIR/RocketMinipoolRegistry.abi" "RocketMinipoolRegistry" "rocketminipoolregistry"
 
 echo "External ABI downloaded and processed successfully."
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -61,6 +61,7 @@ This changelog tracks deployments of **Hoodi Testnet** contracts. This changelog
 | VanillaRegistry       | `0x536f0792c5d5ed592e67a9260606c85f59c312f0` | `13cf068477e6efdbb5c4fe5ce53a11af30bf8b47` in 'main'      |
 | MevCommitAVS          | `0xdF8649d298ad05f019eE4AdBD6210867B8AB225F` | `13cf068477e6efdbb5c4fe5ce53a11af30bf8b47` in 'main'      |
 | MevCommitMiddleware   | `0x8E847EC4a36c8332652aB3b2B7D5c54dE29c7fde` | `13cf068477e6efdbb5c4fe5ce53a11af30bf8b47` in 'main'      |
+| RocketMinipoolRegistry| `0x30d478b02918c4b11731efc4868d848d551e79b2` | `d994896a8b17b131ebda8bbae1a43ddd55c906c1` in 'rocketpool-registry'      |
 
 
 ### Upgrade History

--- a/contracts/contracts/interfaces/IRocketMinipoolRegistry.sol
+++ b/contracts/contracts/interfaces/IRocketMinipoolRegistry.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BSL 1.1
+pragma solidity 0.8.26;
+
+interface IRocketMinipoolRegistry {
+
+    struct ValidatorRegistration {
+        bool exists;
+        uint64 deregTimestamp;
+        uint64 freezeTimestamp;
+    }
+
+    /// @notice Emitted when a validator is registered.
+    event ValidatorRegistered(bytes validatorPubKey, address indexed nodeAddress);
+
+    /// @notice Emitted when a validator is deregistered.
+    event ValidatorDeregistered(bytes validatorPubKey, address indexed nodeAddress);
+
+    /// @notice Emitted when a validator is frozen.
+    event ValidatorFrozen(bytes validatorPubKey);
+
+    /// @notice Emitted when a validator is unfrozen.
+    event ValidatorUnfrozen(bytes validatorPubKey);
+
+    /// @notice Emitted when a validator deregistration request is made.
+    event ValidatorDeregistrationRequested(bytes validatorPubKey, address indexed nodeAddress);
+
+    error ValidatorAlreadyRegistered(bytes validatorPubkey);
+
+    error ValidatorAlreadyFrozen(bytes validatorPubkey);
+
+    error ValidatorNotFrozen(bytes validatorPubkey);
+
+    error ValidatorNotRegistered(bytes validatorPubkey);
+
+    error DeregRequestAlreadyExists(bytes validatorPubkey);
+
+    error FrozenValidatorCannotDeregister(bytes validatorPubkey);
+
+    error DeregistrationTooSoon(bytes validatorPubkey);
+
+    error ValidatorDeregistrationNotExpired(bytes validatorPubkey);
+
+    error NotMinipoolOperator(bytes validatorPubkey);
+
+    error MinipoolNotActive(bytes validatorPubkey);
+
+    error NoMinipoolForKey(bytes validatorPubkey);
+
+    error DeregRequestDoesNotExist(bytes validatorPubkey);
+
+    error OnlyFreezeOracle();
+
+    error InvalidBLSPubKeyLength(uint256 expectedLength, uint256 actualLength);
+
+    error UnfreezeFeeRequired(uint256 requiredFee);
+
+    error UnfreezeTransferFailed();
+
+    error RefundFailed();
+
+    /// @notice Registers validators with a minipool.
+    function registerValidators(bytes[] calldata validatorPubkeys) external;
+
+    /// @notice Requests deregistration for validators.
+    function requestValidatorDeregistration(bytes[] calldata validatorPubkeys) external;
+
+    /// @notice Deregisters validators.
+    function deregisterValidators(bytes[] calldata validatorPubkeys) external;
+
+    /// @notice Freezes validators.
+    function freeze(bytes[] calldata validatorPubkeys) external;
+
+    /// @notice Unfreezes validators.
+    function unfreeze(bytes[] calldata validatorPubkeys) external payable;
+
+    /// @notice Returns the node address for a validator.
+    function getNodeAddressFromPubkey(bytes calldata validatorPubkey) external view returns (address);
+
+    /// @notice Returns the minipool for a validator.
+    function getMinipoolFromPubkey(bytes calldata validatorPubkey) external view returns (address);
+
+    /// @notice Returns the node address for a validator's minipool.
+    function getNodeAddressFromMinipool(address minipool) external view returns (address);
+
+    /// @notice Returns both the node address and the withdrawal address of the key's minipool, as these addresses both have minipool permissions.
+    function getValidOperatorsForKey(bytes calldata validatorPubkey) external view returns (address, address);
+
+    /// @notice Returns the time at which a validator can be deregistered.
+    function getEligibleTimeForDeregistration(bytes calldata validatorPubkey) external view returns (uint64);
+
+    /// @notice Returns the validator registration info.
+    function getValidatorRegInfo(bytes calldata validatorPubkey) external view returns (ValidatorRegistration memory);
+
+    /// @notice Checks if a validator is opted-in.  
+    function isValidatorOptedIn(bytes calldata validatorPubkey) external view returns (bool);
+}

--- a/contracts/contracts/interfaces/IRocketMinipoolRegistry.sol
+++ b/contracts/contracts/interfaces/IRocketMinipoolRegistry.sol
@@ -9,20 +9,24 @@ interface IRocketMinipoolRegistry {
         uint64 freezeTimestamp;
     }
 
+    // ----------------- EVENTS -----------------
+
     /// @notice Emitted when a validator is registered.
-    event ValidatorRegistered(bytes validatorPubKey, address indexed nodeAddress);
-
-    /// @notice Emitted when a validator is deregistered.
-    event ValidatorDeregistered(bytes validatorPubKey, address indexed nodeAddress);
-
-    /// @notice Emitted when a validator is frozen.
-    event ValidatorFrozen(bytes validatorPubKey);
-
-    /// @notice Emitted when a validator is unfrozen.
-    event ValidatorUnfrozen(bytes validatorPubKey);
+    event ValidatorRegistered(bytes indexed validatorPubKey, address indexed nodeAddress);
 
     /// @notice Emitted when a validator deregistration request is made.
-    event ValidatorDeregistrationRequested(bytes validatorPubKey, address indexed nodeAddress);
+    event ValidatorDeregistrationRequested(bytes indexed validatorPubKey, address indexed nodeAddress);
+
+    /// @notice Emitted when a validator is deregistered.
+    event ValidatorDeregistered(bytes indexed validatorPubKey, address indexed nodeAddress);
+
+    /// @notice Emitted when a validator is frozen.
+    event ValidatorFrozen(bytes indexed validatorPubKey);
+
+    /// @notice Emitted when a validator is unfrozen.
+    event ValidatorUnfrozen(bytes indexed validatorPubKey);
+
+    // ----------------- ERRORS -----------------
 
     error ValidatorAlreadyRegistered(bytes validatorPubkey);
 
@@ -57,6 +61,10 @@ interface IRocketMinipoolRegistry {
     error UnfreezeTransferFailed();
 
     error RefundFailed();
+
+    error ZeroParam();
+
+    // ----------------- FUNCTIONS -----------------
 
     /// @notice Registers validators with a minipool.
     function registerValidators(bytes[] calldata validatorPubkeys) external;
@@ -93,4 +101,7 @@ interface IRocketMinipoolRegistry {
 
     /// @notice Checks if a validator is opted-in.  
     function isValidatorOptedIn(bytes calldata validatorPubkey) external view returns (bool);
+
+    /// @notice Checks if an operator is valid to interact on behalf of a validator.
+    function isOperatorValidForKey(address operator, bytes calldata validatorPubkey) external view returns (bool);
 }

--- a/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistry.sol
+++ b/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistry.sol
@@ -48,10 +48,15 @@ contract RocketMinipoolRegistry is IRocketMinipoolRegistry, RocketMinipoolRegist
         revert Errors.InvalidFallback();
     }
     
-    function initialize(address owner) external initializer {
+    function initialize(address owner, address freezeOracle, address unfreezeReceiver, address rocketStorage, uint256 unfreezeFee, uint64 deregistrationPeriod) external initializer {
         __Ownable_init(owner);
         __Pausable_init();
         __UUPSUpgradeable_init();
+        _setFreezeOracle(freezeOracle);
+        _setUnfreezeReceiver(unfreezeReceiver);
+        _setUnfreezeFee(unfreezeFee);
+        _setRocketStorage(rocketStorage);
+        _setDeregistrationPeriod(deregistrationPeriod);
     }
 
     function registerValidators(bytes[] calldata valPubKeys) external onlyValidBLSPubKeys(valPubKeys) whenNotPaused {
@@ -114,27 +119,27 @@ contract RocketMinipoolRegistry is IRocketMinipoolRegistry, RocketMinipoolRegist
 
     /// @dev Sets the deregistration period, restricted to contract owner.
     function setDeregistrationPeriod(uint64 newDeregistrationPeriod) external onlyOwner {
-        deregistrationPeriod = newDeregistrationPeriod;
+        _setDeregistrationPeriod(newDeregistrationPeriod);
     }
 
     /// @dev Sets the rocket storage, restricted to contract owner.    
     function setRocketStorage(address newRocketStorage) external onlyOwner {
-        rocketStorage = RocketStorageInterface(newRocketStorage);
+        _setRocketStorage(newRocketStorage);
     }
 
     /// @dev Sets the freeze oracle, restricted to contract owner.
     function setFreezeOracle(address newFreezeOracle) external onlyOwner {
-        freezeOracle = newFreezeOracle;
+        _setFreezeOracle(newFreezeOracle);
     }
 
     /// @dev Sets the unfreeze receiver, restricted to contract owner.
     function setUnfreezeReceiver(address newUnfreezeReceiver) external onlyOwner {
-        unfreezeReceiver = newUnfreezeReceiver;
+        _setUnfreezeReceiver(newUnfreezeReceiver);
     }
 
     /// @dev Sets the unfreeze fee, restricted to contract owner.
     function setUnfreezeFee(uint256 newUnfreezeFee) external onlyOwner {
-        unfreezeFee = newUnfreezeFee;
+        _setUnfreezeFee(newUnfreezeFee);
     }
 
     /// @dev Unfreezes validators, restricted to contract owner.
@@ -247,6 +252,26 @@ contract RocketMinipoolRegistry is IRocketMinipoolRegistry, RocketMinipoolRegist
         require(regInfo.freezeTimestamp != 0, ValidatorNotFrozen(valPubKey)); 
         regInfo.freezeTimestamp = 0;
         emit ValidatorUnfrozen(valPubKey);
+    }
+
+    function _setFreezeOracle(address newFreezeOracle) internal {
+        freezeOracle = newFreezeOracle;
+    }
+
+    function _setUnfreezeReceiver(address newUnfreezeReceiver) internal {
+        unfreezeReceiver = newUnfreezeReceiver;
+    }
+
+    function _setUnfreezeFee(uint256 newUnfreezeFee) internal {
+        unfreezeFee = newUnfreezeFee;
+    }
+
+    function _setRocketStorage(address newRocketStorage) internal {
+        rocketStorage = RocketStorageInterface(newRocketStorage);
+    }
+
+    function _setDeregistrationPeriod(uint64 newDeregistrationPeriod) internal {
+        deregistrationPeriod = newDeregistrationPeriod;
     }
 
     /// @dev Authorizes contract upgrades, restricted to contract owner.

--- a/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistry.sol
+++ b/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistry.sol
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: BSL 1.1
+pragma solidity 0.8.26;
+
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {RocketMinipoolInterface} from "rocketpool/contracts/interface/minipool/RocketMinipoolInterface.sol";
+import {MinipoolStatus} from "rocketpool/contracts/types/MinipoolStatus.sol";
+import {RocketStorageInterface} from "rocketpool/contracts/interface/RocketStorageInterface.sol";
+
+import {Errors} from "../../utils/Errors.sol";
+import {IRocketMinipoolRegistry} from "../../interfaces/IRocketMinipoolRegistry.sol";
+import {RocketMinipoolRegistryStorage} from "./RocketMinipoolRegistryStorage.sol";
+
+/// @title RocketMinipoolRegistry
+/// @notice This contract serves as the entrypoint for operators to register with
+/// the mev-commit protocol via Rocketpool minipools.
+contract RocketMinipoolRegistry is IRocketMinipoolRegistry, RocketMinipoolRegistryStorage,
+    Ownable2StepUpgradeable, PausableUpgradeable, UUPSUpgradeable {
+
+    modifier onlyFreezeOracle() {
+        require(msg.sender == freezeOracle, IRocketMinipoolRegistry.OnlyFreezeOracle());
+        _;
+    }
+
+    /// @dev Modifier to confirm all provided BLS pubkeys are valid length.
+    modifier onlyValidBLSPubKeys(bytes[] calldata valPubKeys) {
+        uint256 len = valPubKeys.length;
+        for (uint256 i = 0; i < len; ++i) {
+            require(valPubKeys[i].length == 48, IRocketMinipoolRegistry.InvalidBLSPubKeyLength(48, valPubKeys[i].length));
+        }
+        _;
+    }
+
+    /// @dev See https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializing_the_implementation_contract
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @dev Receive function to prevent unintended contract interactions.
+    receive() external payable {
+        revert Errors.InvalidReceive();
+    }
+
+    /// @dev Fallback function to prevent unintended contract interactions.
+    fallback() external payable {
+        revert Errors.InvalidFallback();
+    }
+    
+    function initialize(address owner) external initializer {
+        __Ownable_init(owner);
+        __Pausable_init();
+        __UUPSUpgradeable_init();
+    }
+
+    function registerValidators(bytes[] calldata valPubKeys) external onlyValidBLSPubKeys(valPubKeys) whenNotPaused {
+        uint256 len = valPubKeys.length;
+        for (uint256 i = 0; i < len; ++i) {
+            _registerValidator(valPubKeys[i]);
+            
+        }
+    }
+
+    function requestValidatorDeregistration(bytes[] calldata valPubKeys) external onlyValidBLSPubKeys(valPubKeys) whenNotPaused {
+        uint256 len = valPubKeys.length;
+        for (uint256 i = 0; i < len; ++i) {
+            _requestValidatorDeregistration(valPubKeys[i]);
+        }
+    }
+
+    /// @dev Deregister validators. Can only be called once the deregistration period has passed from time of request.
+    function deregisterValidators(bytes[] calldata valPubKeys) external onlyValidBLSPubKeys(valPubKeys) whenNotPaused {
+        uint256 len = valPubKeys.length;
+        for (uint256 i = 0; i < len; ++i) {
+            _deregisterValidator(valPubKeys[i]);
+        }
+    }
+
+    /// @dev Allows the freeze oracle account to freeze validators which disobey the mev-commit protocol.
+    function freeze(bytes[] calldata valPubKeys) external whenNotPaused onlyFreezeOracle() {
+        uint256 len = valPubKeys.length;
+        for (uint256 i = 0; i < len; ++i) {
+            _freeze(valPubKeys[i]);
+        }
+    }
+
+    /// @dev Allows any account to unfreeze validators which have been frozen, for a fee.
+    function unfreeze(bytes[] calldata valPubKeys) external payable whenNotPaused {
+        uint256 requiredFee = unfreezeFee * valPubKeys.length;
+        require(msg.value >= requiredFee, UnfreezeFeeRequired(requiredFee));
+        uint256 len = valPubKeys.length;
+        for (uint256 i = 0; i < len; ++i) {
+            _unfreeze(valPubKeys[i]);
+        }
+        (bool success, ) = unfreezeReceiver.call{value: requiredFee}("");
+        require(success, UnfreezeTransferFailed());
+        uint256 excessFee = msg.value - requiredFee;
+        if (excessFee != 0) {
+            (bool successRefund, ) = msg.sender.call{value: excessFee}("");
+            require(successRefund, RefundFailed());
+        }
+    }
+
+    /// @dev Pauses the contract, restricted to contract owner.
+    function pause() external onlyOwner whenNotPaused {
+        _pause();
+    }
+
+    /// @dev Unpauses the contract, restricted to contract owner.   
+    function unpause() external onlyOwner whenPaused {
+        _unpause();
+    }
+
+    /// @dev Sets the deregistration period, restricted to contract owner.
+    function setDeregistrationPeriod(uint64 newDeregistrationPeriod) external onlyOwner {
+        deregistrationPeriod = newDeregistrationPeriod;
+    }
+
+    /// @dev Sets the rocket storage, restricted to contract owner.    
+    function setRocketStorage(address newRocketStorage) external onlyOwner {
+        rocketStorage = RocketStorageInterface(newRocketStorage);
+    }
+
+    /// @dev Sets the freeze oracle, restricted to contract owner.
+    function setFreezeOracle(address newFreezeOracle) external onlyOwner {
+        freezeOracle = newFreezeOracle;
+    }
+
+    /// @dev Sets the unfreeze receiver, restricted to contract owner.
+    function setUnfreezeReceiver(address newUnfreezeReceiver) external onlyOwner {
+        unfreezeReceiver = newUnfreezeReceiver;
+    }
+
+    /// @dev Sets the unfreeze fee, restricted to contract owner.
+    function setUnfreezeFee(uint256 newUnfreezeFee) external onlyOwner {
+        unfreezeFee = newUnfreezeFee;
+    }
+
+    /// @dev Unfreezes validators, restricted to contract owner.
+    function ownerUnfreeze(bytes[] calldata valPubKeys) external onlyOwner {
+        uint256 len = valPubKeys.length;
+        for (uint256 i = 0; i < len; ++i) {
+            _unfreeze(valPubKeys[i]);
+        }
+    }
+
+    /// @dev Returns the time at which a validator can be deregistered.
+    function getEligibleTimeForDeregistration(bytes calldata validatorPubkey) external view returns (uint64) {
+        uint64 deregistrationTime = validatorRegistrations[validatorPubkey].deregTimestamp;
+        return deregistrationTime != 0 ? (deregistrationTime + deregistrationPeriod) : 0;
+    }
+
+    /// @dev Returns both the node address and the withdrawal address of the key's minipool, as these addresses both have minipool permissions.
+    function getValidOperatorsForKey(bytes calldata validatorPubkey) external view returns (address, address) {
+        address minipool = getMinipoolFromPubkey(validatorPubkey);
+        address nodeAddress = getNodeAddressFromMinipool(minipool);
+        return (nodeAddress, rocketStorage.getNodeWithdrawalAddress(nodeAddress));
+    }
+
+    /// @dev Returns validator registration info.
+    function getValidatorRegInfo(bytes calldata valPubKey) external view returns (ValidatorRegistration memory) {
+        return validatorRegistrations[valPubKey];
+    }
+
+    /// @dev Checks if a validator is opted-in.
+    function isValidatorOptedIn(bytes calldata valPubKey) external view returns (bool) {
+        return _isValidatorOptedIn(valPubKey);
+    }
+
+        /// @dev Returns the minipool for a validator.
+    function getMinipoolFromPubkey(bytes calldata validatorPubkey) public view returns (address) {
+        return rocketStorage.getAddress(keccak256(abi.encodePacked("validator.minipool", validatorPubkey)));
+    }
+
+    /// @dev Returns the node address from a validator's minipool.
+    function getNodeAddressFromPubkey(bytes calldata validatorPubkey) public view returns (address) {
+        address minipool = getMinipoolFromPubkey(validatorPubkey);
+        return getNodeAddressFromMinipool(minipool);
+    }
+
+    /// @dev Returns true if a minipool is active.
+    function isMinipoolActive(address minipool) public view returns (bool) {
+        return RocketMinipoolInterface(minipool).getStatus() == MinipoolStatus.Staking;
+    }
+
+    /// @dev Fetches the minipool from a validator's pubkey and returns true if caller is either the minipool's node address or node's withdrawal address.
+    function isOperatorValidForKey(bytes calldata validatorPubkey) public view returns (bool) {
+        address minipool = getMinipoolFromPubkey(validatorPubkey);
+        address nodeAddress = getNodeAddressFromMinipool(minipool);
+        return (nodeAddress == msg.sender || rocketStorage.getNodeWithdrawalAddress(nodeAddress) == msg.sender);
+    }
+
+    function isValidatorRegistered(bytes calldata validatorPubkey) public view returns (bool) {
+        return validatorRegistrations[validatorPubkey].exists;
+    }
+
+    /// @dev Returns the node address of a minipool.
+    function getNodeAddressFromMinipool(address minipool) public view returns (address) {
+        return RocketMinipoolInterface(minipool).getNodeAddress();
+    }
+
+    /// @dev Registers a validator.
+    function _registerValidator(bytes calldata valPubKey) internal {
+        address minipool = getMinipoolFromPubkey(valPubKey);
+        require(minipool != address(0), NoMinipoolForKey(valPubKey));
+        require(_isOperatorValid(minipool), NotMinipoolOperator(valPubKey));
+        require(isMinipoolActive(minipool), MinipoolNotActive(valPubKey));
+        require(!isValidatorRegistered(valPubKey), ValidatorAlreadyRegistered(valPubKey));
+        address nodeAddress = getNodeAddressFromMinipool(minipool);
+        IRocketMinipoolRegistry.ValidatorRegistration storage reg = validatorRegistrations[valPubKey];
+        reg.exists = true;
+        emit ValidatorRegistered(valPubKey, nodeAddress);
+    }
+
+    /// @dev Requests deregistration for a validator.
+    function _requestValidatorDeregistration(bytes calldata valPubKey) internal {
+        address nodeAddress = getNodeAddressFromPubkey(valPubKey);
+        require(_isOperatorValid(nodeAddress), NotMinipoolOperator(valPubKey));
+        require(isValidatorRegistered(valPubKey), ValidatorNotRegistered(valPubKey));
+        IRocketMinipoolRegistry.ValidatorRegistration storage reg = validatorRegistrations[valPubKey];
+        require(reg.deregTimestamp == 0, DeregRequestAlreadyExists(valPubKey));
+        reg.deregTimestamp = uint64(block.timestamp);
+        emit ValidatorDeregistrationRequested(valPubKey, nodeAddress);
+    }
+    
+    function _deregisterValidator(bytes calldata valPubKey) internal {
+        address nodeAddress = getNodeAddressFromPubkey(valPubKey);
+        require(_isOperatorValid(nodeAddress), NotMinipoolOperator(valPubKey));
+        IRocketMinipoolRegistry.ValidatorRegistration storage reg = validatorRegistrations[valPubKey];
+        require(reg.deregTimestamp != 0, DeregRequestDoesNotExist(valPubKey));
+        require(uint64(block.timestamp) > reg.deregTimestamp + deregistrationPeriod, DeregistrationTooSoon(valPubKey));
+        require(reg.freezeTimestamp == 0, FrozenValidatorCannotDeregister(valPubKey));
+        delete validatorRegistrations[valPubKey];
+        emit ValidatorDeregistered(valPubKey, nodeAddress);
+    }
+
+    function _freeze(bytes calldata valPubKey) internal {
+        require(isValidatorRegistered(valPubKey), ValidatorNotRegistered(valPubKey));
+        require(validatorRegistrations[valPubKey].freezeTimestamp == 0, ValidatorAlreadyFrozen(valPubKey));
+        validatorRegistrations[valPubKey].freezeTimestamp = uint64(block.timestamp);
+        emit ValidatorFrozen(valPubKey);
+    }
+
+    function _unfreeze(bytes calldata valPubKey) internal {
+        IRocketMinipoolRegistry.ValidatorRegistration storage regInfo = validatorRegistrations[valPubKey];
+        require(regInfo.freezeTimestamp != 0, ValidatorNotFrozen(valPubKey)); 
+        regInfo.freezeTimestamp = 0;
+        emit ValidatorUnfrozen(valPubKey);
+    }
+
+    /// @dev Authorizes contract upgrades, restricted to contract owner.
+    // solhint-disable-next-line no-empty-blocks
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    function _isValidatorOptedIn(bytes calldata valPubKey) internal view returns (bool) {
+        if (!isValidatorRegistered(valPubKey)) return false;
+        if (validatorRegistrations[valPubKey].freezeTimestamp != 0) return false;
+        if (validatorRegistrations[valPubKey].deregTimestamp != 0) return false;
+        if (getMinipoolFromPubkey(valPubKey) == address(0)) return false;
+        if (!isMinipoolActive(getMinipoolFromPubkey(valPubKey))) return false;
+        return true;
+    }
+
+    /// @dev Returns true if caller is either the minipool's node address or node'swithdrawal address.
+    function _isOperatorValid(address operator) internal view returns (bool) {
+        return (operator == msg.sender || rocketStorage.getNodeWithdrawalAddress(operator) == msg.sender);
+    }
+}

--- a/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistry.sol
+++ b/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistry.sol
@@ -110,12 +110,12 @@ contract RocketMinipoolRegistry is IRocketMinipoolRegistry, RocketMinipoolRegist
     }
 
     /// @dev Pauses the contract, restricted to contract owner.
-    function pause() external onlyOwner whenNotPaused {
+    function pause() external onlyOwner {
         _pause();
     }
 
     /// @dev Unpauses the contract, restricted to contract owner.   
-    function unpause() external onlyOwner whenPaused {
+    function unpause() external onlyOwner {
         _unpause();
     }
 

--- a/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistryStorage.sol
+++ b/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistryStorage.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSL 1.1
+pragma solidity 0.8.26;
+
+import {RocketStorageInterface} from "rocketpool/contracts/interface/RocketStorageInterface.sol";
+import {IRocketMinipoolRegistry} from "../../interfaces/IRocketMinipoolRegistry.sol";
+
+abstract contract RocketMinipoolRegistryStorage {
+    RocketStorageInterface public rocketStorage;
+
+    /// @notice Number of seconds a validator must wait after requesting deregistration before it can be finalized.
+    uint64 public deregistrationPeriod = 1 days;
+
+    uint256 public unfreezeFee;
+    address public freezeOracle;
+    address public unfreezeReceiver;
+
+    mapping(bytes => IRocketMinipoolRegistry.ValidatorRegistration) public validatorRegistrations;
+
+}

--- a/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistryStorage.sol
+++ b/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistryStorage.sol
@@ -16,4 +16,5 @@ abstract contract RocketMinipoolRegistryStorage {
 
     mapping(bytes => IRocketMinipoolRegistry.ValidatorRegistration) public validatorRegistrations;
 
+    uint256[44] private __gap;
 }

--- a/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistryStorage.sol
+++ b/contracts/contracts/validator-registry/rocketpool/RocketMinipoolRegistryStorage.sol
@@ -8,7 +8,7 @@ abstract contract RocketMinipoolRegistryStorage {
     RocketStorageInterface public rocketStorage;
 
     /// @notice Number of seconds a validator must wait after requesting deregistration before it can be finalized.
-    uint64 public deregistrationPeriod = 1 days;
+    uint64 public deregistrationPeriod;
 
     uint256 public unfreezeFee;
     address public freezeOracle;

--- a/contracts/l1-deployer-cli.sh
+++ b/contracts/l1-deployer-cli.sh
@@ -331,7 +331,7 @@ check_rpc_url() {
 }
 
 check_etherscan_api_key() {
-    response=$(curl -s "https://api.etherscan.io/api?module=account&action=balance&address=${SENDER}&tag=latest&apikey=${ETHERSCAN_API_KEY}")
+    response=$(curl -s "https://api.etherscan.io/v2/api?chainid=${chain_id}&module=account&action=balance&address=${SENDER}&tag=latest&apikey=${ETHERSCAN_API_KEY}")
 
     status=$(echo "$response" | grep -o '"status":"[0-9]"' | cut -d':' -f2 | tr -d '"')
 

--- a/contracts/l1-deployer-cli.sh
+++ b/contracts/l1-deployer-cli.sh
@@ -4,6 +4,7 @@ deploy_all_flag=false
 deploy_vanilla_flag=false
 deploy_avs_flag=false
 deploy_middleware_flag=false
+deploy_rocketpool_flag=false
 deploy_opt_in_hub_flag=false
 deploy_block_rewards_flag=false
 deploy_reward_distributor_flag=false
@@ -25,6 +26,7 @@ help() {
     echo "  deploy-vanilla      Deploy and verify the VanillaRegistry contract to L1."
     echo "  deploy-avs          Deploy and verify the MevCommitAVS contract to L1."
     echo "  deploy-middleware   Deploy and verify the MevCommitMiddleware contract to L1."
+    echo "  deploy-rocketpool   Deploy and verify the RocketMinipoolRegistry contract to L1."
     echo "  deploy-opt-in-hub       Deploy and verify the ValidatorOptInHub contract to L1."
     echo "  deploy-block-rewards      Deploy and verify the BlockRewardManager contract to L1."
     echo "  deploy-reward-distributor      Deploy and verify the RewardDistributor contract to L1."
@@ -122,6 +124,10 @@ parse_args() {
                 deploy_middleware_flag=true
                 shift
                 ;;
+            deploy-rocketpool)
+                deploy_rocketpool_flag=true
+                shift
+                ;;
             deploy-opt-in-hub)
                 deploy_opt_in_hub_flag=true
                 shift
@@ -215,7 +221,7 @@ parse_args() {
     fi
 
     commands_specified=0
-    for flag in deploy_all_flag deploy_vanilla_flag deploy_avs_flag deploy_middleware_flag deploy_opt_in_hub_flag deploy_block_rewards_flag deploy_reward_distributor_flag; do
+    for flag in deploy_all_flag deploy_vanilla_flag deploy_avs_flag deploy_middleware_flag deploy_rocketpool_flag deploy_opt_in_hub_flag deploy_block_rewards_flag deploy_reward_distributor_flag; do
         if [[ "${!flag}" == true ]]; then
             ((commands_specified++))
         fi
@@ -394,6 +400,10 @@ deploy_middleware() {
     deploy_contract_generic "scripts/validator-registry/middleware/DeployMiddleware.s.sol"
 }
 
+deploy_rocketpool() {
+    deploy_contract_generic "scripts/validator-registry/rocketpool/DeployRocketMinipoolRegistry.s.sol"
+}
+
 deploy_opt_in_hub() {
     deploy_contract_generic "scripts/validator-registry/DeployValidatorOptInHub.s.sol"
 }
@@ -420,6 +430,7 @@ main() {
         deploy_vanilla
         deploy_avs
         deploy_middleware
+        deploy_rocketpool
         deploy_opt_in_hub
     elif [[ "${deploy_vanilla_flag}" == true ]]; then
         deploy_vanilla
@@ -427,6 +438,8 @@ main() {
         deploy_avs
     elif [[ "${deploy_middleware_flag}" == true ]]; then
         deploy_middleware
+    elif [[ "${deploy_rocketpool_flag}" == true ]]; then
+        deploy_rocketpool
     elif [[ "${deploy_opt_in_hub_flag}" == true ]]; then
         deploy_opt_in_hub
     elif [[ "${deploy_block_rewards_flag}" == true ]]; then

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -7,3 +7,4 @@ forge-std/=lib/forge-std/src/
 eigenlayer-contracts/=lib/eigenlayer-contracts/
 symbiotic-core/=lib/core/src/
 symbiotic-burners/=lib/burners/src/
+rocketpool/=lib/rocketpool/

--- a/contracts/scripts/validator-registry/rocketpool/DeployRocketMinipoolRegistry.s.sol
+++ b/contracts/scripts/validator-registry/rocketpool/DeployRocketMinipoolRegistry.s.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BSL 1.1
+
+// solhint-disable no-console
+// solhint-disable one-contract-per-file
+
+pragma solidity 0.8.26;
+
+import {Script} from "forge-std/Script.sol";
+import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {RocketMinipoolRegistry} from "../../contracts/validator-registry/rocketpool/RocketMinipoolRegistry.sol";
+import {console} from "forge-std/console.sol";
+import {MainnetConstants} from "../MainnetConstants.sol";
+
+contract BaseDeploy is Script {
+    function deployRocketMinipoolRegistry(
+        address owner,
+        address freezeOracle,
+        address unfreezeReceiver,
+        address rocketStorage,
+        uint256 unfreezeFee,
+        uint256 deregistrationPeriod
+    ) public returns (address) {
+        console.log("Deploying RocketMinipoolRegistry on chain:", block.chainid);
+        address proxy = Upgrades.deployUUPSProxy(
+            "RocketMinipoolRegistry.sol",
+            abi.encodeCall(
+                RocketMinipoolRegistry.initialize,
+                (owner, freezeOracle, unfreezeReceiver, rocketStorage, unfreezeFee, deregistrationPeriod)
+            )
+        );
+        console.log("RocketMinipoolRegistry UUPS proxy deployed to:", address(proxy));
+        RocketMinipoolRegistry rocketMinipoolRegistry = RocketMinipoolRegistry(payable(proxy));
+        console.log("RocketMinipoolRegistry owner:", rocketMinipoolRegistry.owner());
+        return proxy;
+    }
+}
+
+contract DeployMainnet is BaseDeploy {
+    address constant public OWNER = MainnetConstants.PRIMEV_TEAM_MULTISIG;
+    address constant public FREEZE_ORACLE = MainnetConstants.PRIMEV_TEAM_MULTISIG;
+    address constant public UNFREEZE_RECEIVER = MainnetConstants.COMMITMENT_HOLDINGS_MULTISIG;
+    uint256 constant public UNFREEZE_FEE = 1 ether;
+    uint256 constant public DEREGISTRATION_PERIOD = 86400; // 86400/60s = 1 day
+    address constant public ROCKET_STORAGE = 0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46;
+
+    function run() external {
+        require(block.chainid == 1, "must deploy on mainnet");
+        vm.startBroadcast();
+        deployRocketMinipoolRegistry(OWNER, FREEZE_ORACLE, UNFREEZE_RECEIVER, ROCKET_STORAGE, UNFREEZE_FEE, DEREGISTRATION_PERIOD);
+        vm.stopBroadcast();
+    }
+}
+
+
+contract DeployHoodi is BaseDeploy {
+    address constant public FREEZE_ORACLE = 0x1623fE21185c92BB43bD83741E226288B516134a;
+    address constant public UNFREEZE_RECEIVER = 0x1623fE21185c92BB43bD83741E226288B516134a;
+    uint256 constant public UNFREEZE_FEE = 0.01 ether;
+    uint256 constant public DEREGISTRATION_PERIOD = 300; // 300/60s = 5 minutes
+    address constant public ROCKET_STORAGE = 0x594Fb75D3dc2DFa0150Ad03F99F97817747dd4E1;
+
+    // This is the most important field. On mainnet it'll be the primev multisig.
+    address constant public OWNER = 0x1623fE21185c92BB43bD83741E226288B516134a;
+
+    function run() external {
+        require(block.chainid == 560048, "must deploy on Hoodi");
+        vm.startBroadcast();
+        deployRocketMinipoolRegistry(OWNER, FREEZE_ORACLE, UNFREEZE_RECEIVER, ROCKET_STORAGE, UNFREEZE_FEE, DEREGISTRATION_PERIOD);
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/scripts/validator-registry/rocketpool/DeployRocketMinipoolRegistry.s.sol
+++ b/contracts/scripts/validator-registry/rocketpool/DeployRocketMinipoolRegistry.s.sol
@@ -7,9 +7,9 @@ pragma solidity 0.8.26;
 
 import {Script} from "forge-std/Script.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
-import {RocketMinipoolRegistry} from "../../contracts/validator-registry/rocketpool/RocketMinipoolRegistry.sol";
+import {RocketMinipoolRegistry} from "../../../contracts/validator-registry/rocketpool/RocketMinipoolRegistry.sol";
 import {console} from "forge-std/console.sol";
-import {MainnetConstants} from "../MainnetConstants.sol";
+import {MainnetConstants} from "../../MainnetConstants.sol";
 
 contract BaseDeploy is Script {
     function deployRocketMinipoolRegistry(
@@ -18,7 +18,7 @@ contract BaseDeploy is Script {
         address unfreezeReceiver,
         address rocketStorage,
         uint256 unfreezeFee,
-        uint256 deregistrationPeriod
+        uint64 deregistrationPeriod
     ) public returns (address) {
         console.log("Deploying RocketMinipoolRegistry on chain:", block.chainid);
         address proxy = Upgrades.deployUUPSProxy(
@@ -40,7 +40,7 @@ contract DeployMainnet is BaseDeploy {
     address constant public FREEZE_ORACLE = MainnetConstants.PRIMEV_TEAM_MULTISIG;
     address constant public UNFREEZE_RECEIVER = MainnetConstants.COMMITMENT_HOLDINGS_MULTISIG;
     uint256 constant public UNFREEZE_FEE = 1 ether;
-    uint256 constant public DEREGISTRATION_PERIOD = 86400; // 86400/60s = 1 day
+    uint64 constant public DEREGISTRATION_PERIOD = 86400; // 86400/60s = 1 day
     address constant public ROCKET_STORAGE = 0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46;
 
     function run() external {
@@ -56,7 +56,7 @@ contract DeployHoodi is BaseDeploy {
     address constant public FREEZE_ORACLE = 0x1623fE21185c92BB43bD83741E226288B516134a;
     address constant public UNFREEZE_RECEIVER = 0x1623fE21185c92BB43bD83741E226288B516134a;
     uint256 constant public UNFREEZE_FEE = 0.01 ether;
-    uint256 constant public DEREGISTRATION_PERIOD = 300; // 300/60s = 5 minutes
+    uint64 constant public DEREGISTRATION_PERIOD = 300; // 300/60s = 5 minutes
     address constant public ROCKET_STORAGE = 0x594Fb75D3dc2DFa0150Ad03F99F97817747dd4E1;
 
     // This is the most important field. On mainnet it'll be the primev multisig.

--- a/contracts/test/validator-registry/rocketpool/RocketMinipoolRegistryTest.sol
+++ b/contracts/test/validator-registry/rocketpool/RocketMinipoolRegistryTest.sol
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: BSL 1.1
+pragma solidity 0.8.26;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {Options}  from "openzeppelin-foundry-upgrades/Options.sol";
+
+import {RocketMinipoolRegistry} from "../../../contracts/validator-registry/rocketpool/RocketMinipoolRegistry.sol";
+import {IRocketMinipoolRegistry} from "../../../contracts/interfaces/IRocketMinipoolRegistry.sol";
+import {MinipoolStatus} from "rocketpool/contracts/types/MinipoolStatus.sol";
+
+// ---------- Mocks ----------
+
+contract RocketStorageMock {
+    mapping(bytes32 => address) internal _addr;
+    mapping(address => address) internal _withdrawal;
+
+    function setMinipoolForPubkey(bytes calldata pk, address mp) external {
+        _addr[keccak256(abi.encodePacked("validator.minipool", pk))] = mp;
+    }
+
+    function setNodeWithdrawalAddress(address node, address withdrawal) external {
+        _withdrawal[node] = withdrawal;
+    }
+
+    // registry reads these
+    function getAddress(bytes32 key) external view returns (address) {
+        return _addr[key];
+    }
+
+    function getNodeWithdrawalAddress(address node) external view returns (address) {
+        return _withdrawal[node];
+    }
+}
+
+contract MinipoolMock {
+    address public node;
+    MinipoolStatus public status;
+
+    constructor(address _node) {
+        node = _node;
+        status = MinipoolStatus.Staking; // default to active
+    }
+
+    function getNodeAddress() external view returns (address) {
+        return node;
+    }
+
+    function getStatus() external view returns (MinipoolStatus) {
+        return status;
+    }
+
+    function setStatus(MinipoolStatus s) external {
+        status = s;
+    }
+}
+
+// ---------- Tests ----------
+
+contract RocketMinipoolRegistryTest is Test {
+    // actors
+    address internal owner      = makeAddr("owner");
+    address internal oracle     = makeAddr("freezeOracle");
+    address internal node       = makeAddr("node");
+    address internal withdrawal = makeAddr("withdrawal");
+    address internal stranger   = makeAddr("stranger");
+    address internal receiver   = makeAddr("receiver");
+
+    // system
+    RocketStorageMock internal storageMock;
+    MinipoolMock internal mp1;
+    RocketMinipoolRegistry internal reg;
+
+    // params
+    uint256 internal fee = 0.01 ether;
+    uint64  internal period = 3 days;
+
+    // sample 48-byte pubkeys (96 hex chars)
+    bytes internal pk1 = hex"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    bytes internal pk2 = hex"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbaaaaaaaabbbbb";
+
+    function setUp() public {
+        deal(address(this), 100 ether); // for unfreeze tests
+
+        // mocks
+        storageMock = new RocketStorageMock();
+        mp1 = new MinipoolMock(node);
+
+        // wire lookups
+        storageMock.setMinipoolForPubkey(pk1, address(mp1));
+        storageMock.setNodeWithdrawalAddress(node, withdrawal);
+
+        Options memory opts;
+        opts.unsafeSkipAllChecks = true; // or opts.unsafeSkipStorageCheck = true
+
+        address proxy = Upgrades.deployUUPSProxy(
+            "RocketMinipoolRegistry.sol",
+            abi.encodeCall(
+                RocketMinipoolRegistry.initialize,
+                (owner, oracle, receiver, address(storageMock), fee, period)
+            ),
+            opts // ← IMPORTANT: pass opts here
+        );
+        reg = RocketMinipoolRegistry(payable(proxy));
+    }
+
+    // helpers
+    function _one(bytes memory pk) internal pure returns (bytes[] memory a) {
+        a = new bytes[](1);
+        a[0] = pk;
+    }
+
+    // ---------- initializer, setters, pause ----------
+    function test_Initialize_And_Setters_And_Pause() public {
+        assertEq(reg.unfreezeFee(), fee);
+        assertEq(reg.freezeOracle(), oracle);
+        assertEq(reg.unfreezeReceiver(), receiver);
+        assertEq(address(reg.rocketStorage()), address(storageMock));
+        assertEq(reg.deregistrationPeriod(), period);
+
+        vm.prank(owner); reg.setUnfreezeFee(2 ether);              assertEq(reg.unfreezeFee(), 2 ether);
+        vm.prank(owner); reg.setFreezeOracle(stranger);            assertEq(reg.freezeOracle(), stranger);
+        vm.prank(owner); reg.setUnfreezeReceiver(withdrawal);      assertEq(reg.unfreezeReceiver(), withdrawal);
+        vm.prank(owner); reg.setRocketStorage(address(storageMock));assertEq(address(reg.rocketStorage()), address(storageMock));
+        vm.prank(owner); reg.setDeregistrationPeriod(1 days);      assertEq(reg.deregistrationPeriod(), 1 days);
+
+        vm.prank(owner); reg.pause();
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        reg.registerValidators(_one(pk1));
+
+        vm.prank(owner); reg.unpause();
+        vm.prank(node); reg.registerValidators(_one(pk1)); // ok
+    }
+
+    // ---------- register ----------
+    function test_Register_ByNode_Succeeds() public {
+        vm.expectEmit(false, true, false, true);
+        emit IRocketMinipoolRegistry.ValidatorRegistered(pk1, node);
+        vm.prank(node);
+        reg.registerValidators(_one(pk1));
+
+        // ✅ read struct, then fields
+        IRocketMinipoolRegistry.ValidatorRegistration memory info = reg.getValidatorRegInfo(pk1);
+        assertEq(info.freezeTimestamp, 0);
+        assertEq(info.exists, true);
+
+        assertTrue(reg.isValidatorRegistered(pk1));
+        assertTrue(reg.isValidatorOptedIn(pk1));
+
+        (address n, address w) = reg.getValidOperatorsForKey(pk1);
+        assertEq(n, node);
+        assertEq(w, withdrawal);
+    }
+
+    function test_Register_ByWithdrawal_Succeeds() public {
+        vm.prank(withdrawal);
+        reg.registerValidators(_one(pk1));
+        assertTrue(reg.isValidatorRegistered(pk1));
+    }
+
+    function test_Register_InvalidKeyLength_Reverts() public {
+        bytes[] memory bad = new bytes[](1);
+        bad[0] = hex"01";
+        vm.expectRevert(abi.encodeWithSelector(IRocketMinipoolRegistry.InvalidBLSPubKeyLength.selector, 48, 1));
+        reg.registerValidators(bad);
+    }
+
+    function test_Register_MinipoolNotActive_Reverts() public {
+        mp1.setStatus(MinipoolStatus.Withdrawable); // anything != Staking
+        vm.prank(node);
+        vm.expectRevert(abi.encodeWithSelector(IRocketMinipoolRegistry.MinipoolNotActive.selector, pk1));
+        reg.registerValidators(_one(pk1));
+    }
+
+    function test_Register_Twice_Reverts() public {
+        vm.prank(node); reg.registerValidators(_one(pk1));
+        vm.prank(node);
+        vm.expectRevert(abi.encodeWithSelector(IRocketMinipoolRegistry.ValidatorAlreadyRegistered.selector, pk1));
+        reg.registerValidators(_one(pk1));
+    }
+
+    // ---------- freeze / unfreeze ----------
+    function test_Freeze_OnlyOracle() public {
+        vm.prank(node); reg.registerValidators(_one(pk1));
+
+        vm.expectRevert(IRocketMinipoolRegistry.OnlyFreezeOracle.selector);
+        reg.freeze(_one(pk1)); // caller = this
+
+        vm.prank(oracle);
+        reg.freeze(_one(pk1));
+        IRocketMinipoolRegistry.ValidatorRegistration memory info = reg.getValidatorRegInfo(pk1);
+        assertTrue(info.freezeTimestamp != 0);
+
+        vm.prank(oracle);
+        vm.expectRevert(abi.encodeWithSelector(IRocketMinipoolRegistry.ValidatorAlreadyFrozen.selector, pk1));
+        reg.freeze(_one(pk1));
+    }
+
+    function test_Unfreeze_RequiresFee_And_Refunds() public {
+        // setup: register & freeze
+        vm.prank(node); reg.registerValidators(_one(pk1));
+        vm.prank(oracle); reg.freeze(_one(pk1));
+
+        // underpay -> revert with required fee
+        vm.expectRevert(abi.encodeWithSelector(IRocketMinipoolRegistry.UnfreezeFeeRequired.selector, fee));
+        reg.unfreeze{value: fee - 1}(_one(pk1));
+
+        // exact pay -> receiver gets fee, registry keeps nothing, sender net-spend = fee
+        uint256 rBefore = receiver.balance;
+        uint256 sBefore = address(this).balance;
+        uint256 regBefore = address(reg).balance;
+
+        reg.unfreeze{value: fee}(_one(pk1));
+
+        assertEq(receiver.balance, rBefore + fee, "receiver should get exact fee");
+        assertEq(address(this).balance, sBefore - fee, "sender net-spend should equal fee");
+        assertEq(address(reg).balance, regBefore, "registry should not retain ETH");
+
+        // re-freeze, then overpay -> refund everything above fee
+        vm.prank(oracle); reg.freeze(_one(pk1));
+
+        uint256 extra = 1 ether;
+        rBefore = receiver.balance;
+        sBefore = address(this).balance;
+        regBefore = address(reg).balance;
+
+        reg.unfreeze{value: fee + extra}(_one(pk1));
+
+        assertEq(receiver.balance, rBefore + fee, "receiver should still get only fee");
+        assertEq(address(this).balance, sBefore - fee, "sender net-spend still fee (extra refunded)");
+        assertEq(address(reg).balance, regBefore, "registry balance unchanged");
+    }
+
+    function test_OwnerUnfreeze_NoFee() public {
+        vm.prank(node); reg.registerValidators(_one(pk1));
+        vm.prank(oracle); reg.freeze(_one(pk1));
+
+        vm.prank(owner);
+        reg.ownerUnfreeze(_one(pk1));
+        IRocketMinipoolRegistry.ValidatorRegistration memory info = reg.getValidatorRegInfo(pk1);
+        assertEq(info.freezeTimestamp, 0);
+    }
+
+    // ---------- deregistration flow ----------
+    function test_RequestDereg_Then_Finalize() public {
+        vm.prank(node); reg.registerValidators(_one(pk1));
+
+        vm.expectEmit(false, true, false, true);
+        emit IRocketMinipoolRegistry.ValidatorDeregistrationRequested(pk1, node);
+        vm.prank(node);
+        reg.requestValidatorDeregistration(_one(pk1));
+
+        vm.prank(node);
+        vm.expectRevert(abi.encodeWithSelector(IRocketMinipoolRegistry.DeregRequestAlreadyExists.selector, pk1));
+        reg.requestValidatorDeregistration(_one(pk1));
+
+        vm.prank(node);
+        vm.expectRevert(abi.encodeWithSelector(IRocketMinipoolRegistry.DeregistrationTooSoon.selector, pk1));
+        reg.deregisterValidators(_one(pk1));
+
+        vm.prank(oracle); reg.freeze(_one(pk1));
+        vm.warp(block.timestamp + period + 1);
+
+        vm.prank(node);
+        vm.expectRevert(abi.encodeWithSelector(IRocketMinipoolRegistry.FrozenValidatorCannotDeregister.selector, pk1));
+        reg.deregisterValidators(_one(pk1));
+
+        reg.unfreeze{value: fee}(_one(pk1));
+        vm.prank(node);
+        reg.deregisterValidators(_one(pk1));
+
+        assertFalse(reg.isValidatorRegistered(pk1));
+        IRocketMinipoolRegistry.ValidatorRegistration memory info2 = reg.getValidatorRegInfo(pk1);
+        // after dereg, nodeAddress can be zeroed; rely on the isValidatorRegistered guard instead
+        assertEq(info2.exists, false);
+        assertEq(reg.getEligibleTimeForDeregistration(pk1), 0);
+    }
+
+    // ---------- getters / helpers ----------
+    function test_Getters_Work() public {
+        vm.prank(node); reg.registerValidators(_one(pk1));
+        assertEq(reg.getNodeAddressFromPubkey(pk1), node);
+        assertEq(reg.getMinipoolFromPubkey(pk1), address(mp1));
+
+        (address n, address w) = reg.getValidOperatorsForKey(pk1);
+        assertEq(n, node);
+        assertEq(w, withdrawal);
+
+        assertTrue(reg.isMinipoolActive(address(mp1)));
+
+        // if your isOperatorValidForKey uses msg.sender, these pass; if it takes (addr, key), swap accordingly.
+        vm.prank(node);      assertTrue(reg.isOperatorValidForKey(node, pk1));
+        vm.prank(withdrawal);assertTrue(reg.isOperatorValidForKey(withdrawal,pk1));
+        vm.prank(stranger);  assertFalse(reg.isOperatorValidForKey(stranger,pk1));
+    }
+
+    function test_IsValidatorOptedIn_TruthTable() public {
+        // not registered
+        assertFalse(reg.isValidatorOptedIn(pk1));
+
+        // registered + active
+        vm.prank(node); reg.registerValidators(_one(pk1));
+        assertTrue(reg.isValidatorOptedIn(pk1));
+
+        // frozen -> false
+        vm.prank(oracle); reg.freeze(_one(pk1));
+        assertFalse(reg.isValidatorOptedIn(pk1));
+        reg.unfreeze{value: fee}(_one(pk1));
+
+        // dereg requested -> false
+        vm.prank(node); reg.requestValidatorDeregistration(_one(pk1));
+        assertFalse(reg.isValidatorOptedIn(pk1));
+
+        // complete dereg clears
+        vm.warp(block.timestamp + period + 1);
+        vm.prank(node); reg.deregisterValidators(_one(pk1));
+        assertFalse(reg.isValidatorOptedIn(pk1));
+
+        // inactive minipool -> false
+        vm.prank(node); reg.registerValidators(_one(pk1));
+        MinipoolMock(address(mp1)).setStatus(MinipoolStatus.Withdrawable);
+        assertFalse(reg.isValidatorOptedIn(pk1));
+    }
+
+    // receive refunds
+    receive() external payable {}
+}


### PR DESCRIPTION
## Describe your changes
Adds a RocketPool validator registry for Mev-Commit. Operators register using validator pubkeys; we read ownership/status from Rocket Pool and only track minimal participation state on our side.

How it works: given a validator pubkey, we resolve pubkey → minipool via RocketStorage, read the node address from the minipool, and verify the minipool is active (“Staking”). We also read the node’s current withdrawal address. A call is authorized if msg.sender is either the node address or the withdrawal address. On success we mark the pubkey as registered in a tiny struct (exists, deregTimestamp, freezeTimestamp).

Key points:

Registration is free (gas only).

Both the node address and the withdrawal address can register, request deregistration, and finalize deregistration.

Freezing functionality similar to AVS Registry: A designated freeze oracle can freeze; unfreezing requires a fee. The fee is fully forwarded to the configured receiver; any overpayment is refunded to the caller; the registry never retains ETH. The owner can unfreeze without a fee.

Deregistration is two-step: request (records a timestamp) then finalize after a configurable period, and only if not frozen. Finalization clears the registration.

“Opted in” is true only when registered, minipool currently active, not frozen, and no pending deregistration.

Batch operations supported for register/freeze/unfreeze/deregister.

Admin controls: freeze oracle, unfreeze fee, unfreeze fee receiver, deregistration period, and RocketStorage address. Contract is pausable and UUPS-upgradeable.

Integration touchpoints (read-only): pubkey → minipool via RocketStorage; node address and status from the minipool; node’s withdrawal address from Rocket Pool. This keeps Rocket Pool as the source of truth for validator ownership/lifecycle while giving Mev-Commit opt-in, freeze policy, and deregistration controls.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
