### PR TITLE
fix: updated vanilla reputational to 1 eth min stake

### DIFF
--- a/contracts/scripts/validator-registry/DeployVanillaReputational.s.sol
+++ b/contracts/scripts/validator-registry/DeployVanillaReputational.s.sol
@@ -37,7 +37,7 @@ contract BaseDeploy is Script {
 
 contract DeployMainnet is BaseDeploy {
     address constant public OWNER = MainnetConstants.PRIMEV_TEAM_MULTISIG;
-    uint256 constant public MIN_STAKE = 0 ether;
+    uint256 constant public MIN_STAKE = 1 ether;
     address constant public SLASH_ORACLE = MainnetConstants.PRIMEV_TEAM_MULTISIG;
     address constant public SLASH_RECEIVER = MainnetConstants.COMMITMENT_HOLDINGS_MULTISIG;
     uint256 constant public UNSTAKE_PERIOD_BLOCKS = 7200; // 7200 * 12s ~= 1 day.
@@ -53,7 +53,7 @@ contract DeployMainnet is BaseDeploy {
 
 
 contract DeployHoodi is BaseDeploy {
-    uint256 constant public MIN_STAKE = 0 ether; // 10k vals = 1 ETH cost
+    uint256 constant public MIN_STAKE = 0.1 ether; // 10k vals = 1 ETH cost
     address constant public SLASH_ORACLE = 0x1623fE21185c92BB43bD83741E226288B516134a;
     address constant public SLASH_RECEIVER = 0x1623fE21185c92BB43bD83741E226288B516134a;
     uint256 constant public UNSTAKE_PERIOD_BLOCKS = 32 * 3; // 2 epoch finalization time + settlement buffer


### PR DESCRIPTION
## Describe your changes
Updated vanilla reputational deployment to have 1 ETH min stake (will be used for lido registry as well)

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [] I have added tests that prove my fix is effective or that my feature works
- [] I have made corresponding changes to the documentation
