### PR TITLE
fix: updated hub deployment to not immediately impact optinrouter

### DIFF
--- a/contracts/scripts/validator-registry/DeployValidatorOptInHub.s.sol
+++ b/contracts/scripts/validator-registry/DeployValidatorOptInHub.s.sol
@@ -9,11 +9,7 @@ import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 import {ValidatorOptInHub} from "../../contracts/validator-registry/ValidatorOptInHub.sol";
-import {ValidatorOptInRouter} from "../../contracts/validator-registry/ValidatorOptInRouter.sol";
 import {AlwaysFalseRegistry} from "../../contracts/validator-registry/falseRegistry/AlwaysFalseRegistry.sol";
-import {IMevCommitAVS} from "../../contracts/interfaces/IMevCommitAVS.sol";
-import {IMevCommitMiddleware} from "../../contracts/interfaces/IMevCommitMiddleware.sol";
-import {IVanillaRegistry} from "../../contracts/interfaces/IVanillaRegistry.sol";
 import {MainnetConstants} from "../MainnetConstants.sol";
 
 contract BaseDeploy is Script {


### PR DESCRIPTION
## Describe your changes
Hub deployment script no longer updates router registries
This gives us a buffer to update our internal dependencies to use the OptInHub before making OptInRouter backwards compatible, as backwards compatibility will cause OptInRouter to display all validators as opted in through Vanilla.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
