### PR TITLE
fix: sim on correct state, retry if not available

### DIFF
--- a/tools/preconf-rpc/sender/sender.go
+++ b/tools/preconf-rpc/sender/sender.go
@@ -925,7 +925,14 @@ func (t *TxSender) sendBid(
 		logger.Debug("FastSwap transaction - skipping balance check", "sender", txn.Sender.Hex())
 	}
 
-	state := sim.Latest
+	// Pin simulation to the blockTracker's known latest block to avoid
+	// stale state when the sim node lags behind the WS-connected blockTracker.
+	latestBlockNumber := t.blockTracker.LatestBlockNumber()
+	state := sim.AtBlock(latestBlockNumber)
+	if bidBlockNo >= latestBlockNumber+2 {
+		// Missed slot — intermediate block doesn't exist yet, use pending state
+		state = sim.Pending
+	}
 	if latestBaseFee.Sign() > 0 && feePerGas.Cmp(latestBaseFee) < 0 {
 		state = sim.Pending
 	}
@@ -937,17 +944,30 @@ func (t *TxSender) sendBid(
 		logs, isSwap, err := t.simulator.Simulate(ctx, txn.Raw, state)
 		if err != nil {
 			txn.simFailed = true
-			logger.Error("Failed to simulate transaction", "error", err, "blockNumber", bidBlockNo)
+
+			// If the tx has commitments for the previous block and sim fails on the
+			// next block, retry with delay to allow for inclusion confirmation.
 			if len(txn.commitments) > 0 && txn.commitments[0].BlockNumber+1 == int64(bidBlockNo) {
-				// Could happen that it takes time to get confirmation of txn inclusion
-				// so simulation would return error but we should retry after a delay to allow
-				// the transaction to be included
+				logger.Error("Failed to simulate transaction", "error", err, "blockNumber", bidBlockNo)
 				return bidResult{}, &errRetry{
 					err:        fmt.Errorf("failed to simulate transaction: %w", err),
 					retryAfter: 2 * time.Second,
 				}
 			}
-			return bidResult{}, fmt.Errorf("failed to simulate transaction: %w", err)
+
+			// NonRetryableError means the tx itself is invalid (revert, bad request) — fatal.
+			var nonRetryable *sim.NonRetryableError
+			if errors.As(err, &nonRetryable) {
+				logger.Error("Failed to simulate transaction", "error", err, "blockNumber", bidBlockNo)
+				return bidResult{}, fmt.Errorf("failed to simulate transaction: %w", err)
+			}
+
+			// Transient error (sim node hasn't ingested block yet, network issue) — retryable.
+			logger.Warn("Simulation transient error, will retry", "error", err, "blockNumber", bidBlockNo)
+			return bidResult{}, &errRetry{
+				err:        fmt.Errorf("failed to simulate transaction: %w", err),
+				retryAfter: 100 * time.Millisecond,
+			}
 		}
 		txn.simFailed = false
 		if !isRetry {

--- a/tools/preconf-rpc/sim/simulator.go
+++ b/tools/preconf-rpc/sim/simulator.go
@@ -64,6 +64,11 @@ var (
 	Pending SimState = "pending"
 )
 
+// AtBlock returns a SimState that pins simulation to a specific block number.
+func AtBlock(blockNumber uint64) SimState {
+	return SimState(fmt.Sprintf("0x%x", blockNumber))
+}
+
 // Simulator is the external rethsim simulator with fallback support
 type Simulator struct {
 	apiURLs []string


### PR DESCRIPTION
## Describe your changes

Pin simulation to blockTracker's known block to prevent stale state

The rethsim simulator and the blockTracker are separate infrastructure — blockTracker gets new heads via WebSocket while rethsim uses a separate HTTP node. When blockTracker learns about a new block before rethsim has ingested it, simulating against rethsim's "latest" can execute against stale parent state, producing a false-positive sim result that gets cached for all retries within that block window.

This happened on 2026-04-07: a FastSwap tx was preconfirmed for block 24828356 based on a sim that ran against post-24828354 state (missing block 24828355), then reverted on-chain.

Changes:

Pin simulation to the blockTracker's actual latest block number instead of relying on rethsim's "latest". If the sim node hasn't ingested that block yet, it returns an error rather than silently simulating against wrong state.
For missed slots (bidBlockNo >= latest + 2), fall back to "pending" since the intermediate block doesn't exist yet.
Make transient sim errors (block not ready, network issues) retryable with a 100ms delay, instead of killing the tx. Only NonRetryableError (reverts, bad requests) remains fatal.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
