### PR TITLE
feat: allow any fastswap slippage

### DIFF
--- a/tools/preconf-rpc/fastswap/fastswap.go
+++ b/tools/preconf-rpc/fastswap/fastswap.go
@@ -270,7 +270,18 @@ func (s *Service) CallBarterAPI(ctx context.Context, intent Intent, slippageStr 
 	// Default slippage 0.5% if not provided
 	fraction := 0.995
 	if slippageStr != "" {
-		if val, err := strconv.ParseFloat(slippageStr, 64); err == nil && val >= 0 && val <= 100 {
+		val, err := strconv.ParseFloat(slippageStr, 64)
+		switch {
+		case err != nil || val < 0 || val > 100:
+			s.logger.Warn("invalid slippage, falling back to default", "value", slippageStr, "path", "executor-swap", "err", err)
+		default:
+			// Barter only accepts up to 2% slippage. Cap here so requests with a
+			// higher user tolerance still route; UserAmtOut still enforces the
+			// user's actual minimum and any excess flows through as surplus.
+			if val > 2.0 {
+				s.logger.Info("capping barter slippage to 2%", "requested", val, "path", "executor-swap")
+				val = 2.0
+			}
 			fraction = 1.0 - (val / 100.0)
 		}
 	}
@@ -597,7 +608,18 @@ func (s *Service) CallBarterAPIForETH(ctx context.Context, req ETHSwapRequest) (
 	// Default slippage 0.5% if not provided
 	fraction := 0.995
 	if req.Slippage != "" {
-		if val, err := strconv.ParseFloat(req.Slippage, 64); err == nil && val >= 0 && val <= 100 {
+		val, err := strconv.ParseFloat(req.Slippage, 64)
+		switch {
+		case err != nil || val < 0 || val > 100:
+			s.logger.Warn("invalid slippage, falling back to default", "value", req.Slippage, "path", "eth-swap", "err", err)
+		default:
+			// Barter only accepts up to 2% slippage. Cap here so requests with a
+			// higher user tolerance still route; UserAmtOut still enforces the
+			// user's actual minimum and any excess flows through as surplus.
+			if val > 2.0 {
+				s.logger.Info("capping barter slippage to 2%", "requested", val, "path", "eth-swap")
+				val = 2.0
+			}
 			fraction = 1.0 - (val / 100.0)
 		}
 	}


### PR DESCRIPTION
## Describe your changes

-Cap user-supplied slippage at 2% before calling Barter (Barter's max), in both CallBarterAPI (Path 1) and CallBarterAPIForETH (Path 2). Higher user tolerances now route successfully instead of being rejected by Barter.

-UserAmtOut (user's minAmountOut) is untouched and still enforced via the existing outAmt < UserAmtOut check, so any actual slippage between 2% and the user's tolerance flows through as settlement surplus → more miles.

-Added Info log when slippage is capped (with requested value + path) and Warn log when slippage is unparseable or out of [0, 100] (falls back to existing 0.5% default — no behavior change, just visibility).

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
