### PR TITLE
fix: set gas floor for swaps to prevent out of gas

### DIFF
--- a/tools/preconf-rpc/fastswap/fastswap.go
+++ b/tools/preconf-rpc/fastswap/fastswap.go
@@ -126,7 +126,7 @@ type sourceFee struct {
 
 // minGasLimit prevents OOG from the EIP-150 63/64 cascade on simple routes
 // where Barter's small GasEstimation produces a tight gasLimit.
-const minGasLimit = 400_000
+const minGasLimit = 525_000
 
 // Mainnet WETH address
 var mainnetWETH = common.HexToAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")

--- a/tools/preconf-rpc/fastswap/fastswap.go
+++ b/tools/preconf-rpc/fastswap/fastswap.go
@@ -124,6 +124,10 @@ type sourceFee struct {
 
 // ============ Service ============
 
+// minGasLimit prevents OOG from the EIP-150 63/64 cascade on simple routes
+// where Barter's small GasEstimation produces a tight gasLimit.
+const minGasLimit = 400_000
+
 // Mainnet WETH address
 var mainnetWETH = common.HexToAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
 
@@ -393,7 +397,7 @@ func (s *Service) HandleSwap(ctx context.Context, req SwapRequest) (*SwapResult,
 	// Barter's GasEstimation covers their swap routing gas. We add 135k for
 	// settlement contract + permit2 overhead, then apply 2.5x on the estimation
 	// to cover variance across different swap routes.
-	gasLimit := uint64(float64(barterResp.Route.GasEstimation)*2.5) + 135000
+	gasLimit := max(uint64(float64(barterResp.Route.GasEstimation)*2.5)+135000, minGasLimit)
 
 	// 4. Get nonce for executor wallet
 	// Use same logic as sender's hasCorrectNonce
@@ -737,7 +741,7 @@ func (s *Service) HandleETHSwap(ctx context.Context, req ETHSwapRequest) (*ETHSw
 
 	// 3. Calculate gas limit from Barter's gas estimation + settlement overhead.
 	// ETH path has additional WETH wrap overhead (~17k) on top of permit path overhead.
-	gasLimit := uint64(float64(barterResp.Route.GasEstimation)*2.5) + 152000
+	gasLimit := max(uint64(float64(barterResp.Route.GasEstimation)*2.5)+152000, minGasLimit)
 
 	s.logger.Info("ETH swap request processed",
 		"sender", req.Sender.Hex(),


### PR DESCRIPTION
## Describe your changes

Adds a 400k floor on the fastswap executor `gasLimit` to prevent OOG reverts on simple single-hop routes.

  ## Why

  For simple routes, Barter returns a small `GasEstimation` (~70k), and the formula `× 2.5 + 135k/152k` lands at ~310-330k — right at the median observed natural
   `gasUsed` (316,980 across 29 on-chain samples). With the EIP-150 63/64 cascade through nested CALLs, inner calls OOG before the swap completes. Reproduced
  against revm directly (anvil `eth_simulateV1`) and Tenderly archive.

  ## Why a floor (not a multiplier bump)

  Distribution is bimodal: simple routes ~272-320k natural gas, multi-hop ~600-700k. Barter's estimate already scales for the larger ones — only the simple
  cluster hits the cliff. Floor at 400k touches only Barter estimates ≤ ~106k; everything above is unchanged.

## Issue ticket number and link

Fixes # (issue)

## Checklist before requesting a review

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
